### PR TITLE
Add Block-Param/HTML-Tag shadowing rule to Template Patterns skill

### DIFF
--- a/Skill/dev-template-patterns.md
+++ b/Skill/dev-template-patterns.md
@@ -43,6 +43,66 @@ The `markdown` format emits plain text (Boxel Flavored Markdown), not HTML. A wo
 - Need filtering? → Use query patterns (PrerenderedCardSearch/getCards)
 - Need custom control? → Use @model but handle ALL rendering yourself
 
+#### ⚠️ CRITICAL: Block-Param Names Must Not Match HTML Tag Names
+
+**A block param introduced by `as |x|` shadows any lowercase HTML tag with the same name inside the block.** In `.gts` strict mode, `<x>` is resolved as "invoke the block-param `x` as a component", *not* as an HTML element. Picking block-param names that don't collide with HTML tags is the rule; this is about avoiding the footgun in the first place.
+
+```hbs
+<!-- ❌ block-param `s` shadows the <s> strikethrough tag -->
+<Shell as |s|>
+  <button disabled={{not s.isEditing}}><s>S</s></button>
+</Shell>
+
+<!-- ❌ block-param `section` shadows the <section> HTML5 element -->
+{{#each this.sections as |section sectionIndex|}}
+  <section class='content-section'>...</section>
+{{/each}}
+
+<!-- ❌ block-param `option` shadows the <option> tag -->
+<BoxelSelect @options={{@model.options}} as |option|>
+  <option />
+</BoxelSelect>
+
+<!-- ✅ rename the block param so it can't collide -->
+<Shell as |shell|>
+  <button disabled={{not shell.isEditing}}><s>S</s></button>
+</Shell>
+
+{{#each this.sections as |sec sectionIndex|}}
+  <section class='content-section'>...</section>
+{{/each}}
+
+<BoxelSelect @options={{@model.options}} as |opt|>
+  <option>{{opt.label}}</option>
+</BoxelSelect>
+```
+
+**Avoid these block-param names** (HTML tags that commonly come up as iteration / yield-data names):
+
+| Don't use | Use instead |
+|---|---|
+| `s`, `b`, `i`, `u`, `q` | `surface`, `bold`, `item`, `unit`, `quote` |
+| `section` | `sec` |
+| `option` | `opt` |
+| `a` | `link`, `anchor` |
+| `p` | `para` |
+| `nav`, `header`, `footer`, `main`, `aside`, `article` | qualify (`navData`, `pageHeader`, …) |
+| `form`, `input`, `button`, `label`, `select`, `option` | qualify |
+| `dt`, `dd`, `li`, `tr`, `td`, `th` | qualify |
+| `sub`, `sup`, `del`, `ins` | qualify |
+
+The safe rule: **block-param names should be at least 2 characters AND not match any HTML tag**. Multi-word names (`firstItem`, `selectedOption`, `currentSection`) are always safe. Short single-word names are fine if they're not tag names (`item`, `tile`, `bullet`, `member`, `task` etc.).
+
+**Exception — when the block-param IS a component:** sometimes the yielded value is itself a card/field component you want to invoke (e.g. `<@fields.items as |Item|>` … `<Item @format='embedded' />`). In that case, **capitalize the block-param name** (TitleCase). Strict mode treats uppercase tags as components unconditionally — no shadowing concern, and the convention matches Ember's component-naming rules. The lowercase footgun only applies when the yielded value is data, not a component.
+
+**If the rule is violated, the runtime symptom is generic and unhelpful:** Glimmer's component-manager lookup returns `null` for the shadowed name and crashes with
+
+```
+TypeError: Cannot read properties of null (reading 'manager')
+```
+
+…sometimes wrapped as `"Render binding desync"` in the indexer's error_doc with the TypeError buried in `additionalErrors[0]`. The error does NOT name the offending block-param or tag, and the same message can come from many other causes (any path where Glimmer is asked to invoke a `null` component reference). Treat the message as a hint to look for this footgun, *not* as proof of it — but the easiest way not to chase the message is to not write the footgun in the first place.
+
 ### Accessing @fields by Index: The Bridge Pattern
 
 **Use Case:** You need to use `@model` data to find specific items in a `containsMany` or `linksToMany` collection, then render those items using their field templates for proper delegated rendering.


### PR DESCRIPTION
## Summary

Adds a new `⚠️ CRITICAL` rule to `Skill/dev-template-patterns.md` next to the existing `@model Iteration vs @fields Delegation` rule, teaching the agent to avoid shadowing HTML lowercase tag names with block-param names in `.gts` strict-mode templates.

## Why

Surfaced from a multi-realm staging incident. ~20 staging realms had cards stuck in indexing with the error message `TypeError: Cannot read properties of null (reading 'manager')` (often wrapped as `"Render binding desync"` in the indexer's `error_doc` with the TypeError relegated to `additionalErrors[0]`). Three independent realms / card families turned out to have hit the same root cause:

| Realm / card family | Pattern |
|---|---|
| `ctse/concrete-mockingbird` and `ctse/collective-ostrich-28` (`Environment` card) | `<Shell as \|s\|>` then `<s>S</s>` (strikethrough toolbar button) |
| `ctse/spruce-citadel`, `furniture-scrollcase`, `buck/spruce-citadel` (`BoxelScroll`) | `{{#each this.sections as \|section sectionIndex\|}}` then `<section>` HTML5 element |
| `chuan16/20250527-test-workspace-2` (`LifeSatisfactionSurvey` via `question.gts`) | `<BoxelSelect ... as \|option\|>` then `<option />` |

Each case is the same Glimmer strict-mode rule: a block param introduced by `as |x|` shadows any lowercase HTML tag with the same name inside the block. `<x>` is then resolved as "invoke the block-param `x` as a component" — and since the yielded value is a plain data object with no manager registered, `constants.component(value, owner, /* isOptional= */ true)` returns `null`, opcode 79 of `@glimmer/runtime` reads `definition.manager` on the null, crash.

## What's in the rule

- **Lead with the avoid-it framing** — pick block-param names that don't collide with HTML tags. The skill is geared toward not writing the footgun in the first place.
- Three concrete ❌/✅ examples drawn from the real failures (the three rows in the table above).
- An "avoid" table of HTML tags that commonly come up as iteration / yield names: `s`, `section`, `option`, `a`, `p`, `nav`/`header`/`footer`/`main`/`aside`/`article`, `form`/`input`/`button`/`label`/`select`/`option`, `dt`/`dd`/`li`/`tr`/`td`/`th`, `sub`/`sup`/`del`/`ins`.
- A "safe rule" summary: block-param names should be ≥ 2 characters AND not match any HTML tag. Multi-word names (`firstItem`, `selectedOption`) are always safe.
- An **exception** for the legitimate "yield a component" pattern (`<@fields.items as |Item|>` … `<Item @format='embedded' />`): capitalize the block-param. Strict mode treats uppercase tags as components unconditionally, so no shadowing concern.
- A closing note that the runtime error message is **generic** — the same `Cannot read properties of null (reading 'manager')` can come from any path where Glimmer is asked to invoke a `null` component reference. Treat the message as a hint to check this footgun, not as a fingerprint of it.

## Why this skill, this section

`dev-template-patterns.md` is the right home: its summary is *"Field access, delegation, arrays, and fallback patterns"*, and the existing `⚠️ CRITICAL: @model Iteration vs @fields Delegation` rule is structurally identical (also a strict-mode template gotcha, also involves `as |x|` block-params). The new rule sits immediately after it at the same `####` heading depth, so an agent retrieving Template Patterns sees both at once.

Considered alternatives:
- `dev-technical-rules.md` — data-model rules (`contains` vs `linksTo`, exports). Not template-syntax.
- `dev-core-patterns.md` — card/field *definition* patterns. Block-param shadowing is about *invocation* semantics in templates.
- `dev-defensive-programming.md` — runtime safety (optional chaining, null guards). The block-param rule is a compile-time template-shape rule.

## Test plan

- [x] `dev-template-patterns.md` heading hierarchy preserved (verified `grep -nE "^####|^###|^##"` before/after).
- [x] New section is at line 46, sitting between the existing `@model Iteration vs @fields Delegation` rule (line 17) and `Accessing @fields by Index: The Bridge Pattern` (line 106) — the natural neighborhood for `as |x|` block-param guidance.
- [ ] `workspace-push` to a Boxel workspace and exercise via chat to confirm the rule fires when the agent is about to author a shadowing template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)