### PR TITLE
Carry requiresApproval placement fix from boxel-workspaces

### DIFF
--- a/skills/boxel-environment/references/host-commands-reference.md
+++ b/skills/boxel-environment/references/host-commands-reference.md
@@ -7,59 +7,59 @@ boxel:
     - codeRef:
         module: '@cardstack/boxel-host/tools/switch-submode'
         name: default
-        requiresApproval: false
+      requiresApproval: false
     - codeRef:
         module: '@cardstack/boxel-host/tools/show-card'
         name: default
-        requiresApproval: false
+      requiresApproval: false
     - codeRef:
         module: '@cardstack/boxel-host/tools/transform-cards'
         name: default
-        requiresApproval: true
+      requiresApproval: true
     - codeRef:
         module: '@cardstack/boxel-host/tools/read-card-for-ai-assistant'
         name: default
-        requiresApproval: false
+      requiresApproval: false
     - codeRef:
         module: '@cardstack/boxel-host/tools/read-file-for-ai-assistant'
         name: default
-        requiresApproval: false
+      requiresApproval: false
     - codeRef:
         module: '@cardstack/boxel-host/tools/set-active-llm'
         name: default
-        requiresApproval: false
+      requiresApproval: false
     - codeRef:
         module: '@cardstack/boxel-host/tools/open-workspace'
         name: default
-        requiresApproval: false
+      requiresApproval: false
     - codeRef:
         module: '@cardstack/boxel-host/tools/preview-format'
         name: default
-        requiresApproval: false
+      requiresApproval: false
     - codeRef:
         module: '@cardstack/boxel-host/tools/update-code-path-with-selection'
         name: default
-        requiresApproval: false
+      requiresApproval: false
     - codeRef:
         module: '@cardstack/boxel-host/tools/write-text-file'
         name: default
-        requiresApproval: true
+      requiresApproval: true
     - codeRef:
         module: '@cardstack/boxel-host/tools/copy-card'
         name: default
-        requiresApproval: true
+      requiresApproval: true
     - codeRef:
         module: '@cardstack/boxel-host/tools/copy-source'
         name: default
-        requiresApproval: true
+      requiresApproval: true
     - codeRef:
         module: '@cardstack/boxel-host/tools/patch-fields'
         name: default
-        requiresApproval: true
+      requiresApproval: true
     - codeRef:
         module: '@cardstack/boxel-host/tools/update-room-skills'
         name: default
-        requiresApproval: false
+      requiresApproval: false
 ---
 
 # Host Commands Reference

--- a/skills/boxel-environment/references/indexing-operations.md
+++ b/skills/boxel-environment/references/indexing-operations.md
@@ -7,19 +7,19 @@ boxel:
     - codeRef:
         module: '@cardstack/boxel-host/tools/invalidate-realm-identifiers'
         name: default
-        requiresApproval: false
+      requiresApproval: false
     - codeRef:
         module: '@cardstack/boxel-host/tools/reindex-realm'
         name: default
-        requiresApproval: false
+      requiresApproval: false
     - codeRef:
         module: '@cardstack/boxel-host/tools/full-reindex-realm'
         name: default
-        requiresApproval: false
+      requiresApproval: false
     - codeRef:
         module: '@cardstack/boxel-host/tools/cancel-indexing-job'
         name: default
-        requiresApproval: false
+      requiresApproval: false
 ---
 
 # Indexing Operations

--- a/skills/boxel-environment/references/markdown-edit.md
+++ b/skills/boxel-environment/references/markdown-edit.md
@@ -7,7 +7,7 @@ boxel:
     - codeRef:
         module: '@cardstack/boxel-host/tools/apply-markdown-edit'
         name: default
-        requiresApproval: true
+      requiresApproval: true
 ---
 
 # Markdown Field Editing

--- a/skills/boxel-environment/references/searching-and-querying.md
+++ b/skills/boxel-environment/references/searching-and-querying.md
@@ -7,11 +7,11 @@ boxel:
     - codeRef:
         module: '@cardstack/boxel-host/tools/search-cards'
         name: SearchCardsByTypeAndTitleCommand
-        requiresApproval: false
+      requiresApproval: false
     - codeRef:
         module: '@cardstack/boxel-host/tools/search-cards'
         name: SearchCardsByQueryCommand
-        requiresApproval: false
+      requiresApproval: false
 ---
 
 ## Query Structure

--- a/skills/catalog-listing/SKILL.md
+++ b/skills/catalog-listing/SKILL.md
@@ -7,23 +7,23 @@ boxel:
     - codeRef:
         module: '@cardstack/catalog/commands/listing-create'
         name: default
-        requiresApproval: false
+      requiresApproval: false
     - codeRef:
         module: '@cardstack/catalog/commands/listing-use'
         name: default
-        requiresApproval: false
+      requiresApproval: false
     - codeRef:
         module: '@cardstack/catalog/commands/listing-install'
         name: default
-        requiresApproval: false
+      requiresApproval: false
     - codeRef:
         module: '@cardstack/catalog/commands/listing-remix'
         name: default
-        requiresApproval: false
+      requiresApproval: false
     - codeRef:
         module: '@cardstack/boxel-host/tools/preview-format'
         name: default
-        requiresApproval: false
+      requiresApproval: false
 ---
 
 # catalog-listing


### PR DESCRIPTION
Scripted sync (`scripts/import-from-workspaces.mjs`) carrying [boxel-workspaces#22](https://github.com/cardstack/boxel-workspaces/pull/22): `requiresApproval` in skill tool frontmatter moves from inside `codeRef` to its sibling position, which is where the `ToolField` schema and Boxel's index-time tool-definition stamping read it. Nested inside `codeRef` it is silently ignored, so every tool in these skills was treated as requiring approval — including `switch-submode` and `show-card`, which declare `requiresApproval: false`.

26 entries across 5 files; frontmatter-only.

Serving note: realms serving this content need a reindex for the corrected values to reach the stamped tool definitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)