### PR TITLE
Add skills for markdown format and BFM syntax

### DIFF
--- a/Skill/dev-bfm-syntax.json
+++ b/Skill/dev-bfm-syntax.json
@@ -1,0 +1,38 @@
+{
+  "data": {
+    "type": "card",
+    "attributes": {
+      "cardTitle": "Boxel Flavored Markdown (BFM)",
+      "cardDescription": "The markdown dialect Boxel reads and writes: CommonMark + GFM plus card directives for embedding cards by URL.",
+      "cardInfo": {
+        "notes": null,
+        "name": "Boxel Flavored Markdown (BFM)",
+        "summary": "BFM dialect reference: where it renders, base syntax, and the :card/::card directives for embedding cards.",
+        "cardThumbnailURL": null
+      },
+      "commands": []
+    },
+    "meta": {
+      "adoptsFrom": {
+        "name": "SkillPlusMarkdown",
+        "module": "https://cardstack.com/base/skill-plus"
+      }
+    },
+    "relationships": {
+      "cardInfo.theme": {
+        "links": {
+          "self": "https://cardstack.com/base/Theme/cardstack-brand-guide"
+        }
+      },
+      "instructionsSource": {
+        "links": {
+          "self": "./dev-bfm-syntax.md"
+        },
+        "data": {
+          "type": "file",
+          "id": "./dev-bfm-syntax.md"
+        }
+      }
+    }
+  }
+}

--- a/Skill/dev-bfm-syntax.json
+++ b/Skill/dev-bfm-syntax.json
@@ -3,11 +3,11 @@
     "type": "card",
     "attributes": {
       "cardTitle": "Boxel Flavored Markdown (BFM)",
-      "cardDescription": "The markdown dialect Boxel reads and writes: CommonMark + GFM plus card directives for embedding cards by URL.",
+      "cardDescription": "The markdown dialect Boxel reads and writes: CommonMark + GFM plus card directives, mermaid diagrams, KaTeX math, GFM alerts, footnotes, extended tables, and Monaco-highlighted code blocks.",
       "cardInfo": {
         "notes": null,
         "name": "Boxel Flavored Markdown (BFM)",
-        "summary": "BFM dialect reference: where it renders, base syntax, and the :card/::card directives for embedding cards.",
+        "summary": "BFM reference: render surfaces, base syntax, :card/::card directives, mermaid, math ($...$ / $$...$$), alerts, footnotes, and code highlighting.",
         "cardThumbnailURL": null
       },
       "commands": []

--- a/Skill/dev-bfm-syntax.md
+++ b/Skill/dev-bfm-syntax.md
@@ -1,6 +1,13 @@
 # Boxel Flavored Markdown (BFM)
 
-BFM is the markdown dialect Boxel reads and writes. It extends CommonMark + GitHub Flavored Markdown with directives for embedding cards by URL.
+BFM is the markdown dialect Boxel reads and writes. It extends CommonMark + GitHub Flavored Markdown with:
+
+- Card directives (`:card[URL]`, `::card[URL | spec]`) for embedding cards
+- Mermaid diagrams in fenced code blocks
+- LaTeX math via `$...$` / `$$...$$` (KaTeX)
+- GFM alerts (`> [!NOTE]`, `> [!WARNING]`, etc.)
+- Footnotes, extended tables, heading IDs
+- Monaco-powered syntax highlighting for fenced code blocks
 
 ## Where BFM is used
 
@@ -18,12 +25,89 @@ The same text copies cleanly between these surfaces.
 
 Standard CommonMark plus GFM. The common subset you can rely on:
 
-- ATX headings (`# H1` … `###### H6`) — marker and text must be on the **same line**
+- ATX headings (`# H1` … `###### H6`) — marker and text must be on the **same line**. BFM auto-assigns `user-content-*` IDs to headings so they're anchorable.
 - Paragraphs, hard breaks (two trailing spaces + `\n`), horizontal rules
 - Emphasis (`*em*`, `**strong**`), inline code (`` `x` ``), fenced code blocks
 - Lists (bullet `-`/`+`/`*`, ordered `1.` — note `.` not `)`)
 - Links `[text](url)` and images `![alt](url)`
 - GFM tables (`|`-separated), strikethrough (`~~x~~`), autolinks
+- **Extended tables** — column alignment, colspan/rowspan, multi-line cells (via `marked-extended-tables`)
+
+## BFM extensions beyond CommonMark/GFM
+
+In addition to card directives, BFM enables several marked extensions. Anywhere BFM renders, these work:
+
+### Mermaid diagrams
+
+Fenced code blocks tagged `mermaid` render as SVG diagrams (lazily loaded client-side):
+
+```md
+```mermaid
+flowchart TD
+    A[Start] --> B{Decision}
+    B -->|Yes| C[Do thing]
+    B -->|No| D[Skip]
+```
+```
+
+Server-rendered output emits a `<pre class="mermaid">…source…</pre>` placeholder that the client replaces with rendered SVG on mount. If mermaid fails to parse the source, the placeholder stays visible as plain text — safe but ugly, so validate your diagram syntax.
+
+### Math (KaTeX)
+
+LaTeX-style math via `$...$` (inline) and `$$...$$` (block). Both use KaTeX under the hood.
+
+```md
+Inline math: the area is $\pi r^2$ square units.
+
+Block math on its own lines:
+
+$$
+E = mc^2
+$$
+```
+
+Inline rules:
+- Must be bounded by `$` or `$$` with no whitespace immediately inside (`$ x $` won't match; `$x$` will)
+- Must be followed by whitespace, punctuation, or end-of-string
+
+Block rules:
+- Opening `$$` and closing `$$` each on their own line
+- Content between on one or more lines
+
+Rendering is lazy: the parser emits a `.math-placeholder` element with the raw LaTeX in `data-math`, and KaTeX is loaded and invoked client-side on mount. Escape a literal `$` in prose as `\$` to prevent it being interpreted as math.
+
+### GFM alerts
+
+Blockquote-based callout syntax:
+
+```md
+> [!NOTE]
+> Useful information.
+
+> [!TIP]
+> Helpful advice.
+
+> [!IMPORTANT]
+> Crucial context.
+
+> [!WARNING]
+> Caution required.
+
+> [!CAUTION]
+> Risk of harm.
+```
+
+### Footnotes
+
+```md
+Here's a claim.[^1]
+
+[^1]: And here's the backing source.
+```
+
+### Syntax-highlighted code blocks
+
+Fenced code blocks with a language tag (e.g. ``` ```ts ```) are highlighted via the Monaco editor's tokenizer when Monaco is available on the page. Falls back to plain `<pre>` when it isn't. The `mermaid` language is special-cased (see above).
 
 ## Card directives (the Boxel extension)
 
@@ -107,7 +191,28 @@ Block card with size:
 | --- | --- |
 |  a  |  b  |
 
-```lang
-fenced code
+Inline math: $\pi r^2$
+
+Block math:
+
+$$
+E = mc^2
+$$
+
+> [!NOTE]
+> GFM alert.
+
+Footnote reference.[^1]
+
+[^1]: And its definition.
+
+```mermaid
+flowchart TD
+  A --> B
+```
+
+```ts
+// highlighted by Monaco when available
+const answer = 42;
 ```
 ```

--- a/Skill/dev-bfm-syntax.md
+++ b/Skill/dev-bfm-syntax.md
@@ -1,0 +1,113 @@
+# Boxel Flavored Markdown (BFM)
+
+BFM is the markdown dialect Boxel reads and writes. It extends CommonMark + GitHub Flavored Markdown with directives for embedding cards by URL.
+
+## Where BFM is used
+
+BFM is the same dialect everywhere Boxel parses or emits markdown:
+
+- `.md` files stored in a realm (rendered by the base realm's MarkdownTemplate)
+- `MarkdownField` values (inline markdown stored in a card's JSON)
+- AI assistant messages in Boxel
+- The `markdown` format output of any card (served via `Accept: text/markdown` or produced by "Copy as Markdown")
+- The "Rendered" view of the code-mode markdown preview panel
+
+The same text copies cleanly between these surfaces.
+
+## Base syntax
+
+Standard CommonMark plus GFM. The common subset you can rely on:
+
+- ATX headings (`# H1` … `###### H6`) — marker and text must be on the **same line**
+- Paragraphs, hard breaks (two trailing spaces + `\n`), horizontal rules
+- Emphasis (`*em*`, `**strong**`), inline code (`` `x` ``), fenced code blocks
+- Lists (bullet `-`/`+`/`*`, ordered `1.` — note `.` not `)`)
+- Links `[text](url)` and images `![alt](url)`
+- GFM tables (`|`-separated), strikethrough (`~~x~~`), autolinks
+
+## Card directives (the Boxel extension)
+
+Two forms reference a card by its full URL:
+
+### Inline: `:card[URL]`
+
+Renders the target card in **atom** format, inline with surrounding text.
+
+```md
+Written by :card[https://my.realm/Author/jane] for the team.
+```
+
+Use inline form when the card should flow with the sentence.
+
+### Block: `::card[URL]`  or  `::card[URL | spec]`
+
+Renders the target card in a block slot, separated from surrounding prose. Default format is **embedded**.
+
+```md
+See the latest post:
+
+::card[https://my.realm/BlogPost/first-look]
+```
+
+The optional `| spec` after the URL controls size/format. Common specs:
+
+| Spec                  | Meaning                                          |
+| --------------------- | ------------------------------------------------ |
+| `embedded` (implicit) | Default when no spec is given                    |
+| `isolated`            | Full detailed view                               |
+| `fitted`              | Fitted format at its container's natural size    |
+| `fitted 250x40`       | Fitted format at a specific width × height (px)  |
+| `strip`               | Horizontal strip layout                          |
+
+```md
+Featured authors:
+
+::card[https://my.realm/Author/jane | fitted 300x120]
+::card[https://my.realm/Author/mohammed | fitted 300x120]
+```
+
+### Unresolved references
+
+If the renderer can't resolve a card URL (deleted, permissions, offline), the directive falls back to a muted pill badge showing the URL. Don't rely on card directives for content that must render without the Boxel runtime — plain markdown links (`[text](url)`) are safe everywhere.
+
+### Inside code blocks
+
+Card directives inside fenced or inline code are **not** converted — they render as literal text. Use this when you need to show directive syntax in documentation.
+
+## Authoring notes
+
+- **Use full URLs in directives**, not relative paths — directives are resolved by the Boxel store, not by the surrounding document's base.
+- **Escape user-supplied text** before interpolating it into a BFM string. `[`, `]`, `(`, `)`, `|`, `:`, `#`, `*`, `` ` ``, `_`, `~`, `!`, `<`, `>`, leading `+`/`-`, and line-start `1.` all have meaning. See the `dev-markdown-format` skill for `markdownEscape` and helper functions.
+- **Prettier reflows markdown.** When a template's output must preserve column-zero placement (ATX headings, fence columns), protect it with `{{!-- prettier-ignore --}}`.
+
+## Quick reference
+
+```md
+# Heading
+
+A paragraph with **bold**, *italic*, `code`, and a [link](https://example.com).
+
+Inline card: :card[https://my.realm/Author/jane]
+
+Block card (embedded default):
+
+::card[https://my.realm/BlogPost/first-look]
+
+Block card with size:
+
+::card[https://my.realm/Author/jane | fitted 300x120]
+
+- bullet
+- another
+
+1. ordered
+2. another
+
+| col | col |
+| --- | --- |
+|  a  |  b  |
+
+```lang
+fenced code
+```
+```

--- a/Skill/dev-bfm-syntax.md
+++ b/Skill/dev-bfm-syntax.md
@@ -133,22 +133,39 @@ See the latest post:
 ::card[https://my.realm/BlogPost/first-look]
 ```
 
-The optional `| spec` after the URL controls size/format. Common specs:
+The optional `| spec` after the URL controls size/format. The grammar:
 
-| Spec                  | Meaning                                          |
-| --------------------- | ------------------------------------------------ |
-| `embedded` (implicit) | Default when no spec is given                    |
-| `isolated`            | Full detailed view                               |
-| `fitted`              | Fitted format at its container's natural size    |
-| `fitted 250x40`       | Fitted format at a specific width × height (px)  |
-| `strip`               | Horizontal strip layout                          |
+| Spec                             | Meaning                                                                |
+| -------------------------------- | ---------------------------------------------------------------------- |
+| *(no spec)*                      | Default — embedded                                                     |
+| `embedded`                       | Embedded format (explicit)                                             |
+| `isolated`                       | Isolated format (full detailed view)                                   |
+| `fitted`                         | Fitted format at its container's natural size                          |
+| `fitted <WxH>`                   | Fitted at an exact width × height in px, e.g. `fitted 400x200`         |
+| `fitted <named>`                 | Fitted at a named size constant, e.g. `fitted strip`                   |
+| `<WxH>`                          | Bare dimensions (fitted implied), e.g. `400x200`                       |
+| `<named>`                        | Bare named constant (fitted implied), e.g. `strip`                     |
+| `w:<N> h:<N>` (or either alone)  | Explicit width/height in px. Width accepts `%`, e.g. `w:50% h:200`     |
+
+**Named size constants** map to preset dimensions:
+
+| Category | Constants |
+| -------- | --------- |
+| Shorthand aliases | `strip` (→ `single-strip`, 250×40), `tile` (→ `regular-tile`, 250×170), `grid-tile` (→ `cardsgrid-tile`, 170×250) |
+| Badges            | `small-badge` 150×40, `medium-badge` 150×65, `large-badge` 150×105 |
+| Strips            | `single-strip` 250×40, `double-strip` 250×65, `triple-strip` 250×105, `double-wide-strip` 400×65, `triple-wide-strip` 400×105 |
+| Tiles             | `small-tile` 150×170, `regular-tile` 250×170, `cardsgrid-tile` 170×250, `tall-tile` 150×275, `large-tile` 250×275 |
+| Cards             | `compact-card` 400×170, `full-card` 400×275, `expanded-card` 400×445 |
 
 ```md
 Featured authors:
 
 ::card[https://my.realm/Author/jane | fitted 300x120]
-::card[https://my.realm/Author/mohammed | fitted 300x120]
+::card[https://my.realm/Author/mohammed | strip]
+::card[https://my.realm/Essay/manifesto | isolated]
 ```
+
+If a spec fails to parse, the renderer emits the directive with no format override, so the card falls back to embedded with no error — validate specs before shipping.
 
 ### Unresolved references
 

--- a/Skill/dev-core-concept.md
+++ b/Skill/dev-core-concept.md
@@ -25,6 +25,7 @@ Boxel is a composable card-based system where information lives in self-containe
   - `fitted`: **🚨 ESSENTIAL** - Fixed dimensions for grids/galleries/dashboards (parent sets both width AND height)
   - `atom`: Minimal inline representation
   - `edit`: Form for data modification (default provided, override only if needed)
+  - `markdown`: Text-only Boxel Flavored Markdown representation (default HTML-to-markdown fallback provided — override only when the fallback produces poor output). See `dev-markdown-format` and `dev-bfm-syntax` skills.
 
 **🔴 CRITICAL:** Modern Boxel cards require ALL THREE display formats: isolated, embedded, AND fitted. Missing custom fitted format will fallback to basic fitted view that won't look very nice or have enough info to show in grids, choosers, galleries, or dashboards.
 
@@ -91,6 +92,7 @@ For computed fields, ask: "Am I keeping this simple and unidirectional?"
 - `fitted` - Fixed dimensions for grids/galleries
 - `atom` - Minimal inline representation
 - `edit` - Form for data modification
+- `markdown` - BFM text representation (default fallback provided; opt-in override)
 
 **Every CardDef inherits:**
 

--- a/Skill/dev-markdown-format.json
+++ b/Skill/dev-markdown-format.json
@@ -1,0 +1,38 @@
+{
+  "data": {
+    "type": "card",
+    "attributes": {
+      "cardTitle": "Markdown Format Authoring",
+      "cardDescription": "How to write `static markdown` templates on CardDef, FieldDef, and FileDef — when to rely on the default HTML-to-markdown fallback, which helpers to use, and the authoring pitfalls to avoid.",
+      "cardInfo": {
+        "notes": null,
+        "name": "Markdown Format Authoring",
+        "summary": "Authoring `static markdown` templates: defaults, markdownEscape, markdown-helpers toolkit, delegation, and pitfalls.",
+        "cardThumbnailURL": null
+      },
+      "commands": []
+    },
+    "meta": {
+      "adoptsFrom": {
+        "name": "SkillPlusMarkdown",
+        "module": "https://cardstack.com/base/skill-plus"
+      }
+    },
+    "relationships": {
+      "cardInfo.theme": {
+        "links": {
+          "self": "https://cardstack.com/base/Theme/cardstack-brand-guide"
+        }
+      },
+      "instructionsSource": {
+        "links": {
+          "self": "./dev-markdown-format.md"
+        },
+        "data": {
+          "type": "file",
+          "id": "./dev-markdown-format.md"
+        }
+      }
+    }
+  }
+}

--- a/Skill/dev-markdown-format.md
+++ b/Skill/dev-markdown-format.md
@@ -1,0 +1,220 @@
+# Authoring the `markdown` Format
+
+Boxel has a sixth display format alongside `isolated`, `embedded`, `fitted`, `atom`, and `edit`:
+
+- **`markdown`** — the card (or field, or file) rendered as text in **Boxel Flavored Markdown** (BFM).
+
+This format is what the realm serves under `Accept: text/markdown`, what "Copy as Markdown" puts on the clipboard, what the code-mode markdown preview panel shows, and what gets indexed into the `boxel_index.markdown` column. See the `dev-bfm-syntax` skill for the dialect itself.
+
+## The default — usually good enough
+
+Every `CardDef`, `FieldDef`, and `FileDef` already has a working `markdown` format. The default renders the card's HTML fallback (`isolated` for cards, `embedded` for fields) into a hidden container and converts it to markdown via turndown + GFM.
+
+**Do not define `static markdown` just to have one.** The default handles headings, paragraphs, lists, links, images, tables, and embedded cards (HTML card containers become `:card[…]` / `::card[…]` directives automatically).
+
+Define an explicit `static markdown` only when:
+
+- The HTML fallback produces noisy or misleading output (style leakage, odd layout artifacts)
+- The field has a natural non-HTML representation (code files → fenced code blocks, dates → formatted strings, scalar values → bare text)
+- You need deterministic output for indexing or downstream consumers
+- A stakeholder explicitly wants a specific markdown shape
+
+## Shape of a `static markdown` template
+
+It's a format slot like `static isolated`, but emits **plain text**, not HTML. Glimmer HTML-escapes the string in the DOM; the prerender pipeline decodes those entities when it captures `textContent`, so the markdown parser downstream sees the literal characters you emitted.
+
+```gts
+import { CardDef, Component } from 'https://cardstack.com/base/card-api';
+import { markdownEscape } from '@cardstack/boxel-ui/helpers';
+
+export class Note extends CardDef {
+  static displayName = 'Note';
+
+  static markdown = class Markdown extends Component<typeof this> {
+    get text() {
+      return markdownEscape(this.args.model?.title ?? '');
+    }
+    <template>{{this.text}}</template>
+  };
+}
+```
+
+Rules of thumb:
+
+- The template should emit **only text** — no layout elements, no `<style>`, no `{{! comments }}` that leak.
+- Return `''` for null/empty — never emit the string `"undefined"` or `"null"`.
+- Whitespace is preserved (the render container applies `white-space: pre`), so newlines and indentation you emit survive into the output.
+
+## Essential helper: `markdownEscape`
+
+```gts
+import { markdownEscape } from '@cardstack/boxel-ui/helpers';
+```
+
+Escapes every CommonMark/GFM metacharacter (`\`, `` ` ``, `*`, `_`, `[`, `]`, `(`, `)`, `<`, `>`, `|`, `~`, `!`, `#`, `+`, `-`) plus line-start numeric list prefixes (`1.` → `1\.`). Null/undefined inputs return `''`; non-string inputs are coerced with `String()`.
+
+**Use it on any user-supplied string** before it lands in markdown output. Skipping it will eventually bite when a user types `*`, `_`, or a leading `1.`.
+
+## The `markdown-helpers` toolkit
+
+Module: `https://cardstack.com/base/markdown-helpers`
+
+```gts
+import {
+  formatDateForMarkdown,
+  formatDateTimeForMarkdown,
+  formatDateRangeForMarkdown,
+  markdownLink,
+  markdownImage,
+  fencedCodeBlock,
+  markdownLinkForCard,
+  markdownLinksForCards,
+  markdownEmbedForCard,
+  markdownEmbedsForCards,
+} from 'https://cardstack.com/base/markdown-helpers';
+```
+
+All helpers return pre-escaped strings — safe to interpolate directly.
+
+| Helper                                       | Output                                                           |
+| -------------------------------------------- | ---------------------------------------------------------------- |
+| `formatDateForMarkdown(date)`                | `Mar 5, 2026` (empty for null/invalid)                           |
+| `formatDateTimeForMarkdown(date)`            | `Mar 5, 2026, 3:42 PM`                                           |
+| `formatDateRangeForMarkdown(start, end)`     | `Mar 5, 2026 - Mar 12, 2026`                                     |
+| `markdownLink(text, href)`                   | `[escaped text](encoded-href)` — parens in URL become `%28`/`%29` |
+| `markdownImage(alt, url)`                    | `![alt](url)`, or `[binary image]` when url is missing           |
+| `fencedCodeBlock(content, language?)`        | Auto-widens the fence past any backtick run in `content`         |
+| `markdownLinkForCard(card, text?)`           | `[title](card.id)` — empty for null card                         |
+| `markdownLinksForCards(cards, { style })`    | `style: 'list'` (default, `- [A](id)` per line) or `'inline'` (`[A](id), [B](id)`) |
+| `markdownEmbedForCard(card, { kind, size })` | `:card[id]` (inline) or `::card[id]` / `::card[id \| size]` (block, default) |
+| `markdownEmbedsForCards(cards, options)`     | Multiple embeds joined by `separator` (default `\n\n` block, `' '` inline) |
+
+The last four emit BFM card directives — see the `dev-bfm-syntax` skill.
+
+## Delegation composes
+
+Inside a `static markdown` template, `<@fields.x />` recursively renders the child's `markdown` format (not `embedded`/`fitted`). So composition works the same way as any other format:
+
+```gts
+static markdown = class Markdown extends Component<typeof this> {
+  <template>
+    {{! prettier-ignore }}
+# {{markdownEscape @model.cardTitle}}
+
+{{#if @model.author}}
+By <@fields.author />
+{{/if}}
+
+<@fields.body />
+  </template>
+};
+```
+
+**Each `<@fields.x />` invocation emits that child's `markdown` output**, whitespace-preserved.
+
+## Pitfalls
+
+### ATX headings must be on one line
+
+`# Heading` requires the `#` and the text on the same line in the emitted string. Prettier will reformat a multi-line template and break this — protect it:
+
+```gts
+static markdown = class Markdown extends Component<typeof this> {
+  <template>
+    {{!-- prettier-ignore --}}
+# {{markdownEscape @model.title}}
+  </template>
+};
+```
+
+### Multi-line text needs hard breaks
+
+A single `\n` between lines collapses into a paragraph. For `TextAreaField`-style content, escape each line and join with CommonMark hard breaks (`  \n`):
+
+```gts
+get lines() {
+  return (this.args.model ?? '')
+    .split('\n')
+    .map((line) => markdownEscape(line))
+    .join('  \n');
+}
+```
+
+### Fenced code blocks around arbitrary content
+
+Use `fencedCodeBlock(content, lang)` rather than hand-rolling triple backticks — it widens the fence past any run of backticks inside `content` so the block can't be closed prematurely.
+
+### FileDef code blocks: `static markdownLanguage`
+
+Code-file FileDef subclasses (`TsFileDef`, `GtsFileDef`, `JsonFileDef`, `CsvFileDef`, `TextFileDef`) use a `static markdownLanguage` property to label the fence:
+
+```gts
+export class TsFileDef extends FileDef {
+  static markdownLanguage = 'ts';
+  // ...
+  static markdown = class Markdown extends Component<typeof TsFileDef> {
+    get text() {
+      let content = this.args.model?.content;
+      if (!content) return '';
+      let ctor = this.args.model?.constructor as typeof TsFileDef | undefined;
+      return fencedCodeBlock(content, ctor?.markdownLanguage ?? TsFileDef.markdownLanguage);
+    }
+    <template>{{this.text}}</template>
+  };
+}
+```
+
+Override `markdownLanguage` in a subclass to change the language tag (e.g. `GtsFileDef` sets `'gts'`).
+
+### Don't wrap in HTML
+
+No `<div>`, no `<style>`, no `<article>` — the markdown format is text-only. The render container already supplies `white-space: pre`. HTML you emit will be captured as literal characters by `textContent` and pollute the output.
+
+### Subclass overrides win
+
+The format resolver uses bracket-notation lookup, so `static markdown` on a subclass overrides the inherited default (or a parent's explicit template) with no further ceremony.
+
+## Worked example: `Note` card with custom markdown
+
+```gts
+import { CardDef, field, contains, linksTo, Component } from 'https://cardstack.com/base/card-api';
+import StringField from 'https://cardstack.com/base/string';
+import MarkdownField from 'https://cardstack.com/base/markdown';
+import { markdownEscape } from '@cardstack/boxel-ui/helpers';
+import { markdownLinkForCard, formatDateTimeForMarkdown } from 'https://cardstack.com/base/markdown-helpers';
+import { Author } from './author';
+
+export class Note extends CardDef {
+  static displayName = 'Note';
+
+  @field title = contains(StringField);
+  @field body = contains(MarkdownField);
+  @field author = linksTo(Author);
+  @field publishedAt = contains(DateTimeField);
+
+  static markdown = class Markdown extends Component<typeof this> {
+    get header() {
+      let title = markdownEscape(this.args.model?.title ?? 'Untitled');
+      let byline = this.args.model?.author
+        ? `By ${markdownLinkForCard(this.args.model.author)}`
+        : '';
+      let when = formatDateTimeForMarkdown(this.args.model?.publishedAt);
+      let meta = [byline, when].filter(Boolean).join(' · ');
+      return meta ? `# ${title}\n\n${meta}` : `# ${title}`;
+    }
+    <template>
+      {{!-- prettier-ignore --}}
+{{this.header}}
+
+<@fields.body />
+    </template>
+  };
+}
+```
+
+## When you're done
+
+- Test output by opening the card in code mode and toggling the preview panel to **Markdown → Source**.
+- Hit the realm with `Accept: text/markdown` to see the served output.
+- Run `"Copy as Markdown"` from the isolated view context menu to verify clipboard output.
+- Markdown lives in the `boxel_index.markdown` column after the card re-indexes, so changes propagate once the instance is touched.

--- a/Skill/dev-quick-reference.md
+++ b/Skill/dev-quick-reference.md
@@ -20,7 +20,8 @@ import { formatDateTime, formatCurrency } from '@cardstack/boxel-ui/helpers';
 
 **File Types:** `.gts` (definitions) | `.json` (instances)  
 **Core Pattern:** CardDef/FieldDef → contains/linksTo → Templates → Instances  
-**Essential Formats:** Every CardDef MUST implement `isolated`, `embedded`, AND `fitted` formats
+**Essential Formats:** Every CardDef MUST implement `isolated`, `embedded`, AND `fitted` formats  
+**Optional `markdown` Format:** A working default (HTML-to-markdown fallback) is provided; only define `static markdown` when the default output is poor — see `dev-markdown-format`.
 
 ```gts
 // ═══ [EDIT TRACKING: ON] Mark all changes with ⁿ ═══
@@ -72,6 +73,7 @@ import { Button, Pill, Avatar, FieldContainer, CardContainer, BoxelSelect, ViewS
 // ⁴ Helper imports
 import { eq, gt, gte, lt, lte, and, or, not, cn, add, subtract, multiply, divide } from '@cardstack/boxel-ui/helpers';
 import { currencyFormat, formatDateTime, optional, pick } from '@cardstack/boxel-ui/helpers';
+import { markdownEscape } from '@cardstack/boxel-ui/helpers'; // escape user-supplied strings in `static markdown` templates
 import { concat, fn } from '@ember/helper';
 import { get } from '@ember/helper';
 import { on } from '@ember/modifier';

--- a/Skill/dev-template-patterns.md
+++ b/Skill/dev-template-patterns.md
@@ -10,6 +10,10 @@
 
 For theming, CSS variables, spacing scales, and CSS safety rules, see Module 3: Theme-First Design System.
 
+### `static markdown` templates
+
+The `markdown` format emits plain text (Boxel Flavored Markdown), not HTML. A working default exists (HTML-to-markdown fallback), so only define `static markdown` when the default is poor. When you do, the same `<@fields.x />` delegation rules apply — children render their own `markdown` format, composed into the parent's output with whitespace preserved. See the `dev-markdown-format` skill for authoring details and the `dev-bfm-syntax` skill for the dialect.
+
 #### ⚠️ CRITICAL: @model Iteration vs @fields Delegation
 
 **Once you iterate with @model, you CANNOT delegate to @fields within that iteration.**


### PR DESCRIPTION
## Summary

- New `dev-bfm-syntax` skill — documents Boxel Flavored Markdown as a dialect (CommonMark + GFM plus `:card[URL]` / `::card[URL | spec]` card directives) and where it renders (realm `.md` files, `MarkdownField`, AI messages, the new `markdown` format output, preview panel).
- New `dev-markdown-format` skill — how to author `static markdown` templates on `CardDef`/`FieldDef`/`FileDef`: when to override the default HTML-to-markdown fallback, `markdownEscape`, the `packages/base/markdown-helpers` toolkit, `<@fields.x />` delegation, and the common pitfalls (ATX headings + `prettier-ignore`, hard breaks, `static markdownLanguage` on FileDef subclasses, no HTML wrappers).
- Minor updates to three existing skills (`dev-core-concept`, `dev-quick-reference`, `dev-template-patterns`) to mention the new `markdown` format as an opt-in sixth format and point at the new skills.

Paired with boxel [PR #4412](https://github.com/cardstack/boxel/pull/4412), which landed the markdown format itself.

## Test plan

- [ ] Push to a workspace with `workspace-push` and open the new skills in Boxel to confirm they render as SkillPlusMarkdown cards.
- [ ] Spot-check the body renders (headings, tables, code fences) in the skill preview.
- [ ] Sanity-check an LLM conversation that activates these skills — verify it produces a correct `static markdown` template on request without asking for internals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)