### PR TITLE
Document runtime-common subpath imports (CS-10860 follow-up)

### DIFF
--- a/Skill/dev-external-libraries.md
+++ b/Skill/dev-external-libraries.md
@@ -1,3 +1,22 @@
+## Importing runtime helpers from `@cardstack/runtime-common`
+
+The `@cardstack/runtime-common` package exposes its surface at two granularities:
+
+1. **The bare module ID** — `import { Loader, baseRealm, ... } from '@cardstack/runtime-common'`. Eagerly bundled in the host. Stable, broad, always available.
+2. **Subpath modules** — `import { markdownToHtml } from '@cardstack/runtime-common/marked-sync'`. Lazy-loaded so heavy deps (markdown parser, DOMPurify, etc.) don't bloat the eager host bundle for cards that don't use them.
+
+**Subpath exports are NOT re-exported from the bare module.** Common subpaths and the names they expose:
+
+| Subpath | Useful exports |
+|---|---|
+| `@cardstack/runtime-common/marked-sync` | `markdownToHtml`, `preloadMarkdownLanguages`, `wrapTablesHtml` |
+
+If you import a name that doesn't exist on a namespace, JavaScript silently binds it to `undefined`. The runtime now catches this at module-load time and surfaces a tight `ReferenceError` that names the missing export AND the source module — so a typo'd import path is visible immediately instead of producing a confusing downstream `TypeError` from inside Glimmer's helper-encoder.
+
+When in doubt: **prefer the subpath import** for anything that isn't a core runtime utility. The error message itself will tell you when you've reached for a bare-module name that doesn't exist.
+
+## Async loading external CDN libraries
+
 **Async loading pattern:**
 ```gts
 import { task, restartableTask, timeout } from 'ember-concurrency';

--- a/Skill/dev-external-libraries.md
+++ b/Skill/dev-external-libraries.md
@@ -11,9 +11,11 @@ The `@cardstack/runtime-common` package exposes its surface at two granularities
 |---|---|
 | `@cardstack/runtime-common/marked-sync` | `markdownToHtml`, `preloadMarkdownLanguages`, `wrapTablesHtml` |
 
-If you import a name that doesn't exist on a namespace, JavaScript silently binds it to `undefined`. The runtime now catches this at module-load time and surfaces a tight `ReferenceError` that names the missing export AND the source module — so a typo'd import path is visible immediately instead of producing a confusing downstream `TypeError` from inside Glimmer's helper-encoder.
+If you reach for a subpath-only export on the bare module — a common slip when a name is "almost" on the right module — the runtime catches the mismatch at module-load time and surfaces a tight `ReferenceError` that names both the missing export and the source module. So a wrong import path is visible immediately, with an actionable message, instead of producing a confusing downstream `TypeError` from inside Glimmer's helper-encoder.
 
-When in doubt: **prefer the subpath import** for anything that isn't a core runtime utility. The error message itself will tell you when you've reached for a bare-module name that doesn't exist.
+When in doubt: **prefer the subpath import** for anything that isn't a core runtime utility. If you reach for a name from the wrong `@cardstack/runtime-common` module, the runtime error will tell you which export is missing from which module.
+
+(Background: in standard ESM, a named-import mismatch fails at module-link time and you'd see the error immediately. Cardstack's realm loader uses an AMD-style transform under the hood, which historically turned missing-export mismatches into silent `undefined` bindings that failed later. The current runtime restores the link-time-error behavior for shimmed modules.)
 
 ## Async loading external CDN libraries
 

--- a/Skill/dev-markdown-format.md
+++ b/Skill/dev-markdown-format.md
@@ -230,7 +230,7 @@ let html = markdownToHtml(rawSource, {
 
 **Critical: import from the subpath `@cardstack/runtime-common/marked-sync`, not the bare `@cardstack/runtime-common`.** The `marked-sync` module is registered as a separate (lazy-loaded) shim so the markdown parser + DOMPurify + extensions don't get pulled into the eager host bundle for cards that don't render markdown. The bare `@cardstack/runtime-common` does **not** re-export `markdownToHtml` or `preloadMarkdownLanguages`.
 
-If you import from the wrong path, the named import silently binds to `undefined`. JavaScript namespace imports never error on missing keys — they just produce `undefined`, which then fails downstream when you try to call the helper. The runtime now surfaces this as a tight `ReferenceError` at module-load time:
+If you import from the wrong path, the runtime catches the mismatch at module-load time and surfaces a tight `ReferenceError` naming both the missing export and the source module:
 
 ```
 ReferenceError: Module '@cardstack/runtime-common' has no exported
@@ -238,6 +238,8 @@ member 'markdownToHtml'. If this is a card, check the import
 statement that names 'markdownToHtml' — you may be importing from
 the wrong module ID.
 ```
+
+(In standard ESM, a named-import mismatch like this would already fail at module-link time. Cardstack's realm loader uses an AMD-style transform under the hood, which historically turned missing-export mismatches into silent `undefined` bindings that failed later with confusing downstream errors. The current runtime restores the link-time-error behavior for shimmed modules — so wrong imports surface immediately, with the actionable message above.)
 
 Other helpers that live on the same `marked-sync` subpath (also import from there, not the bare module):
 

--- a/Skill/dev-markdown-format.md
+++ b/Skill/dev-markdown-format.md
@@ -212,6 +212,39 @@ export class Note extends CardDef {
 }
 ```
 
+## Rendering markdown → HTML at runtime
+
+If your card has a markdown field and you need to render it as HTML in a *non-markdown* format (e.g. an `isolated` template that shows the body as styled HTML), the `MarkdownField`'s default `embedded` template already handles that. Use `<@fields.body />` and let the field render itself.
+
+Reach for the runtime helper only when you need the HTML string directly — for diffing, plain-text extraction, custom downstream processing, etc.:
+
+```gts
+import { markdownToHtml } from '@cardstack/runtime-common/marked-sync';
+//                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//                          subpath, NOT '@cardstack/runtime-common'
+
+let html = markdownToHtml(rawSource, {
+  preprocessKatex: true, // or false depending on your need
+});
+```
+
+**Critical: import from the subpath `@cardstack/runtime-common/marked-sync`, not the bare `@cardstack/runtime-common`.** The `marked-sync` module is registered as a separate (lazy-loaded) shim so the markdown parser + DOMPurify + extensions don't get pulled into the eager host bundle for cards that don't render markdown. The bare `@cardstack/runtime-common` does **not** re-export `markdownToHtml` or `preloadMarkdownLanguages`.
+
+If you import from the wrong path, the named import silently binds to `undefined`. JavaScript namespace imports never error on missing keys — they just produce `undefined`, which then fails downstream when you try to call the helper. The runtime now surfaces this as a tight `ReferenceError` at module-load time:
+
+```
+ReferenceError: Module '@cardstack/runtime-common' has no exported
+member 'markdownToHtml'. If this is a card, check the import
+statement that names 'markdownToHtml' — you may be importing from
+the wrong module ID.
+```
+
+Other helpers that live on the same `marked-sync` subpath (also import from there, not the bare module):
+
+- `markdownToHtml(content, options)` — the main renderer; sanitises by default
+- `preloadMarkdownLanguages(langs)` — pre-loads syntax highlighters for fenced code blocks
+- `wrapTablesHtml(html)` — adds responsive wrappers around `<table>` (use after `markdownToHtml` if needed)
+
 ## When you're done
 
 - Test output by opening the card in code mode and toggling the preview panel to **Markdown → Source**.


### PR DESCRIPTION
> ⚠️ **Editorial note from review:** I'm not 100% sure that `markdownToHtml` from `@cardstack/runtime-common/marked-sync` is intended as a stable API surface for card authors. The function exists primarily for host-internal markdown rendering (`MarkdownField`'s embedded format does this for you), and a card author who reaches for it directly is bypassing the field's existing render path. That said — it's already in use in the production whitepaper card, so we can reasonably expect other authors to discover and use it the same way. This skill update treats the import path as a reality of the surface today and tells authors how to use it correctly. We may want to revisit whether to formalize or discourage this path separately.

Companion to cardstack/boxel#4532 (named-export missing check). That PR adds a runtime-level Proxy that throws a clear `ReferenceError` when a card imports a name that doesn't exist on a shimmed module. This PR adds the matching guidance so card authors hit the right import path the first time.

## Background

The whitepaper render bug (CS-10860) was caused by:

```ts
// boxel-whitepaper.gts (the actual prod card source)
import {
  markdownToHtml,
  preloadMarkdownLanguages,
} from '@cardstack/runtime-common';
```

But `@cardstack/runtime-common`'s index doesn't re-export those names — they live on `@cardstack/runtime-common/marked-sync`, which is registered as a separate (lazy-loaded) shim so the markdown parser + DOMPurify + extensions don't get pulled into the eager host bundle. JavaScript namespace imports never error on missing keys at module-link time when running through Cardstack's AMD-style loader transform; the bindings just resolve to `undefined`. The whitepaper card then surfaced that downstream as a confusing "Cannot convert undefined or null to object" deep in Glimmer's helper-encoder, which in production manifested as a 90s render timeout.

## Changes

**`Skill/dev-markdown-format.md`** — adds a "Rendering markdown → HTML at runtime" section. Anyone authoring markdown-related code reads this skill first, so it's the right home for the specific `markdownToHtml` import path and the warning about what happens when it's wrong.

**`Skill/dev-external-libraries.md`** — adds an "Importing runtime helpers from `@cardstack/runtime-common`" section covering the broader pattern: the bare module is for stable runtime utilities, subpath modules host heavy lazy-loaded helpers, and subpath exports are NOT re-exported from the bare module. Includes the table of useful exports per subpath (just `marked-sync` for now; easy to extend as we add more lazy submodules).

Both sections include a parenthetical noting why the runtime now surfaces a tight `ReferenceError` for these mismatches — Cardstack's realm loader uses an AMD-style transform that historically bound missing exports to silent `undefined`, and the new strict-namespace check restores the link-time-error behavior that standard ESM has natively.

## Test plan

- [x] Markdown formatting renders correctly in both files
- [ ] Skill writer user picks up changes after deploy → next sync brings them into the realm

🤖 Generated with [Claude Code](https://claude.com/claude-code)