### PR TITLE
ci: Move dry run output to details element

### DIFF
--- a/.github/workflows/sync-to-workspace.yml
+++ b/.github/workflows/sync-to-workspace.yml
@@ -156,7 +156,7 @@ jobs:
         with:
           script: |
             const syncOutput = `${{ steps.dry_run.outputs.SYNC_OUTPUT }}`;
-            const body = `## 🔍 Workspace Sync Dry-Run Complete\n\n✅ Dry-run completed successfully - no changes were made\n📁 **Target workspace:** ${{ env.STAGING_WORKSPACE_URL }}\n🔗 **PR:** #${{ github.event.number }}\nℹ️ Changes will be synced when this PR is merged to main\n\n### Dry-Run Results\n\`\`\`\n${syncOutput}\n\`\`\``;
+            const body = `## 🔍 Workspace Sync Dry-Run Complete\n\n✅ Dry-run completed successfully - no changes were made\n📁 **Target workspace:** ${{ env.STAGING_WORKSPACE_URL }}\n🔗 **PR:** #${{ github.event.number }}\nℹ️ Changes will be synced when this PR is merged to main\n\n<details>\n<summary>Dry-Run Results</summary>\n\n\`\`\`\n${syncOutput}\n\`\`\`\n\n</details>`;
 
             await github.rest.issues.createComment({
               owner: context.repo.owner,


### PR DESCRIPTION
I suspect people rarely look at this output, and if they want to, it’s still viewable but opt-in:

<img width="2496" height="11986" alt="CleanShot 2026-04-30 at 07 32 25@2x" src="https://github.com/user-attachments/assets/95c4690e-9452-48df-831b-4e108821dd84" />
