### PR TITLE
Fix position of instructionsSource relationship

### DIFF
--- a/Skill/boxel-ui-guidelines.json
+++ b/Skill/boxel-ui-guidelines.json
@@ -14,7 +14,14 @@
         "summary": "Ensures boxel-ui components are used in templates and theming guidelines are followed",
         "cardThumbnailURL": null
       },
-      "commands": [],
+      "commands": []
+    },
+    "relationships": {
+      "cardInfo.theme": {
+        "links": {
+          "self": "https://cardstack.com/base/Theme/boxel-brand-guide"
+        }
+      },
       "instructionsSource": {
         "links": {
           "self": "./boxel-ui-guidelines.md"
@@ -22,13 +29,6 @@
         "data": {
           "type": "file",
           "id": "./boxel-ui-guidelines.md"
-        }
-      }
-    },
-    "relationships": {
-      "cardInfo.theme": {
-        "links": {
-          "self": "https://cardstack.com/base/Theme/boxel-brand-guide"
         }
       }
     }


### PR DESCRIPTION
I noticed this during the prefix RRI migration in production, this file has the relationship block in the wrong place:

<img width="5160" height="2770" alt="s 2026-07-03 at 11 42 25@2x" src="https://github.com/user-attachments/assets/b00967fd-b23e-4d4b-8a4e-c1b350cbd7e2" />
