### PR TITLE
Add Searchable Fields skill; document the searchable field option (CS-11725)

### DIFF
--- a/Skill/boxel-development.json
+++ b/Skill/boxel-development.json
@@ -126,6 +126,11 @@
           "inclusionMode": "full",
           "contentSummary": "linksTo / linksToMany slots read as Card | undefined during the lazy-load window and on broken links; guard patterns for computeds, templates, and helpers (optional chaining, == null skips, ?. in maps, filter before render); getRelationship for structured per-slot state",
           "alternateTitle": "Defensive Link Traversal"
+        },
+        {
+          "inclusionMode": "link-only",
+          "contentSummary": "The `searchable` field option controls which links a card's search doc follows: contained fields are always included; a link is { id } until made searchable; true = the self link, a dotted path = a deeper (n+1) link, an array combines routes; links capture the declared type only; query-backed relationships are inert; querying a resolvable-but-non-searchable path errors",
+          "alternateTitle": "Searchable Fields"
         }
       ]
     },
@@ -233,6 +238,11 @@
       "relatedSkills.19.skill": {
         "links": {
           "self": "./dev-defensive-link-traversal"
+        }
+      },
+      "relatedSkills.20.skill": {
+        "links": {
+          "self": "./dev-searchable-fields"
         }
       }
     }

--- a/Skill/boxel-development.json
+++ b/Skill/boxel-development.json
@@ -129,7 +129,7 @@
         },
         {
           "inclusionMode": "link-only",
-          "contentSummary": "The `searchable` field option controls which links a card's search doc follows: contained fields are always included; a link is { id } until made searchable; true = the self link, a dotted path = a deeper (n+1) link, an array combines routes; links capture the declared type only; query-backed relationships are inert; querying a resolvable-but-non-searchable path errors",
+          "contentSummary": "The `searchable` field option controls which links a card's search doc follows: contained fields are always included; an unmarked link is a bare reference only (a linksTo as its { id }, a linksToMany as an array of them) until made searchable; true = the self link, a dotted path = a deeper (n+1) link, an array combines routes; links capture the declared type only; query-backed relationships are inert; querying a resolvable-but-non-searchable path errors",
           "alternateTitle": "Searchable Fields"
         }
       ]

--- a/Skill/dev-core-patterns.md
+++ b/Skill/dev-core-patterns.md
@@ -49,7 +49,7 @@ export class BlogPost extends CardDef {
   
   @field headline = contains(StringField);
   @field publishDate = contains(DateField);
-  @field author = linksTo(Author);
+  @field author = linksTo(Author, { searchable: true }); // searchable → filter on author.* in queries
   @field tags = containsMany(TagField);
   @field relatedPosts = linksToMany(() => BlogPost);
   

--- a/Skill/dev-delegated-rendering.md
+++ b/Skill/dev-delegated-rendering.md
@@ -5,6 +5,8 @@
 <@fields.items @format="embedded" />
 ```
 
+> Delegated rendering governs **display** only. What a card's embedded/fitted templates render does **not** decide how deep its search doc goes — that is controlled entirely by the `searchable` field option (see the **Searchable Fields** skill). Rendering a linked card in a template does not make it queryable, and marking a link `searchable` does not require rendering it.
+
 **Make cards clickable:**
 ```hbs
 <CardContainer

--- a/Skill/dev-searchable-fields.json
+++ b/Skill/dev-searchable-fields.json
@@ -1,0 +1,36 @@
+{
+  "data": {
+    "meta": {
+      "adoptsFrom": {
+        "name": "SkillPlusMarkdown",
+        "module": "https://cardstack.com/base/skill-plus"
+      }
+    },
+    "type": "card",
+    "attributes": {
+      "cardInfo": {
+        "notes": null,
+        "name": "Searchable Fields",
+        "summary": "The `searchable` field option — how it decides which links are followed into a card's search doc (contained always included; links opt-in; true = self link, dotted path = deeper link)",
+        "cardThumbnailURL": null
+      },
+      "commands": []
+    },
+    "relationships": {
+      "cardInfo.theme": {
+        "links": {
+          "self": "https://cardstack.com/base/Theme/cardstack-brand-guide"
+        }
+      },
+      "instructionsSource": {
+        "links": {
+          "self": "./dev-searchable-fields.md"
+        },
+        "data": {
+          "type": "file",
+          "id": "./dev-searchable-fields.md"
+        }
+      }
+    }
+  }
+}

--- a/Skill/dev-searchable-fields.md
+++ b/Skill/dev-searchable-fields.md
@@ -14,7 +14,7 @@ type Searchable = true | string | string[];
 ## The one invariant: contained is always in, links are opt-in
 
 - **Contained fields are always included** — for the card being indexed and for every card pulled into the doc. `searchable` never touches them; a `contains` / `containsMany` value is in the doc because its owner is.
-- **A link is `{ id }` only unless you make it searchable.** Not annotated ⇒ just the reference. Annotated ⇒ the target card is pulled in, and (being a card in the doc) all of *its* contained fields come along automatically.
+- **A link is captured as a bare reference unless you make it searchable** — a `linksTo` as its target's `{ id }`, a `linksToMany` as an array of `{ id }` refs. Not annotated ⇒ just the reference(s). Annotated ⇒ the target card(s) are pulled in, and (being cards in the doc) all of *their* contained fields come along automatically.
 
 This shallow-by-default behavior for links is the whole point: a search doc includes exactly the linked cards you name, nothing more.
 
@@ -65,7 +65,7 @@ There is no path segment that names "this link itself" — paths name the *next*
   @field author = linksTo(Author, { searchable: true });   // now `eq: { 'author.name': … }` resolves
   ```
 
-- **Query-backed relationships are never captured.** A `linksTo` / `linksToMany` with a `query` can't be invalidated when matching cards change, so it would go stale. `searchable` is accepted but **inert** on one (a valid no-op), and a path cannot route deeper through it — routing a *filter* through a query-backed hop errors like any other non-searchable hop.
+- **Query-backed relationships are never captured.** A `linksTo` / `linksToMany` with a `query` can't be invalidated when matching cards change, so it would go stale. `searchable` is accepted but **inert** on a query-backed relationship (a valid no-op), and a path cannot route deeper through it — routing a *filter* through a query-backed hop errors like any other non-searchable hop.
 - **No wildcard.** There is deliberately no "make everything searchable" form; a cyclic or high-fan-out link graph could otherwise pull an unbounded slice of the realm into one doc.
 - **Cycles clip to `{ id }`; broken or not-loaded links degrade to `{ id }`.**
 

--- a/Skill/dev-searchable-fields.md
+++ b/Skill/dev-searchable-fields.md
@@ -1,0 +1,101 @@
+# Searchable Fields
+
+A card's **search doc** is the flattened JSON the index queries against. Every **contained** field is always in it. The `searchable` field option decides which **links** (`linksTo` / `linksToMany`) are followed into the doc — i.e. which linked cards get pulled in rather than left as a bare reference.
+
+```ts
+type Searchable = true | string | string[];
+```
+
+```gts
+@field author = linksTo(Author, { searchable: true });
+@field authors = linksToMany(Author, { searchable: 'address.country' });
+```
+
+## The one invariant: contained is always in, links are opt-in
+
+- **Contained fields are always included** — for the card being indexed and for every card pulled into the doc. `searchable` never touches them; a `contains` / `containsMany` value is in the doc because its owner is.
+- **A link is `{ id }` only unless you make it searchable.** Not annotated ⇒ just the reference. Annotated ⇒ the target card is pulled in, and (being a card in the doc) all of *its* contained fields come along automatically.
+
+This shallow-by-default behavior for links is the whole point: a search doc includes exactly the linked cards you name, nothing more.
+
+## `true` vs a dotted path
+
+There is no path segment that names "this link itself" — paths name the *next* link and beyond. So:
+
+- **`searchable: true`** — make **this** link (the immediate, "self" link) searchable. Its target is pulled in; the target's own links stay `{ id }`.
+- **a dotted path** — make a **deeper** (n+1) link searchable. The path routes *from this link's target* through its links, pulling in every card along the route. To reach a deeper link through a contained `FieldDef`, name the intermediate contained field(s) as segments.
+- **an array** — combine multiple routes.
+- **omitted** — the link stays `{ id }` only.
+
+```gts
+@field author = linksTo(Author);
+// Not searchable → { id } only.
+
+@field author = linksTo(Author, { searchable: true });
+// Author is pulled in (with all Author's contained fields). Author's own links stay { id }.
+
+@field author = linksTo(Author, { searchable: 'address' });
+// Author AND Author's `address` link are pulled in. Author's other links stay { id }.
+
+@field authors = linksToMany(Author, { searchable: 'address.country' });
+// For each linked Author: pull in address, then country — every card on the route.
+
+@field author = linksTo(Author, { searchable: ['address', 'employer.headquarters'] });
+// Two routes from Author: its address, and its employer's headquarters.
+
+@field citations = containsMany(Citation, { searchable: 'article.author' });
+// Each Citation's contained fields are always in the doc; this additionally makes
+// each citation's `article` link, then that article's `author` link, searchable.
+
+@field signOff = contains(Signoff, { searchable: 'editor' });
+// Signoff's contained fields are always in the doc; this additionally makes its
+// `editor` link searchable.
+
+@field dateLine = contains(DateField);
+// Contained → always fully included. searchable does not apply.
+```
+
+## Firm rules
+
+- **Links capture the declared type only.** `linksTo(X)` / `linksToMany(X)` pulls in exactly `X`'s declared fields. A polymorphic subtype's extra contained fields are *not* captured — they are unqueryable anyway (a filter path resolves against the declared type), so the search-doc shape is fully determined by the static field definitions.
+- **Querying a non-searchable path errors.** A filter whose path resolves in the schema but crosses a `linksTo` / `linksToMany` hop that was never made `searchable` throws a distinct query-time error (separate from "nonexistent field") that names the field and the annotation to add. It surfaces a forgotten annotation at the point of use instead of returning silently-empty results.
+
+  ```gts
+  // Filtering on author.name requires the author link to be searchable:
+  @field author = linksTo(Author, { searchable: true });   // now `eq: { 'author.name': … }` resolves
+  ```
+
+- **Query-backed relationships are never captured.** A `linksTo` / `linksToMany` with a `query` can't be invalidated when matching cards change, so it would go stale. `searchable` is accepted but **inert** on one (a valid no-op), and a path cannot route deeper through it — routing a *filter* through a query-backed hop errors like any other non-searchable hop.
+- **No wildcard.** There is deliberately no "make everything searchable" form; a cyclic or high-fan-out link graph could otherwise pull an unbounded slice of the realm into one doc.
+- **Cycles clip to `{ id }`; broken or not-loaded links degrade to `{ id }`.**
+
+## Routing through FieldDefs
+
+A `FieldDef` may declare its own `linksTo` / `linksToMany`, so a `searchable` path can route through `contains` → `linksTo` chains. Name each intermediate contained field as a segment:
+
+```gts
+class Profile extends FieldDef {
+  @field lead = linksTo(Person);
+  @field members = linksToMany(Person);
+}
+
+class Team extends CardDef {
+  @field profile = contains(Profile, { searchable: ['lead', 'members'] });
+  // profile's contained fields are always in the doc; this additionally makes
+  // profile.lead and profile.members searchable (each Person pulled in).
+}
+```
+
+## Authoring-time validation
+
+An annotation path that doesn't resolve — a typo, a removed field, or a segment that isn't a relationship/contained field — is **logged and recorded in the module's build diagnostics, never thrown**. Definition build is decoupled from the edit that introduced the bad path, so a throw would surface at a confusing, unrelated moment. The bad path is simply not followed; if anything actually queries that intended path, the query-time error above is the loud backstop.
+
+## Key principles
+
+- Contained fields are always in the search doc; `searchable` governs links only.
+- A link is `{ id }` only until made searchable; then its target (and all the target's contained fields) is pulled in.
+- `searchable: true` makes the immediate link searchable; a dotted path makes a deeper (n+1) link searchable; an array combines routes.
+- Links capture the declared type only.
+- Query-backed relationships are never captured — `searchable` is an inert no-op on them.
+- Querying a resolvable-but-non-searchable path throws a distinct error naming the annotation to add.
+- There is no wildcard; cycles and broken/not-loaded links clip to `{ id }`.

--- a/Skill/dev-spec-usage.md
+++ b/Skill/dev-spec-usage.md
@@ -1,9 +1,10 @@
 **Card specs (linksTo/linksToMany):**
 ```gts
 import { Author } from './author';
-@field author = linksTo(Author);
+@field author = linksTo(Author, { searchable: true }); // searchable → queryable via author.*
 @field contributors = linksToMany(Author);
 ```
+Mark a link `searchable` to pull its target into the search doc and make it queryable (a plain link is stored as `{ id }` only); see the **Searchable Fields** skill.
 
 **Field specs (contains/containsMany):**
 ```gts

--- a/Skill/dev-spec-usage.md
+++ b/Skill/dev-spec-usage.md
@@ -4,7 +4,7 @@ import { Author } from './author';
 @field author = linksTo(Author, { searchable: true }); // searchable → queryable via author.*
 @field contributors = linksToMany(Author);
 ```
-Mark a link `searchable` to pull its target into the search doc and make it queryable (a plain link is stored as `{ id }` only); see the **Searchable Fields** skill.
+Mark a link `searchable` to pull its target into the search doc and make it queryable (an unmarked link is stored as a bare reference only — a `linksTo` as its `{ id }`, a `linksToMany` as an array of them); see the **Searchable Fields** skill.
 
 **Field specs (contains/containsMany):**
 ```gts

--- a/Skill/dev-technical-rules.md
+++ b/Skill/dev-technical-rules.md
@@ -45,7 +45,7 @@ class MyCard extends CardDef { }         // ❌ Missing export
 
 ### Making links queryable: the `searchable` option
 
-A `contains` value is always in a card's search doc, so you can filter on it with no extra work. A **link is not**: a `linksTo` / `linksToMany` is stored as `{ id }` only unless you mark it `searchable`, and filtering across a non-searchable link errors at query time.
+A `contains` value is always in a card's search doc, so you can filter on it with no extra work. A **link is not**: unless you mark it `searchable` it is stored as a bare reference only — a `linksTo` as its `{ id }`, a `linksToMany` as an array of `{ id }` refs — and filtering across a non-searchable link errors at query time.
 
 ```gts
 @field author = linksTo(Author);                          // filter on author.name → errors

--- a/Skill/dev-technical-rules.md
+++ b/Skill/dev-technical-rules.md
@@ -43,6 +43,18 @@ class MyCard extends CardDef { }         // ❌ Missing export
 @field address = linksTo(AddressField);       // NEVER!
 ```
 
+### Making links queryable: the `searchable` option
+
+A `contains` value is always in a card's search doc, so you can filter on it with no extra work. A **link is not**: a `linksTo` / `linksToMany` is stored as `{ id }` only unless you mark it `searchable`, and filtering across a non-searchable link errors at query time.
+
+```gts
+@field author = linksTo(Author);                          // filter on author.name → errors
+@field author = linksTo(Author, { searchable: true });    // author.name now queryable
+@field authors = linksToMany(Author, { searchable: 'address.country' }); // deeper route
+```
+
+`searchable: true` makes the link itself queryable; a dotted path reaches a deeper (n+1) link; an array combines routes. See the **Searchable Fields** skill for the full rules.
+
 ### MANDATORY TECHNICAL REQUIREMENTS
 
 1. **Always use SEARCH/REPLACE with tracking for .gts files**


### PR DESCRIPTION
Adds authoring guidance for the `searchable` field option, which controls how deep a card's search doc follows its links.

## New skill

`dev-searchable-fields` (`Searchable Fields`) — contained fields are always in the search doc; a link is `{ id }` only until made searchable; `searchable: true` makes the immediate link searchable and a dotted path a deeper (n+1) link; an array combines routes; links capture the declared type only; query-backed relationships are inert; querying a resolvable-but-non-searchable path errors; routing through contained FieldDefs; no wildcard; cycles and broken/not-loaded links clip to `{ id }`. Registered in the Boxel Development skill set.

## Doc updates

- **dev-technical-rules** — a "making links queryable" note after the contains-vs-linksTo cardinal rule.
- **dev-core-patterns** and **dev-spec-usage** — `searchable` on the linksTo examples.
- **dev-delegated-rendering** — a note that delegated rendering governs display only; search-doc depth comes from `searchable`, not from what a template renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
