### PR TITLE
Update command names

### DIFF
--- a/Skill/boxel-environment.json
+++ b/Skill/boxel-environment.json
@@ -138,7 +138,7 @@
         {
           "codeRef": {
             "name": "default",
-            "module": "@cardstack/boxel-host/commands/invalidate-realm-urls"
+            "module": "@cardstack/boxel-host/commands/invalidate-realm-identifiers"
           },
           "requiresApproval": false
         },

--- a/Skill/env-indexing-operations.json
+++ b/Skill/env-indexing-operations.json
@@ -20,7 +20,7 @@
         {
           "codeRef": {
             "name": "default",
-            "module": "@cardstack/boxel-host/commands/invalidate-realm-urls"
+            "module": "@cardstack/boxel-host/commands/invalidate-realm-identifiers"
           },
           "requiresApproval": false
         },


### PR DESCRIPTION
cardstack/boxel#4627 has a script that applies this transformation when this repository is brought into the monorepo, which will no longer be necessary after this PR is merged.