### PR TITLE
Add Relationship Loading State skill

### DIFF
--- a/Skill/dev-relationship-loading-state.json
+++ b/Skill/dev-relationship-loading-state.json
@@ -1,0 +1,36 @@
+{
+  "data": {
+    "meta": {
+      "adoptsFrom": {
+        "name": "SkillPlusMarkdown",
+        "module": "https://cardstack.com/base/skill-plus"
+      }
+    },
+    "type": "card",
+    "attributes": {
+      "cardInfo": {
+        "notes": null,
+        "name": "Relationship Loading State",
+        "summary": "Render a live progress indicator for query-backed linksToMany (and any linksTo / linksToMany) via getRelationshipMembershipState().isLoading",
+        "cardThumbnailURL": null
+      },
+      "commands": []
+    },
+    "relationships": {
+      "cardInfo.theme": {
+        "links": {
+          "self": "https://cardstack.com/base/Theme/cardstack-brand-guide"
+        }
+      },
+      "instructionsSource": {
+        "links": {
+          "self": "./dev-relationship-loading-state.md"
+        },
+        "data": {
+          "type": "file",
+          "id": "./dev-relationship-loading-state.md"
+        }
+      }
+    }
+  }
+}

--- a/Skill/dev-relationship-loading-state.md
+++ b/Skill/dev-relationship-loading-state.md
@@ -21,13 +21,13 @@ import { getRelationshipMembershipState } from 'https://cardstack.com/base/card-
 
 Expose `isLoading` through a getter and bind it. The flagship case is a **query-backed `linksToMany`**, which runs a search to resolve:
 
-```ts
+```gts
 class Matchmaker extends CardDef {
   @field cardTitle = contains(StringField);
   @field matches = linksToMany(() => Person, {
     query: {
       filter: { eq: { name: '$this.cardTitle' } },
-      page: { size: 10, number: 0 },
+      page: { size: 10 },
     },
   });
 
@@ -57,12 +57,12 @@ This is the one rule that trips people up. `getRelationshipMembershipState` **on
 So a template that shows a spinner **must also render the field**. If you bind `isLoading` but never touch the field, the load never starts and **`isLoading` stays `false` forever** — the spinner never appears.
 
 ```hbs
-{{! ❌ BROKEN — nothing reads `matches`, so the search never runs }}
-{{!    and `matchesLoading` is always false }}
+{{!-- ❌ BROKEN — nothing reads `matches`, so the search never runs
+      and `matchesLoading` is always false --}}
 {{#if @model.matchesLoading}}<Spinner />{{/if}}
 
-{{! ✅ the {{#each}} reads the field, which triggers the search; }}
-{{!    isLoading then reports that search's progress }}
+{{!-- ✅ the {{#each}} reads the field, which triggers the search;
+      isLoading then reports that search's progress --}}
 {{#if @model.matchesLoading}}<Spinner />{{/if}}
 {{#each @model.matches as |match|}}<PersonPill @person={{match}} />{{/each}}
 ```

--- a/Skill/dev-relationship-loading-state.md
+++ b/Skill/dev-relationship-loading-state.md
@@ -1,0 +1,100 @@
+# Relationship Loading State
+
+A `linksTo` / `linksToMany` field loads its linked card(s) lazily, and a **query-backed** `linksToMany` resolves by running a search. Until that load or search finishes, the field has no data to show. `getRelationshipMembershipState` lets a card author render a live progress indicator for that window — a spinner that appears while the field is in flight and clears the moment it resolves.
+
+```ts
+import { getRelationshipMembershipState } from 'https://cardstack.com/base/card-api';
+```
+
+## The shape
+
+`getRelationshipMembershipState(instance, fieldName)` returns one object for **every** `linksTo` / `linksToMany` field — query-backed or not:
+
+```ts
+{ isLoading: boolean; membership: RelationshipState[] | undefined }
+```
+
+- **`isLoading`** — a whole-field boolean, `true` while the field's data is actually being fetched (a declared link still loading, or a query field's search running). It is **live**: backed by tracked state, so a template bound to it re-renders the instant the load settles.
+- **`membership`** — the per-element resolution(s). For the loading-indicator use case you read `isLoading`; the per-slot states in `membership` are covered in the **Defensive Link Traversal** skill.
+
+## Driving a spinner from a template
+
+Expose `isLoading` through a getter and bind it. The flagship case is a **query-backed `linksToMany`**, which runs a search to resolve:
+
+```ts
+class Matchmaker extends CardDef {
+  @field cardTitle = contains(StringField);
+  @field matches = linksToMany(() => Person, {
+    query: {
+      filter: { eq: { name: '$this.cardTitle' } },
+      page: { size: 10, number: 0 },
+    },
+  });
+
+  get matchesLoading() {
+    return getRelationshipMembershipState(this, 'matches').isLoading;
+  }
+
+  static isolated = class extends Component<typeof Matchmaker> {
+    <template>
+      {{#if @model.matchesLoading}}
+        <LoadingIndicator data-test-loading />
+      {{/if}}
+      {{#each @model.matches as |match|}}
+        <PersonPill @person={{match}} />
+      {{/each}}
+    </template>
+  };
+}
+```
+
+While the search runs, `matchesLoading` is `true` and the spinner shows; when results arrive it flips to `false` and the spinner clears — automatically, because the field is tracked.
+
+## `isLoading` is observe-only — the template must still read the field
+
+This is the one rule that trips people up. `getRelationshipMembershipState` **only monitors**; it never starts the load. **The thing that kicks off the lazy load / search is reading the field itself** (`@model.matches` in the `{{#each}}` above).
+
+So a template that shows a spinner **must also render the field**. If you bind `isLoading` but never touch the field, the load never starts and **`isLoading` stays `false` forever** — the spinner never appears.
+
+```hbs
+{{! ❌ BROKEN — nothing reads `matches`, so the search never runs }}
+{{!    and `matchesLoading` is always false }}
+{{#if @model.matchesLoading}}<Spinner />{{/if}}
+
+{{! ✅ the {{#each}} reads the field, which triggers the search; }}
+{{!    isLoading then reports that search's progress }}
+{{#if @model.matchesLoading}}<Spinner />{{/if}}
+{{#each @model.matches as |match|}}<PersonPill @person={{match}} />{{/each}}
+```
+
+In practice you always render the field next to its spinner, so this falls out naturally — but if you ever see a spinner that never appears, this is why.
+
+## Works the same for declared `linksTo` / `linksToMany`
+
+The same getter + `{{#if}}` pattern drives a spinner for an ordinary declared link while its lazy load is in flight:
+
+```ts
+get petLoading() {
+  return getRelationshipMembershipState(this, 'pet').isLoading;
+}
+```
+
+```hbs
+{{#if @model.petLoading}}<Spinner />{{/if}}
+<span>{{@model.pet.firstName}}</span>
+```
+
+For a declared `linksToMany`, **`isLoading` stays `true` until *every* element has settled** — a half-loaded list still reports loading.
+
+## Live queries re-enter the loading state
+
+A query-backed field is **live**: when its inputs change (here, `cardTitle`) the search re-runs. On each re-run `isLoading` goes back to `true` (and `membership` back to `undefined`) while the new search is in flight, then back to `false` with the fresh results — the same transition as the initial load. A bound spinner reappears on its own for each re-query.
+
+## Key principles
+
+- `getRelationshipMembershipState(this, 'field').isLoading` is a **live, tracked boolean** — bind it in a template to show a progress indicator that updates on its own.
+- It is **observe-only**: reading `isLoading` never starts the load. Always render the field itself (`{{#each @model.field}}` / `{{@model.field}}`) alongside the spinner, or the load never begins and `isLoading` stays `false`.
+- The flagship use case is a **query-backed `linksToMany`** (a search-driven list): show a spinner while the search runs.
+- A declared `linksToMany` reports `isLoading: true` until **every** element settles.
+- A live query **re-enters** loading on each re-run; the spinner reappears for free.
+- To read per-element state (present / loading / broken), see the **Defensive Link Traversal** skill — `membership` and `RelationshipState` are covered there.


### PR DESCRIPTION
Adds a **Relationship Loading State** skill that teaches card authors to render a live progress indicator for a `linksTo` / `linksToMany` field — the flagship case being a query-backed `linksToMany` (a search-driven list).

The skill documents binding `getRelationshipMembershipState(this, 'field').isLoading` in a template:

```ts
get matchesLoading() {
  return getRelationshipMembershipState(this, 'matches').isLoading;
}
```
```hbs
{{#if @model.matchesLoading}}<Spinner />{{/if}}
{{#each @model.matches as |m|}}<PersonPill @person={{m}} />{{/each}}
```

It covers the points that trip authors up:

- **Observe-only.** `isLoading` is a live, tracked boolean; reading it never starts the load. The field getter (`{{#each @model.matches}}`) is what kicks off the lazy load / search, so a spinner must render the field beside it — otherwise the load never begins and `isLoading` stays `false` forever.
- A declared `linksToMany` reports `isLoading: true` until **every** element settles.
- A **live query re-enters** the loading state on every re-run when its inputs change.

Cross-links the existing **Defensive Link Traversal** skill for per-element `membership` / `RelationshipState`.

Follows the existing `Skill/dev-*` pair convention (`.md` instructions + `SkillPlusMarkdown` card `.json`).

> Depends on the platform change that adds `getRelationshipMembershipState` (the `getRelationship` rename + live `isLoading`); merge after that lands so the documented API exists.
