### PR TITLE
Update catalog-listing skill commands to reference catalog realm

### DIFF
--- a/Skill/catalog-listing.json
+++ b/Skill/catalog-listing.json
@@ -18,28 +18,28 @@
         {
           "codeRef": {
             "name": "default",
-            "module": "@cardstack/boxel-host/commands/listing-create"
+            "module": "@cardstack/catalog/commands/listing-create"
           },
           "requiresApproval": false
         },
         {
           "codeRef": {
             "name": "default",
-            "module": "@cardstack/boxel-host/commands/listing-use"
+            "module": "@cardstack/catalog/commands/listing-use"
           },
           "requiresApproval": false
         },
         {
           "codeRef": {
             "name": "default",
-            "module": "@cardstack/boxel-host/commands/listing-install"
+            "module": "@cardstack/catalog/commands/listing-install"
           },
           "requiresApproval": false
         },
         {
           "codeRef": {
             "name": "default",
-            "module": "@cardstack/boxel-host/commands/listing-remix"
+            "module": "@cardstack/catalog/commands/listing-remix"
           },
           "requiresApproval": false
         },


### PR DESCRIPTION
linear: https://linear.app/cardstack/issue/CS-11428/update-catalog-listing-skill-commands-to-reference-catalog-realm

The Catalog Listing skill JSON files still pointed at
`@cardstack/boxel-host/commands/listing-{create,use,install,remix}`.
With the host shims removed [(CS-11372)](https://github.com/cardstack/boxel/pull/5146), the loader can no longer resolve
those paths and any bot-triggered listing action would fail silently.

Update both skill definitions to point at the canonical catalog
implementations:

- packages/base/Skill/catalog-listing.json
- packages/skills-realm/contents/Skill/catalog-listing.json

`preview-format` is intentionally left on `@cardstack/boxel-host/commands/`
— it is a host-only command with no catalog equivalent.
