### PR TITLE
Add realm.json RealmConfig card (CS-11151)

### DIFF
--- a/.realm.json
+++ b/.realm.json
@@ -1,5 +1,0 @@
-{
-  "name": "Boxel Skills",
-  "backgroundURL": "https://boxel-images.boxel.ai/background-images/background-for-catalog-82x.jpg",
-  "iconURL": "https://boxel-images.boxel.ai/icons/wrench.svg"
-}

--- a/realm.json
+++ b/realm.json
@@ -1,0 +1,18 @@
+{
+  "data": {
+    "type": "card",
+    "attributes": {
+      "cardInfo": {
+        "name": "Boxel Skills"
+      },
+      "backgroundURL": "https://boxel-images.boxel.ai/background-images/background-for-catalog-82x.jpg",
+      "iconURL": "https://boxel-images.boxel.ai/icons/wrench.svg"
+    },
+    "meta": {
+      "adoptsFrom": {
+        "module": "https://cardstack.com/base/realm-config",
+        "name": "RealmConfig"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Per [CS-11151](https://linear.app/cardstack/issue/CS-11151). Replaces `.realm.json` with a `realm.json` RealmConfig card — same name/bg/icon, just in the new format the realm-server has preferred since CS-10051. Unblocks CS-11131.

Safe to merge: `workspace-sync-cli` uploads all files before any deletes, so `realm.json` lands on the workspace before `.realm.json` is removed — no window where both are missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)