### PR TITLE
Steer card search guidance to v2 @context.searchResultsComponent

### DIFF
--- a/Skill/dev-query-systems.md
+++ b/Skill/dev-query-systems.md
@@ -68,7 +68,49 @@ const query = {
 ```
 
 **When to use what to query cards:**
-- Efficient display-only → `PrerenderedCardSearch`
-- Need data manipulation → `getCards`
-- Treat query result as a field → query-backed fields
+- Display a list of results (cards or files) → render with `@context.searchResultsComponent` (the `<SearchResults>` component). It prefers fast prerendered HTML and falls back to a live card per result — you never branch on which.
+- Need the instances in JS (read / manipulate) → `getCards` (reactive) or `@context.store.search` (imperative, returns instances)
+- Treat a query result as a field → query-backed fields (`linksTo` / `linksToMany` with a `query`)
+
+> ⚠️ Deprecated: `@context.prerenderedCardSearchComponent` / `<PrerenderedCardSearch>` is the old display surface. Use `@context.searchResultsComponent` instead.
+
+**Rendering a result list via `@context.searchResultsComponent`:**
+
+Declare a `search-entry`-rooted query and render the yielded entries. Each `entry.component` renders itself — prerendered HTML inert (hydrated lazily on interaction) or a live card — so the card never decides which:
+
+```gts
+import {
+  searchEntryWireQueryFromQuery,
+  type SearchEntryWireQuery,
+} from '@cardstack/runtime-common';
+
+class Isolated extends Component<typeof BlogPost> {
+  get query(): SearchEntryWireQuery {
+    // Build the search-entry query from an ordinary query, then add realms.
+    return {
+      ...searchEntryWireQueryFromQuery({
+        filter: {
+          on: { module: new URL('./author', import.meta.url).href, name: 'Author' },
+          eq: { status: 'active' },
+        },
+        sort: [{ by: 'title', direction: 'asc' }],
+      }),
+      realms: ['https://my-realm.example/'], // realm URLs to search
+    };
+  }
+
+  <template>
+    <@context.searchResultsComponent @query={{this.query}} @mode='hover' as |results|>
+      {{#each results.entries key='id' as |entry|}}
+        <entry.component />
+      {{else}}
+        {{if results.isLoading 'Loading…' 'No results'}}
+      {{/each}}
+    </@context.searchResultsComponent>
+  </template>
+}
 ```
+
+- `@query` — a `search-entry`-rooted query (`SearchEntryWireQuery`). Build it from a normal query with `searchEntryWireQueryFromQuery`, then set `realms` (and optionally `page`). Changing it re-runs the search.
+- `@mode` — hydration of prerendered rows on interaction: `'none'` (stay inert), `'hover'` (default), `'click'`, `'touch'`.
+- Yields `results`: `results.entries` (each `entry` exposes `.component`, `.id`, `.isError`, plus `.displayName` / `.iconHtml` for a row with no HTML yet), `results.isLoading`, `results.meta` (`{ page: { total } }`), and `results.errors`.

--- a/Skill/dev-query-systems.md
+++ b/Skill/dev-query-systems.md
@@ -79,35 +79,38 @@ const query = {
 Declare a `search-entry`-rooted query and render the yielded entries. Each `entry.component` renders itself — prerendered HTML inert (hydrated lazily on interaction) or a live card — so the card never decides which:
 
 ```gts
+import { CardDef, Component } from 'https://cardstack.com/base/card-api';
 import {
   searchEntryWireQueryFromQuery,
   type SearchEntryWireQuery,
 } from '@cardstack/runtime-common';
 
-class Isolated extends Component<typeof BlogPost> {
-  get query(): SearchEntryWireQuery {
-    // Build the search-entry query from an ordinary query, then add realms.
-    return {
-      ...searchEntryWireQueryFromQuery({
-        filter: {
-          on: { module: new URL('./author', import.meta.url).href, name: 'Author' },
-          eq: { status: 'active' },
-        },
-        sort: [{ by: 'title', direction: 'asc' }],
-      }),
-      realms: ['https://my-realm.example/'], // realm URLs to search
-    };
-  }
+class BlogPost extends CardDef {
+  static isolated = class Isolated extends Component<typeof BlogPost> {
+    get query(): SearchEntryWireQuery {
+      // Build the search-entry query from an ordinary query, then add realms.
+      return {
+        ...searchEntryWireQueryFromQuery({
+          filter: {
+            on: { module: new URL('./author', import.meta.url).href, name: 'Author' },
+            eq: { status: 'active' },
+          },
+          sort: [{ by: 'title', direction: 'asc' }],
+        }),
+        realms: ['https://my-realm.example/'], // realm URLs to search
+      };
+    }
 
-  <template>
-    <@context.searchResultsComponent @query={{this.query}} @mode='hover' as |results|>
-      {{#each results.entries key='id' as |entry|}}
-        <entry.component />
-      {{else}}
-        {{if results.isLoading 'Loading…' 'No results'}}
-      {{/each}}
-    </@context.searchResultsComponent>
-  </template>
+    <template>
+      <@context.searchResultsComponent @query={{this.query}} @mode='hover' as |results|>
+        {{#each results.entries key='id' as |entry|}}
+          <entry.component />
+        {{else}}
+          {{if results.isLoading 'Loading…' 'No results'}}
+        {{/each}}
+      </@context.searchResultsComponent>
+    </template>
+  };
 }
 ```
 

--- a/Skill/dev-template-patterns.md
+++ b/Skill/dev-template-patterns.md
@@ -33,14 +33,14 @@ The `markdown` format emits plain text (Boxel Flavored Markdown), not HTML. A wo
 {{/each}}
 
 <!-- ✅ OPTION 3: If filtering needed, use query patterns -->
-<!-- Use PrerenderedCardSearch or getCards for filtered collections -->
+<!-- Use @context.searchResultsComponent or getCards for filtered collections -->
 ```
 
 **Why this breaks:** @fields provides field-level components. Once you're iterating with @model, you're working with raw data, not field components.
 
 **Decision Rule:** Before iterating, decide:
 - Need composability? → Use delegated rendering
-- Need filtering? → Use query patterns (PrerenderedCardSearch/getCards)
+- Need filtering? → Use query patterns (@context.searchResultsComponent / getCards)
 - Need custom control? → Use @model but handle ALL rendering yourself
 
 #### ⚠️ CRITICAL: Block-Param Names Must Not Match HTML Tag Names
@@ -383,7 +383,7 @@ export class ShoppingList extends CardDef {
 **When NOT to Use:**
 - If you need to iterate all items → use `<@fields.items />` delegation
 - If you need custom rendering for each → use `{{#each @model.items}}` pattern
-- For simple filtering → use query patterns with PrerenderedCardSearch
+- For simple filtering → use query patterns with @context.searchResultsComponent
 
 **Performance Consideration:**
 The `get` helper is efficient for accessing specific indices. For complex filtering or transformation, consider using query patterns or computed properties instead.


### PR DESCRIPTION
Updates the card-authoring search guidance to the v2 search surface.

Cards now render a list of search results with `@context.searchResultsComponent` (the `<SearchResults>` component), which prefers fast prerendered HTML and falls back to a live card per result — the card never branches on which. The previous `@context.prerenderedCardSearchComponent` / `<PrerenderedCardSearch>` surface is deprecated.

- **dev-query-systems**: the "when to use what to query cards" list now points to `@context.searchResultsComponent`, plus a worked example — the `search-entry` query (built with `searchEntryWireQueryFromQuery`), the `@mode` hydration arg, and rendering the yielded `results.entries` via `entry.component`.
- **dev-template-patterns**: the three "use query patterns" pointers now name `@context.searchResultsComponent` instead of `PrerenderedCardSearch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
