### PR TITLE
Add Diagnosing Broken Links skill (CS-11265)

### DIFF
--- a/Skill/boxel-development.json
+++ b/Skill/boxel-development.json
@@ -116,6 +116,11 @@
           "inclusionMode": "link-only",
           "contentSummary": "Replicate API essentials, enum fields, API call patterns, response parsing, finding model schemas",
           "alternateTitle": "Replicate AI Integration"
+        },
+        {
+          "inclusionMode": "link-only",
+          "contentSummary": "When a broken-link placeholder appears in a rendered card, follow the placeholder URL back to the linked instance to read its error doc and propose a remediation (fix the linked card, re-target the link, or remove it)",
+          "alternateTitle": "Diagnosing Broken Links"
         }
       ]
     },
@@ -213,6 +218,11 @@
       "relatedSkills.17.skill": {
         "links": {
           "self": "./dev-replicate-ai"
+        }
+      },
+      "relatedSkills.18.skill": {
+        "links": {
+          "self": "./env-diagnosing-broken-links"
         }
       }
     }

--- a/Skill/boxel-environment.json
+++ b/Skill/boxel-environment.json
@@ -217,6 +217,11 @@
           "inclusionMode": "link-only",
           "contentSummary": "Indexing control commands and workflows for realm indexing jobs.",
           "alternateTitle": "Indexing Operations"
+        },
+        {
+          "inclusionMode": "link-only",
+          "contentSummary": "Activate when a broken-link placeholder appears in a card — guides following the URL back to the linked instance to read its error doc and propose a remediation.",
+          "alternateTitle": "Diagnosing Broken Links"
         }
       ]
     },
@@ -274,6 +279,11 @@
       "relatedSkills.9.skill": {
         "links": {
           "self": "./env-indexing-operations"
+        }
+      },
+      "relatedSkills.10.skill": {
+        "links": {
+          "self": "./env-diagnosing-broken-links"
         }
       }
     }

--- a/Skill/env-diagnosing-broken-links.json
+++ b/Skill/env-diagnosing-broken-links.json
@@ -1,0 +1,36 @@
+{
+  "data": {
+    "meta": {
+      "adoptsFrom": {
+        "name": "SkillPlusMarkdown",
+        "module": "https://cardstack.com/base/skill-plus"
+      }
+    },
+    "type": "card",
+    "attributes": {
+      "cardInfo": {
+        "notes": null,
+        "name": "Diagnosing Broken Links",
+        "summary": "When a linksTo or linksToMany target renders the broken-link placeholder, follow the URL back to the linked instance to read its error doc and propose a remediation",
+        "cardThumbnailURL": null
+      },
+      "commands": []
+    },
+    "relationships": {
+      "cardInfo.theme": {
+        "links": {
+          "self": "https://cardstack.com/base/Theme/cardstack-brand-guide"
+        }
+      },
+      "instructionsSource": {
+        "links": {
+          "self": "./env-diagnosing-broken-links.md"
+        },
+        "data": {
+          "type": "file",
+          "id": "./env-diagnosing-broken-links.md"
+        }
+      }
+    }
+  }
+}

--- a/Skill/env-diagnosing-broken-links.md
+++ b/Skill/env-diagnosing-broken-links.md
@@ -1,0 +1,62 @@
+# Diagnosing Broken Links
+
+When a `linksTo` or `linksToMany` target is broken (deleted or errored), Boxel renders a **broken-link placeholder** in place of the linked card. JavaScript access to the field returns `undefined` for singular links and skips the broken element for plural links. The placeholder in the DOM is the **canonical signal** that something is wrong — not a transient loading state, not a missing field, not a bug to ignore.
+
+The parent card carrying the broken link indexes cleanly. The error lives on the **linked instance**, not the parent. To diagnose, you follow the URL back to the linked instance.
+
+## Recognise the placeholder
+
+Every broken-link slot renders a `<div>` carrying these data-test attributes:
+
+| Attribute | Value | Meaning |
+| --- | --- | --- |
+| `data-test-broken-link-template` | `isolated` \| `fitted` \| `embedded` \| `atom` | The render format of the broken slot |
+| `data-test-broken-link-state` | `error` \| `not-found` | What kind of break |
+| `data-test-broken-link-url` | full card URL | The URL of the broken target — **this is your starting point** |
+
+Additional attributes you may see inside the placeholder, when applicable:
+
+| Attribute | Available when |
+| --- | --- |
+| `data-test-broken-link-headline` | always |
+| `data-test-broken-link-status` | the error doc carries a `status` or `title` |
+| `data-test-broken-link-message` | `state === 'error'` only |
+| `data-test-broken-link-stack` | `state === 'error'` and format is `isolated` |
+| `data-test-broken-link-additional-error={i}` | `state === 'error'` and format is `isolated`, when upstream errors are chained |
+
+The URL is also visible to human readers as the placeholder's primary text.
+
+## `error` vs `not-found`
+
+| `state` | What happened | How to fetch the diagnostic |
+| --- | --- | --- |
+| `not-found` | The linked instance doesn't exist (deleted or never created). | Realm GET on the URL returns a 404 error doc directly. |
+| `error` | The linked instance exists but indexed with an error — broken `.gts` dependency, schema mismatch, computed threw, network failure during indexing, etc. | Fetch the linked URL; the error doc lives on **that** instance, not on the card you're editing. |
+
+## Workflow
+
+When the user asks to fix a broken link, or when you encounter a placeholder while reading a card:
+
+1. **Extract the URL** from `data-test-broken-link-url` on the placeholder element.
+2. **Fetch the linked instance** with `read-card-for-ai-assistant_xxxx` (cardId: the broken URL). The tool result surfaces the error message for both `error` and `not-found` states.
+3. **Inspect linked source** if the error implicates a `.gts` dependency or schema mismatch. Use `read-file-for-ai-assistant_a831` with `fileUrl` set to the linked card's `.json` instance file or its `.gts` definition.
+4. **Identify the root cause** — read `message`, `status`, `additionalErrors`, `stack`, and `diagnostics` on the error doc: deleted instance, broken `.gts` dependency, schema mismatch, transient network failure during indexing, etc.
+5. **Propose a remediation**:
+   - **Fix the linked card** itself — typical when `error` is from a broken computed or dependency in its `.gts` def.
+   - **Re-target the link** on the parent to a different existing card. Use `patch-fields_3e67`.
+   - **Remove the link** if the relationship is no longer needed. Use `patch-fields_3e67`.
+   - **Restore the deleted instance** if `not-found` and recovery is possible.
+6. **Verify post-fix**: the parent card's placeholder should disappear on the next render. If it persists, the underlying error wasn't addressed — re-diagnose; don't assume the fix worked.
+
+## What the placeholder is *not*
+
+- **Not a loading state.** Don't wait for it to resolve; act on it.
+- **Not a "missing field" bug.** The parent's schema is fine; don't patch the parent's schema as a workaround.
+- **Not transient.** A re-fetch won't make it disappear; the linked instance needs to be fixed.
+
+## Pre-flight checklist
+
+Before proposing a remediation, verify:
+- [ ] Read the URL from `data-test-broken-link-url`?
+- [ ] Fetched the linked instance and inspected its error doc?
+- [ ] Targeting the right card — the linked one for `error` fixes, the parent's link field for re-targeting or removal?


### PR DESCRIPTION
## Background and Goal

When a `linksTo` or `linksToMany` target is broken (deleted or errored), Boxel renders a placeholder where the linked card would otherwise appear. The parent card indexes cleanly; the error doc lives on the linked instance, not on the parent. Without explicit guidance, an assistant reading the parent sees a placeholder and stops — leaving the user to do the diagnostic legwork.

This adds `env-diagnosing-broken-links` under `Skill/`, wired into `boxel-environment.json` as a `link-only` related skill. The skill names the placeholder's data-test attribute hooks (`data-test-broken-link-template`, `data-test-broken-link-url`, `data-test-broken-link-state`), explains the `error` vs `not-found` distinction, and walks through the workflow: extract the URL, fetch the linked instance with `read-card-for-ai-assistant_xxxx`, read its error doc, propose a remediation, verify.

## Hold for upstream

The behavior this skill describes (parent card no longer inheriting the linked instance's error doc) is gated on [CS-11212](https://linear.app/cardstack/issue/CS-11212) in the boxel main repo. Hold merge until that change is live.