### PR TITLE
Adopt boxel-development, cardinal rules, ember-best-practices, and boxel-ui-component-discovery from the monorepo

### DIFF
--- a/skills/boxel-development/SKILL.md
+++ b/skills/boxel-development/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: boxel-development
+description: Use when working on Boxel card development, especially creating or editing `.gts` card definitions, `.json` card instances, Boxel commands, themes, queries, templates, or related Boxel patterns in a synced workspace. Read the targeted files in `references/` instead of loading broad guidance by default.
+boxel:
+  kind: skill
+---
+
+# Boxel Development
+
+Use this skill for Boxel card and app development. Keep the top-level guidance lean and load only the references needed for the task.
+
+## Core Workflow
+
+1. Confirm whether the task is about a card definition, card instance, query, command, theme, file asset, or styling.
+2. Read only the specific reference files that match the task.
+3. For file placement, naming, or `adoptsFrom.module` paths, also read `../boxel-file-structure/SKILL.md`.
+4. Apply the rules from the relevant references exactly when they are marked critical.
+5. Ignore Boxel in-app editor instructions unless you are explicitly operating inside that environment. In this repo, prefer normal filesystem edits and CLI workflows.
+
+## Always Load First
+
+- `references/dev-core-concept.md`
+- `references/dev-technical-rules.md`
+- `references/dev-quick-reference.md`
+
+These three files establish the data model, the `contains` vs `linksTo` rule, required formats, inherited fields, and common import patterns.
+
+## Load By Task
+
+- Reusing boxel-ui components instead of hand-rolling HTML (search the
+  catalog for an existing component spec before writing any UI):
+  `boxel-ui-component-discovery`
+- Card structure and safe patterns:
+  `references/dev-core-patterns.md`
+- Templates, delegated rendering, and field access:
+  `references/dev-template-patterns.md`
+  `references/dev-delegated-rendering.md`
+- Styling and themes:
+  `references/dev-theme-design-system.md`
+  `references/dev-styling-design.md`
+  `references/dev-fitted-formats.md`
+- Queries and data linking:
+  `references/dev-query-systems.md`
+  `references/dev-data-management.md`
+- File-backed content and file asset cards:
+  `references/dev-file-def.md`
+- Enum fields:
+  `references/dev-enumerations.md`
+- Defensive component logic:
+  `references/dev-defensive-programming.md`
+- Third-party libraries:
+  `references/dev-external-libraries.md`
+- Command implementation:
+  `references/dev-command-development.md`
+- Spec usage:
+  `references/dev-spec-usage.md`
+- Replicate integration:
+  `references/dev-replicate-ai.md`
+
+## Usually Ignore Unless Explicitly Relevant
+
+- `references/dev-file-editing.md`
+  This is primarily for Boxel's in-app AI editing flow, not normal terminal-based editing.
+
+## Key Reminders
+
+- `CardDef` and `FileDef` references use `linksTo` / `linksToMany`.
+- `FieldDef` values use `contains` / `containsMany`.
+- Modern cards should implement `isolated`, `embedded`, and `fitted`.
+- Be precise with relative JSON module paths.
+- Prefer loading one or two reference files over reading the whole reference set.

--- a/skills/boxel-development/references/dev-command-development.md
+++ b/skills/boxel-development/references/dev-command-development.md
@@ -1,0 +1,170 @@
+## Command Development Essentials
+
+Commands extend `Command<InputCardDef, OutputCardDef | undefined>` and execute workflows through host APIs.
+
+### Core Structure
+
+```gts
+import { Command } from '@cardstack/runtime-common';
+import { CardDef, field, contains } from 'https://cardstack.com/base/card-api';
+import StringField from 'https://cardstack.com/base/string';
+
+class MyInput extends CardDef {
+  @field targetRealm = contains(StringField);
+}
+
+export class MyCommand extends Command<typeof MyInput, undefined> {
+  static actionVerb = 'Process';
+  async getInputType() {
+    return MyInput;
+  }
+
+  protected async run(input: MyInput): Promise<undefined> {
+    // Validation first
+    if (!input.targetRealm) throw new Error('Target realm required');
+
+    // Execute workflow
+    // Return result or undefined
+  }
+}
+```
+
+### Host Commands (IO Operations)
+
+**Never use `fetch` directly - always use host commands:**
+
+```gts
+import SaveCardCommand from '@cardstack/boxel-host/commands/save-card';
+import GetCardCommand from '@cardstack/boxel-host/commands/get-card';
+import SendRequestViaProxyCommand from '@cardstack/boxel-host/commands/send-request-via-proxy';
+import SearchCardsByQueryCommand from '@cardstack/boxel-host/commands/search-cards-by-query';
+
+// Save a card
+await new SaveCardCommand(this.commandContext).execute({
+  card: myCard,
+  realm: 'https://realm-url/',
+});
+
+// Get a card
+const card = await new GetCardCommand(this.commandContext).execute({
+  cardId: 'https://realm/Card/id',
+});
+
+// External API call
+const response = await new SendRequestViaProxyCommand(
+  this.commandContext,
+).execute({
+  url: 'https://api.example.com/endpoint',
+  method: 'POST',
+  requestBody: JSON.stringify(data),
+  headers: { 'Content-Type': 'application/json' },
+});
+```
+
+### OpenRouter API Pattern
+
+```gts
+const headers = {
+  'Content-Type': 'application/json',
+  'HTTP-Referer': 'https://realms-staging.stack.cards',
+  'X-Title': 'Your App Name',
+};
+
+const response = await new SendRequestViaProxyCommand(ctx).execute({
+  url: 'https://openrouter.ai/api/v1/chat/completions',
+  method: 'POST',
+  requestBody: JSON.stringify({
+    model: 'google/gemini-2.5-flash',
+    messages: [{ role: 'user', content: 'Your prompt' }],
+  }),
+  headers,
+});
+
+if (!response.response.ok) throw new Error('API call failed');
+const data = await response.response.json();
+const text = data.choices?.[0]?.message?.content ?? '';
+```
+
+### Catalog Command Delegation
+
+**Reuse existing commands instead of reimplementing:**
+
+```gts
+import UploadImageCommand from 'https://realms-staging.stack.cards/catalog/commands/upload-image';
+
+const result = await new UploadImageCommand(this.commandContext).execute({
+  sourceImageUrl: dataUrl,
+  targetRealmUrl: input.realm,
+});
+```
+
+### Query Pattern in Commands
+
+```gts
+import SearchCardsByQueryCommand from '@cardstack/boxel-host/commands/search-cards-by-query';
+
+const results = await new SearchCardsByQueryCommand(
+  this.commandContext,
+).execute({
+  query: {
+    filter: {
+      on: {
+        module: new URL('./product', import.meta.url).href,
+        name: 'Product',
+      },
+      eq: { status: 'active' },
+    },
+  },
+  realmURLs: [input.realm],
+});
+```
+
+### Progress Tracking
+
+```gts
+import { tracked } from '@glimmer/tracking';
+
+export class MyCommand extends Command<typeof Input, undefined> {
+  @tracked step: 'idle' | 'processing' | 'completed' | 'error' = 'idle';
+
+  protected async run(input: Input): Promise<undefined> {
+    this.step = 'processing';
+    try {
+      // Do work
+      this.step = 'completed';
+    } catch (e) {
+      this.step = 'error';
+      throw e;
+    }
+  }
+}
+```
+
+### Menu Integration
+
+```gts
+import { getCardMenuItems } from '@cardstack/runtime-common';
+
+[getCardMenuItems](params: GetCardMenuItemParams): MenuItemOptions[] {
+  return [{
+    label: 'My Action',
+    icon: MyIcon,
+    action: async () => {
+      await new MyCommand(params.commandContext).execute({
+        cardId: this.id,
+        realm: params.realmURL
+      });
+      await params.saveCard(this);
+    }
+  }, ...super[getCardMenuItems](params)];
+}
+```
+
+### Critical Rules
+
+- ✅ **Validate inputs first** - fail early with clear errors
+- ✅ **Use host commands for all IO** - never `fetch` directly
+- ✅ **Include `on` in queries** - for eq/contains/range filters
+- ✅ **Delegate to catalog commands** - don't reimplement uploads/services
+- ✅ **Wrap JSON parsing in try-catch** - handle malformed responses
+- ✅ **Track progress states** - use `@tracked` for UI feedback

--- a/skills/boxel-development/references/dev-core-concept.md
+++ b/skills/boxel-development/references/dev-core-concept.md
@@ -1,0 +1,144 @@
+## Foundational Concepts
+
+### The Boxel Universe
+
+Boxel is a composable card-based system where information lives in self-contained, reusable units. Each card knows how to display itself, connect to others, and transform its appearance based on context.
+
+- **Card:** The central unit of information and display
+  - **Definition (`CardDef` in `.gts`):** Defines the structure (fields) and presentation (templates) of a card type
+  - **Instance (`.json`):** Represents specific data conforming to a Card Definition
+
+- **Field:** Building blocks within a Card
+  - **Base Types:** System-provided fields (StringField, NumberField, etc.)
+  - **Custom Fields (`FieldDef`):** Reusable composite field types you define
+
+- **File (`FileDef` in `.gts`):** A card-like way of interacting with images, documents, and other assets stored in the realm
+  - **Instances:** Actual files (`.png`, `.md`, `.csv`, etc.) indexed automatically with metadata extracted
+  - **Subtypes:** `ImageDef`, `PngDef`, `MarkdownDef`, `CsvFileDef`, and others for specific formats
+  - **Referenced with `linksTo`**, never `contains` — FileDef instances have their own identity like cards
+
+- **Realm/Workspace:** Your project's root directory. All imports and paths are relative to this context
+
+- **Formats:** Different visual representations of the same card:
+  - `isolated`: Full detailed view (should be scrollable for long content)
+  - `embedded`: Compact view for inclusion in other cards
+  - `fitted`: **🚨 ESSENTIAL** - Fixed dimensions for grids/galleries/dashboards (parent sets both width AND height)
+  - `atom`: Minimal inline representation
+  - `edit`: Form for data modification (default provided, override only if needed)
+
+**🔴 CRITICAL:** Modern Boxel cards require ALL THREE display formats: isolated, embedded, AND fitted. Missing custom fitted format will fallback to basic fitted view that won't look very nice or have enough info to show in grids, choosers, galleries, or dashboards.
+
+## Decision Trees
+
+**Data Structure Choice:**
+
+```
+Needs own identity? → CardDef with linksTo
+Referenced from multiple places? → CardDef with linksTo
+Referencing a file (image, doc, etc.)? → FileDef subtype with linksTo
+Just compound data? → FieldDef with contains
+```
+
+**Field Extension Choice:**
+
+```
+Want to customize a base field? → import BaseField, extend it
+Creating new field type? → extends FieldDef directly
+Adding to existing field? → extends BaseFieldName
+```
+
+**Value Setup:**
+
+```
+Computed from other fields? → computeVia
+User-editable with default? → Field literal or computeVia
+Simple one-time value? → Field literal
+```
+
+**Circular Dependencies?**
+
+```
+Use arrow function: () => Type
+```
+
+## ✅ Quick Mental Check Before Every Field
+
+Ask yourself: "Does this type extend CardDef or FieldDef?"
+
+- Extends **CardDef** → MUST use `linksTo` or `linksToMany`
+- Extends **FieldDef** → MUST use `contains` or `containsMany`
+- **No exceptions!**
+
+For computed fields, ask: "Am I keeping this simple and unidirectional?"
+
+- Only reference base fields, never self-reference
+- No circular dependencies between computed fields
+- Wrap in try-catch when accessing relationships
+- If it feels complex, simplify it!
+
+## Foundation Quick Reference
+
+**Data Structure Choice:**
+
+- Needs own identity? → `CardDef` with `linksTo`
+- Referenced from multiple places? → `CardDef` with `linksTo`
+- Just compound data? → `FieldDef` with `contains`
+
+**Formats (what they are):**
+
+- `isolated` - Full detailed view (scrollable)
+- `embedded` - Compact for inclusion in other cards
+- `fitted` - Fixed dimensions for grids/galleries
+- `atom` - Minimal inline representation
+- `edit` - Form for data modification
+
+**Every CardDef inherits:**
+
+- `cardTitle`, `cardDescription`, `cardThumbnailURL`
+
+### Inherited Fields and CardInfo
+
+**IMPORTANT:** Every CardDef automatically inherits these base fields from the CardDef base class (defined in `packages/base/card-api.gts`):
+
+#### CardInfoField (FieldDef — user-editable)
+
+`CardInfoField` is a `FieldDef` with these fields:
+
+- `cardInfo.name` (StringField) — user-editable card name
+- `cardInfo.summary` (StringField) — user-editable card summary
+- `cardInfo.cardThumbnail` (linksTo ImageDef) — linked thumbnail image card
+- `cardInfo.cardThumbnailURL` (MaybeBase64Field) — thumbnail URL or base64 string
+- `cardInfo.theme` (linksTo Theme) — optional theme card link
+- `cardInfo.notes` (MarkdownField) — optional internal notes
+
+#### Computed pass-through fields on CardDef (read-only)
+
+These are computed fields that read from `cardInfo`:
+
+- `cardTitle` (StringField) — computed from `cardInfo.name`, falls back to `Untitled {displayName}`
+- `cardDescription` (StringField) — computed from `cardInfo.summary`
+- `cardThumbnailURL` (MaybeBase64Field) — computed from `cardInfo.cardThumbnailURL`
+
+**How It Works:**
+The top-level `cardTitle`, `cardDescription`, and `cardThumbnailURL` fields are computed properties that pass through values from `cardInfo`. Users edit values through the `cardInfo` field in edit mode.
+
+- `@model.cardTitle` reads `cardInfo.name` (with fallback)
+- `@model.cardDescription` reads `cardInfo.summary`
+- Override these computed fields to add custom logic
+
+**Best Practice:** Define your own primary field and compute `cardTitle` to respect user's `cardInfo.name` choice:
+
+```gts
+export class BlogPost extends CardDef {
+  @field headline = contains(StringField); // Your primary field
+
+  // Override inherited cardTitle - respects user's cardInfo.name if set
+  @field cardTitle = contains(StringField, {
+    computeVia: function (this: BlogPost): string {
+      return this.cardInfo?.name?.trim()?.length
+        ? this.cardInfo.name
+        : (this.headline ?? 'Untitled');
+    },
+  });
+}
+```

--- a/skills/boxel-development/references/dev-core-patterns.md
+++ b/skills/boxel-development/references/dev-core-patterns.md
@@ -1,0 +1,375 @@
+**Card with computed cardTitle:**
+
+A card's display name comes from `cardTitle` (a computed pass-through from
+`cardInfo.name`). To derive it from another field, override `cardTitle` — do
+NOT override the base `title` field; the host reads `cardTitle`, not `title`.
+
+```gts
+export class BlogPost extends CardDef {
+  @field headline = contains(StringField);
+
+  @field cardTitle = contains(StringField, {
+    computeVia: function (this: BlogPost) {
+      return this.headline ?? 'Untitled Post';
+    },
+  });
+}
+```
+
+**Field definition:**
+
+```gts
+export class AddressField extends FieldDef {
+  @field street = contains(StringField);
+  @field city = contains(StringField);
+
+  static embedded = class Embedded extends Component<typeof this> {
+    <template>
+      <div class='address'>
+        <@fields.street />
+        <@fields.city />
+      </div>
+    </template>
+  };
+}
+```
+
+## Core Patterns
+
+### 1. Card Definition with Safe Computed Title
+
+```gts
+import {
+  CardDef,
+  field,
+  contains,
+  linksTo,
+  containsMany,
+  linksToMany,
+  Component,
+} from 'https://cardstack.com/base/card-api';
+import StringField from 'https://cardstack.com/base/string';
+import DateField from 'https://cardstack.com/base/date';
+import FileTextIcon from '@cardstack/boxel-icons/file-text';
+import { Author } from './author';
+
+export class BlogPost extends CardDef {
+  static displayName = 'Blog Post';
+  static icon = FileTextIcon; // ✅ CORRECT: Boxel icons for static card/field type icons
+  static prefersWideFormat = true;
+
+  @field headline = contains(StringField);
+  @field publishDate = contains(DateField);
+  @field author = linksTo(Author);
+  @field tags = containsMany(TagField);
+  @field relatedPosts = linksToMany(() => BlogPost);
+
+  @field cardTitle = contains(StringField, {
+    computeVia: function (this: BlogPost) {
+      try {
+        const baseTitle = this.headline ?? 'Untitled Post';
+        const maxLength = 50;
+        if (baseTitle.length <= maxLength) return baseTitle;
+        return baseTitle.substring(0, maxLength - 3) + '...';
+      } catch (e) {
+        console.error('BlogPost: Error computing cardTitle', e);
+        return 'Untitled Post';
+      }
+    },
+  });
+}
+```
+
+### 2. Field Definition (Always Include Embedded Template)
+
+**CRITICAL:** Every FieldDef file must import FieldDef and MUST be exported:
+
+```gts
+import {
+  FieldDef,
+  field,
+  contains,
+  Component,
+} from 'https://cardstack.com/base/card-api';
+import StringField from 'https://cardstack.com/base/string';
+import LocationIcon from '@cardstack/boxel-icons/map-pin';
+import { concat } from '@ember/helper';
+
+export class AddressField extends FieldDef {
+  static displayName = 'Address';
+  static icon = LocationIcon; // ✅ CORRECT: Boxel icons for static card/field type icons
+
+  @field street = contains(StringField);
+  @field city = contains(StringField);
+  @field postalCode = contains(StringField);
+  @field country = contains(StringField);
+
+  static embedded = class Embedded extends Component<typeof this> {
+    <template>
+      <div class='address'>
+        {{#if @model.street}}
+          <div><@fields.street /></div>
+        {{else}}
+          <div class='placeholder'>Street address not provided</div>
+        {{/if}}
+        <div>
+          {{if @model.city @model.city 'City'}}{{if
+            @model.postalCode
+            (concat ', ' @model.postalCode)
+            ''
+          }}
+        </div>
+        {{#if @model.country}}
+          <div><@fields.country /></div>
+        {{else}}
+          <div class='placeholder'>Country not specified</div>
+        {{/if}}
+      </div>
+      <style scoped>
+        .placeholder {
+          font-style: italic;
+        }
+      </style>
+    </template>
+  };
+}
+```
+
+### 3. Computed Properties with Safety
+
+**CRITICAL:** Avoid cycles and infinite recursion in computed fields.
+
+```gts
+// ❌ DANGEROUS: Self-reference causes infinite recursion
+@field cardTitle = contains(StringField, {
+  computeVia: function(this: BlogPost) {
+    return this.cardTitle || 'Untitled'; // STACK OVERFLOW!
+  }
+});
+
+// ✅ SAFE: Reference only base fields
+@field fullName = contains(StringField, {
+  computeVia: function(this: Person) {
+    try {
+      const first = this.firstName ?? '';
+      const last = this.lastName ?? '';
+      const full = first + ' ' + last;
+      return full.trim() || 'Name not provided';
+    } catch (e) {
+      console.error('Person: Error computing fullName', e);
+      return 'Name unavailable';
+    }
+  }
+});
+```
+
+### 4. Templates with Proper Computation Patterns
+
+**Remember:** When implementing templates via SEARCH/REPLACE, track all major sections with ⁿ and include the post-block notation `╰ ⁿ⁻ᵐ`
+
+```gts
+static isolated = class Isolated extends Component<typeof BlogPost> { // ³⁰ Isolated format
+  @tracked showComments = false;
+
+  // ³¹ CRITICAL: Do ALL computation in functions, never in templates
+  get safeTitle() {
+    try {
+      return this.args?.model?.cardTitle ?? 'Untitled Post';
+    } catch (e) {
+      console.error('BlogPost: Error accessing cardTitle', e);
+      return 'Untitled Post';
+    }
+  }
+
+  get commentButtonText() {
+    try {
+      const count = this.args?.model?.commentCount ?? 0;
+      return this.showComments ? `Hide Comments (${count})` : `Show Comments (${count})`;
+    } catch (e) {
+      console.error('BlogPost: Error computing comment button text', e);
+      return this.showComments ? 'Hide Comments' : 'Show Comments';
+    }
+  }
+
+  // methods referenced from templates must be defined with fat arrow (=>) so that they are properly bound when invoked
+  toggleComments = () => {
+    this.showComments = !this.showComments;
+  }
+
+  <template>
+    <!-- ³² Responsive surface that adapts from wide layouts down to mobile -->
+    <article class="blog-post-surface">
+      <header>
+        <time>{{if @model.publishDate (formatDateTime @model.publishDate 'MMMM D, YYYY') "Date not set"}}</time>
+        <h1>{{this.safeTitle}}</h1>
+
+        {{#if @fields.author}}
+          <@fields.author />
+        {{else}}
+          <div class="author-placeholder">Author not specified</div>
+        {{/if}}
+      </header>
+
+      <div class="post-content">
+        {{#if @model.body}}
+          <@fields.body />
+        {{else}}
+          <div class="content-placeholder">
+            <p>No content has been written yet. Click to start writing!</p>
+          </div>
+        {{/if}}
+      </div>
+
+      <!-- ³³ Handle arrays with REQUIRED spacing -->
+      {{#if (gt @model.tags.length 0)}}
+        <section class="tags-section">
+          <h4>Tags</h4>
+          <div class="tags-container">
+            <@fields.tags @format="atom" />
+          </div>
+        </section>
+      {{/if}}
+
+      {{#if (gt @model.commentCount 0)}}
+      <div>
+        <Button
+          @kind="text-only"
+          @size="extra-small"
+          class="comment-button"
+          {{on 'click' this.toggleComments}}
+        >
+          <svg width='16' height='16' class="button-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
+          </svg>
+          {{this.commentButtonText}}
+        </Button>
+       </div>
+      {{/if}}
+
+      {{#if this.showComments}}
+        <section class="comments-section">
+          <h3>Discussion</h3>
+          {{#if (gt @model.comments.length 0)}}
+            <div class="comments-container">
+              <@fields.comments @format="embedded" />
+            </div>
+          {{else}}
+            <p class="no-comments">No comments yet. Be the first to share your thoughts!</p>
+          {{/if}}
+        </section>
+      {{/if}}
+    </article>
+
+    <style scoped> /* ³⁴ Component styles */
+      .blog-post-surface {
+        width: 100%;
+        max-width: 42rem;
+        margin: 0 auto;
+        padding: clamp(1.25rem, 4vw, 2rem);
+        display: flex;
+        flex-direction: column;
+        gap: clamp(1rem, 2.5vw, 1.5rem);
+        height: 100%;
+        min-height: 100%;
+        overflow-y: auto;
+        font-size: 0.875rem;
+        line-height: 1.3;
+      }
+
+      @media (max-width: 800px) {
+        .blog-post-surface {
+          max-width: none;
+          padding: clamp(1rem, 6vw, 1.5rem);
+        }
+      }
+
+      .blog-post-surface > header h1 {
+        font-size: clamp(1.125rem, 3vw, 1.5rem);
+        margin-top: 0.25rem;
+        line-height: 1.2;
+      }
+
+      .post-content {
+        font-size: 0.8125rem;
+        line-height: 1.25;
+      }
+
+      /* ³⁵ CRITICAL: Always style buttons completely - never use unstyled */
+      .comment-button {
+        /* Style Boxel components to match your design */
+        gap: var(--boxel-sp-2xs);
+      }
+
+      .comment-button .button-icon {
+        width: 1rem;
+        height: 1rem;
+      }
+
+      /* ³⁶ CRITICAL: Spacing for containsMany collections */
+      .tags-container > .containsMany-field {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.25rem; /* Essential spacing between tags */
+      }
+
+      .comments-container > .containsMany-field {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem; /* Essential spacing between comments */
+      }
+    </style>
+  </template>
+};
+```
+
+### WARNING: Do NOT Use Constructors for Default Values
+
+**CRITICAL:** Constructors should NOT be used for setting default values in Boxel cards. Use template fallbacks (if field is editable) or computeVia (only if field is strictly read-only) instead.
+
+```gts
+// ❌ WRONG - Never use constructors for defaults
+export class Todo extends CardDef {
+  constructor(owner: unknown, args: {}) {
+    super(owner, args);
+    this.createdDate = new Date(); // DON'T DO THIS
+    this.isCompleted = false; // DON'T DO THIS
+  }
+}
+```
+
+### **CRITICAL: NEVER Create JavaScript Objects in Templates**
+
+**Templates are for simple display logic only.** Never call constructors, create objects, or perform complex operations in template expressions.
+
+```hbs
+<!-- ❌ WRONG: Creating objects in templates -->
+<span>{{if @model.currentMonth @model.currentMonth (formatDateTime (new Date()) "MMMM YYYY")}}</span>
+<div>{{someFunction(@model.data)}}</div>
+
+<!-- ✅ CORRECT: Move logic to JavaScript computed properties -->
+<span>{{if @model.currentMonth @model.currentMonth this.currentMonthDisplay}}</span>
+<div>{{this.processedData}}</div>
+```
+
+```gts
+// ✅ CORRECT: Define logic in JavaScript
+export class MyCard extends CardDef {
+  get currentMonthDisplay() {
+    return new Intl.DateTimeFormat('en-US', {
+      month: 'long',
+      year: 'numeric',
+    }).format(new Date());
+  }
+
+  get processedData() {
+    return this.args.model?.data
+      ? this.processData(this.args.model.data)
+      : 'No data';
+  }
+
+  private processData(data: any) {
+    // Complex processing logic here
+    return result;
+  }
+}
+```

--- a/skills/boxel-development/references/dev-data-management.md
+++ b/skills/boxel-development/references/dev-data-management.md
@@ -1,0 +1,169 @@
+## File Organization
+
+### Single App Structure
+
+```
+my-realm/
+├── blog-post.gts          # Card definition (kebab-case)
+├── author.gts             # Another card
+├── address-field.gts      # Field definition (kebab-case-field)
+├── BlogPost/              # Instance directory (PascalCase)
+│   ├── hello-world.json   # Instance (any-name)
+│   └── second-post.json
+└── Author/
+    └── jane-doe.json
+```
+
+### Related Cards App Structure
+
+**CRITICAL:** When creating apps with multiple related cards, organize them in common folders:
+
+```
+my-realm/
+├── ecommerce/             # Common folder for related cards
+│   ├── product.gts        # Card definitions
+│   ├── order.gts
+│   ├── customer.gts
+│   ├── Product/           # Instance directories
+│   │   └── laptop-pro.json
+│   └── Order/
+│       └── order-001.json
+├── blog/                  # Another app's folder
+│   ├── post.gts
+│   ├── author.gts
+│   └── Post/
+│       └── welcome.json
+└── shared/                # Shared components
+    └── address-field.gts  # Common field definitions
+```
+
+**Directory Discipline:** When creating files within a specific directory structure (e.g., `ecommerce/`), keep ALL related files within that structure. Don't create files outside the intended directory organization.
+
+**Relationship Path Tracking:** When creating related JSON instances, maintain a mental map of your file paths. Links between instances must use the exact relative paths you've created - consistency prevents broken relationships.
+
+## JSON Instance Format Quick Reference
+
+**When creating `.json` card instances via SEARCH/REPLACE, follow this structure:**
+
+**Naming:** Use natural names for JSON files (e.g., `Author/jane-doe.json`, `Product/laptop-pro.json`) - don't append `-sample-data`
+
+**Path Consistency:** When creating multiple related JSON instances, track the exact file paths you create. Relationship links must match these paths exactly - if you create `Author/dr-nakamura.json`, reference it as `"../Author/dr-nakamura"` from other instances.
+
+### Root Structure
+
+All data wrapped in a `data` object with:
+
+- `type`: Always `"card"` for instances
+- `attributes`: Field values go here
+- `relationships`: Links to other cards
+- `meta.adoptsFrom`: Connection to GTS definition
+
+### Instance Template
+
+```json
+{
+  "data": {
+    "type": "card",
+    "attributes": {
+      // Field values here
+    },
+    "relationships": {
+      // Card links here
+    },
+    "meta": {
+      "adoptsFrom": {
+        "module": "../path-to-gts-file",
+        "name": "CardDefClassName"
+      }
+    }
+  }
+}
+```
+
+### Field Value Patterns
+
+**Simple fields** (`contains(StringField)`, etc.):
+
+```json
+"attributes": {
+  "title": "My Title",
+  "price": 29.99,
+  "isActive": true
+}
+```
+
+**Compound fields** (`contains(AddressField)` - a FieldDef):
+
+```json
+"attributes": {
+  "address": {
+    "street": "4827 Riverside Terrace",
+    "city": "Portland",
+    "postalCode": "97205"
+  }
+}
+```
+
+**Array fields** (`containsMany`):
+
+```json
+"attributes": {
+  "tags": ["urgent", "review", "frontend"],
+  "phoneNumbers": [
+    { "number": "+1-503-555-0134", "type": "work" },
+    { "number": "+1-971-555-0198", "type": "mobile" }
+  ]
+}
+```
+
+### Relationship Patterns
+
+**Single link** (`linksTo`):
+
+```json
+"relationships": {
+  "author": {
+    "links": {
+      "self": "../Author/dr-nakamura"
+    }
+  }
+}
+```
+
+**Multiple links** (`linksToMany`) - note the `.0`, `.1` pattern:
+
+```json
+"relationships": {
+  "teamMembers.0": {
+    "links": { "self": "../Person/kai-nakamura" }
+  },
+  "teamMembers.1": {
+    "links": { "self": "../Person/esperanza-cruz" }
+  }
+}
+```
+
+**Empty linksToMany** - when no relationships exist:
+
+```json
+"relationships": {
+  "nextLevels": {
+    "links": {
+      "self": null
+    }
+  }
+}
+```
+
+Note: Use `null`, not an empty array `[]`
+
+### Path Conventions
+
+- **Module paths**: Relative to JSON location, no `.gts` extension
+  - Local: `"../author"` or `"../../shared/address-field"`
+  - Base: `"https://cardstack.com/base/string"`
+- **Relationship paths**: Relative paths, no `.json` extension
+  - `"../Author/jane-doe"` not `"../Author/jane-doe.json"`
+- **Date formats**:
+  - DateField: `"2024-11-15"`
+  - DateTimeField: `"2024-11-15T10:00:00Z"`

--- a/skills/boxel-development/references/dev-defensive-programming.md
+++ b/skills/boxel-development/references/dev-defensive-programming.md
@@ -1,0 +1,128 @@
+**Always use optional chaining:**
+
+```js
+// ❌ UNSAFE
+if (this.args.model.items.includes(x)) {
+}
+
+// ✅ SAFE
+if (this.args.model?.items?.includes?.(x)) {
+}
+```
+
+**Provide defaults:**
+
+```js
+return (this.args.model?.progress ?? 0) + 10;
+```
+
+**Wrap cross-card access in try-catch:**
+
+```js
+get authorName() {
+  try {
+    const author = this.args?.model?.author;
+    return author?.name ?? 'Unknown Author';
+  } catch (e) {
+    console.error('Error accessing author', e);
+    return 'Author Unavailable';
+  }
+}
+```
+
+## Defensive Programming in Boxel Components
+
+**CRITICAL:** Prevent runtime errors by safely handling undefined/null values and malformed data. Cards boot with no data by default - every component must handle completely empty state gracefully.
+
+### Essential Defensive Patterns
+
+#### Always Use Optional Chaining (`?.`)
+
+```js
+// ❌ UNSAFE: Will throw if model is undefined
+if (this.args.model.completedDays.includes(day)) { ... }
+
+// ✅ SAFE: Optional chaining prevents errors
+if (this.args.model?.completedDays?.includes?.(day)) { ... }
+```
+
+#### Provide Default Values (`??`)
+
+```js
+// ❌ UNSAFE: May result in NaN
+return this.args.model.progress + 10;
+
+// ✅ SAFE: Default value prevents NaN
+return (this.args.model?.progress ?? 0) + 10;
+```
+
+#### Try-Catch for Network of Cards
+
+When accessing data across card relationships, always wrap in try-catch to handle missing or malformed data:
+
+```js
+// ³⁷ In computed properties or methods
+get authorDisplayName() {
+  try {
+    const author = this.args?.model?.author;
+    if (!author) {
+      console.warn('BlogPost: No author assigned');
+      return 'Unknown Author';
+    }
+
+    const name = author.name || author.title;
+    if (!name) {
+      console.warn('BlogPost: Author exists but has no name', { authorId: author.id });
+      return 'Unnamed Author';
+    }
+
+    return name;
+  } catch (error) {
+    console.error('BlogPost: Error accessing author data', {
+      error,
+      postId: this.args.model?.id,
+      authorData: this.args.model?.author
+    });
+    return 'Author Unavailable';
+  }
+}
+
+// ³⁸ In template getters
+get relatedPostsSummary() {
+  try {
+    const posts = this.args.model?.relatedPosts;
+    if (!Array.isArray(posts)) {
+      return 'No related posts';
+    }
+
+    return posts
+      .filter(post => post?.title) // Skip malformed entries
+      .map(post => post.title)
+      .join(', ') || 'No related posts';
+
+  } catch (error) {
+    console.error('BlogPost: Failed to process related posts', error);
+    return 'Related posts unavailable';
+  }
+}
+```
+
+#### Validate Arrays Before Operations
+
+```js
+// ❌ UNSAFE: May throw if not an array
+const sorted = this.completedDays.sort((a, b) => a - b);
+
+// ✅ SAFE: Check existence and type first
+if (!Array.isArray(this.completedDays) || !this.completedDays.length) {
+  return [];
+}
+const sorted = [...this.completedDays].sort((a, b) => a - b);
+```
+
+**Key Principles:**
+
+- Assume data might be missing, null, or the wrong type
+- Provide meaningful fallbacks for user display
+- Log errors with context for debugging (include IDs, data state)
+- Never let malformed data crash your UI

--- a/skills/boxel-development/references/dev-delegated-rendering.md
+++ b/skills/boxel-development/references/dev-delegated-rendering.md
@@ -1,0 +1,201 @@
+**Delegated rendering:**
+
+```hbs
+<!-- Always use @fields, even for singular -->
+<@fields.author @format='embedded' />
+<@fields.items @format='embedded' />
+```
+
+**Make cards clickable:**
+
+```hbs
+<CardContainer
+  {{@context.cardComponentModifier cardId=card.url format='data'}}
+  @displayBoundaries={{true}}
+>
+  <card.component />
+</CardContainer>
+```
+
+**Avoid cycles:**
+
+```gts
+// Canonical links only
+@field supervisor = linksTo(() => Employee);
+
+// Query for reverse
+get directReportsQuery() {
+  return {
+    filter: {
+      on: { module: './employee', name: 'Employee' },
+      eq: { supervisor: this.args.model.id }
+    }
+  };
+}
+```
+
+### BoxelSelect: Smart Dropdown Menus
+
+Regular HTML selects are limited to plain text. BoxelSelect lets you create rich, searchable dropdowns with custom rendering.
+
+#### Pattern: Rich Select with Custom Options
+
+```gts
+export class OptionField extends FieldDef {
+  // ⁴³ Option field for select
+  static displayName = 'Option';
+
+  @field key = contains(StringField);
+  @field label = contains(StringField);
+  @field description = contains(StringField);
+
+  static embedded = class Embedded extends Component<typeof this> {
+    <template>
+      <div class='option-display'>
+        <strong>{{if @model.label @model.label 'Unnamed Option'}}</strong>
+        <span>{{if
+            @model.description
+            @model.description
+            'No description'
+          }}</span>
+      </div>
+    </template>
+  };
+}
+
+export class ProductCategory extends CardDef {
+  // ⁴⁴ Card using BoxelSelect
+  @field selectedCategory = contains(OptionField);
+
+  static edit = class Edit extends Component<typeof this> {
+    // ⁴⁵ Edit format
+    @tracked selectedOption = this.args.model?.selectedCategory;
+
+    options = [
+      {
+        key: '1',
+        label: 'Electronics',
+        description: 'Phones, computers, and gadgets',
+      },
+      { key: '2', label: 'Clothing', description: 'Fashion and apparel' },
+      { key: '3', label: 'Home & Garden', description: 'Furniture and decor' },
+    ];
+
+    updateSelection = (option: (typeof this.options)[0] | null) => {
+      this.selectedOption = option;
+      this.args.model.selectedCategory = option
+        ? new OptionField(option)
+        : null;
+    };
+
+    <template>
+      <FieldContainer @label='Product Category'>
+        <BoxelSelect
+          @selected={{this.selectedOption}}
+          @options={{this.options}}
+          @onChange={{this.updateSelection}}
+          @searchEnabled={{true}}
+          @placeholder='Select a category...'
+          as |option|
+        >
+          <div class='option-item'>
+            <span>{{option.label}}</span>
+            <span>{{option.description}}</span>
+          </div>
+        </BoxelSelect>
+      </FieldContainer>
+    </template>
+  };
+}
+```
+
+### Custom Edit Controls
+
+Create user-friendly edit controls that accept natural input. Hide complexity in expandable sections while keeping ALL properties editable and inspectable.
+
+```gts
+// Example: Natural language time period input
+static edit = class Edit extends Component<typeof this> {
+  @tracked showDetails = false;
+
+  parseInput = (value: string) => {
+    // Parse "Q1 2025" → quarter: 1, year: 2025, startDate: Jan 1, endDate: Mar 31
+    // Parse "April 2025" → month: 4, year: 2025, startDate: Apr 1, endDate: Apr 30
+  }
+
+  <template>
+    <FieldContainer @label="Time Period" @tag="label">
+      <input placeholder="e.g., Q1 2025 or April 2025" {{on 'blur' this.parseInput}} />
+    </FieldContainer>
+
+    <Button {{on 'click' (toggle 'showDetails' this)}}>
+      {{if this.showDetails "Hide" "Show"}} Details
+    </Button>
+
+    {{#if this.showDetails}}
+      <!-- Show all parsed values for verification -->
+      <!-- Allow manual override of auto-parsed results -->
+      <!-- Provide controls for each field property -->
+    {{/if}}
+  </template>
+};
+```
+
+### Alternative: Using the viewCard API
+
+Instead of making entire cards clickable, you can create custom buttons or links that use the `viewCard` API to open cards in specific formats.
+
+#### Basic Implementation
+
+```javascript
+viewOrder = (order: ProductOrder) => {
+  // Open order in isolated view
+  this.args.viewCard(order, 'isolated');
+};
+
+editOrder = (order: ProductOrder) => {
+  // Open card in rightmost stack for side-by-side reference
+  // Useful for: 1) reference lookup, 2) edit panel on right while previewing on left
+  this.args.viewCard(order, 'edit', {
+    openCardInRightMostStack: true
+  });
+};
+
+viewReturnPolicy = () => {
+  // Open card using URL
+  const returnPolicyURL = new URL('https://app.boxel.ai/markinc/storefront/ReturnPolicy/return-policy-0525.json');
+  this.args.viewCard(returnPolicyURL, 'isolated');
+};
+```
+
+#### Template Example
+
+```hbs
+<div class='order-card'>
+  <!-- Custom action buttons -->
+  <div class='order-actions'>
+    <Button @kind='primary' {{on 'click' (fn this.viewOrder order)}}>
+      View Order
+    </Button>
+
+    <Button @kind='secondary-light' {{on 'click' (fn this.editOrder order)}}>
+      Edit Order
+    </Button>
+  </div>
+
+  <Button @kind='text-only' {{on 'click' (fn this.viewReturnPolicy)}}>
+    Return Policy
+  </Button>
+</div>
+```
+
+#### Available Formats
+
+- `'isolated'` - Read-oriented mode, may have some editable forms or interactive widgets
+- `'edit'` - Open card for full editing
+
+#### Use Cases
+
+- Multiple direct call-to-actions per card (view, edit)
+- More control over user interactions
+- Link to any card via a card URL

--- a/skills/boxel-development/references/dev-enumerations.md
+++ b/skills/boxel-development/references/dev-enumerations.md
@@ -1,0 +1,227 @@
+## Enum Field Essentials
+
+**CRITICAL Import Syntax:**
+
+```gts
+import enumField from 'https://cardstack.com/base/enum'; // Default import, not { enumField }
+```
+
+**Quick Start:**
+
+```gts
+const StatusField = enumField(StringField, { options: ['Open', 'Closed'] });
+@field status = contains(StatusField);
+```
+
+**Template:** `<@fields.status />` renders a BoxelSelect in edit mode.
+
+**Rich options with labels/icons:**
+
+```gts
+enumField(StringField, {
+  options: [
+    { value: 'high', label: 'High Priority', icon: ArrowUpIcon },
+    { value: 'low', label: 'Low Priority', icon: ArrowDownIcon },
+  ],
+});
+```
+
+**Key helpers:**
+
+- `enumValues(card, 'fieldName')` → array of primitive values
+- `enumOptions(card, 'fieldName')` → normalized `{ value, label, icon? }`
+
+<!--more-->
+
+# Enum Fields
+
+## Purpose
+
+Use `enumField(BaseField, { options })` to create a `FieldDef` with constrained values and a default dropdown editor. Works with primitive bases (e.g., `StringField`, `NumberField`).
+
+## Import Syntax
+
+**CRITICAL:** Use default import, not destructured import:
+
+```gts
+// ✅ CORRECT
+import enumField from 'https://cardstack.com/base/enum';
+
+// ❌ WRONG
+import { enumField } from 'https://cardstack.com/base/enum';
+```
+
+## Quick Start
+
+**Define:**
+
+```gts
+const StatusField = enumField(StringField, { options: ['Open', 'Closed'] });
+```
+
+**Use:**
+
+```gts
+@field status = contains(StatusField);
+```
+
+**Template:**
+
+```hbs
+<@fields.status /> {{! Renders a BoxelSelect in edit mode }}
+```
+
+## Rich Options (Labels/Icons)
+
+```gts
+enumField(StringField, {
+  options: [
+    { value: 'high', label: 'High', icon: ArrowUpIcon },
+    { value: 'medium', label: 'Medium', icon: MinusIcon },
+    { value: 'low', label: 'Low', icon: ArrowDownIcon },
+  ],
+});
+```
+
+Editor shows labels/icons; stored value is the primitive `value`.
+
+## Dynamic Options
+
+**Provide a function:**
+
+```gts
+enumField(StringField, {
+  options: function () {
+    return this.someList;
+  },
+});
+```
+
+**Per-usage override:**
+
+```gts
+contains(Field, {
+  configuration: enumConfig(function () {
+    return { options: this.someList };
+  }),
+});
+```
+
+**Note:** `this` is the containing card or field
+
+## Helpers
+
+**enumValues** - Get array of primitive values:
+
+```gts
+enumValues(card, 'enumFieldName'); // → ['High', 'Medium', 'Low']
+```
+
+**enumOptions** - Get normalized option objects:
+
+```gts
+enumOptions(card, 'enumFieldName'); // → [{ value, label, icon? }, ...]
+```
+
+## Null Handling
+
+If current value is `null` and `null` isn't in options, placeholder uses `unsetLabel` or "Choose…".
+
+To make `null` selectable:
+
+```gts
+{ value: null, label: 'None' }
+```
+
+## Limitations
+
+- **Compound field values:** Not yet supported
+- **Card values:** Not yet supported
+
+## Validation and Behavior
+
+- Duplicate values throw during option normalization
+- Query and serialization follow the base field
+- Enum wrapping does not change data shape
+
+## Minimal Example
+
+**Define:**
+
+```gts
+import enumField from 'https://cardstack.com/base/enum';
+const Priority = enumField(StringField, { options: ['High', 'Medium', 'Low'] });
+```
+
+**Use:**
+
+```gts
+class Task extends CardDef {
+  @field priority = contains(Priority);
+}
+```
+
+**Template:**
+
+```hbs
+<@fields.priority />
+{{enumValues @model 'priority'}}
+{{! ['High','Medium','Low'] }}
+```
+
+## Factory vs Usage (Clarity)
+
+**Factory defaults:**
+
+```gts
+enumField(Base, { options }); // For simple/static defaults
+```
+
+**Usage overrides:**
+
+```gts
+contains(Field, {
+  configuration: enumConfig(function () {
+    return { options };
+  }),
+}); // For per-instance behavior
+```
+
+Both resolve to `@configuration.enum.options` for templates/formats.
+
+## Callback Context
+
+`computeVia`, `enumField` options functions, and `enumConfig` usage callbacks all receive the containing instance as `this`.
+
+**Prefer `function() { ... }` (not arrow)** to ensure `this` is bound to the parent instance.
+
+**Guidance:** Keep callbacks side-effect free; derive options synchronously from `this`.
+
+## Complete Example
+
+```gts
+import { CardDef, field, contains } from 'https://cardstack.com/base/card-api';
+import StringField from 'https://cardstack.com/base/string';
+import enumField from 'https://cardstack.com/base/enum';
+import ArrowUpIcon from '@cardstack/boxel-icons/arrow-up';
+import ArrowDownIcon from '@cardstack/boxel-icons/arrow-down';
+
+const PriorityField = enumField(StringField, {
+  options: [
+    { value: 'high', label: 'High Priority', icon: ArrowUpIcon },
+    { value: 'medium', label: 'Medium Priority' },
+    { value: 'low', label: 'Low Priority', icon: ArrowDownIcon },
+  ],
+});
+
+export class Task extends CardDef {
+  @field taskName = contains(StringField);
+  @field priority = contains(PriorityField);
+
+  @field cardTitle = contains(StringField, {
+    computeVia: function (this: Task) {
+      return this.taskName ?? 'Untitled Task';
+    },
+  });
+}
+```

--- a/skills/boxel-development/references/dev-external-libraries.md
+++ b/skills/boxel-development/references/dev-external-libraries.md
@@ -1,0 +1,101 @@
+**Async loading pattern:**
+
+```gts
+import { task, restartableTask, timeout } from 'ember-concurrency';
+import Modifier from 'ember-modifier';
+
+private loadLibrary = task(async () => {
+  const script = document.createElement('script');
+  script.src = 'https://cdn.../library.js';
+  await new Promise((resolve, reject) => {
+    script.onload = resolve;
+    script.onerror = reject;
+    document.head.appendChild(script);
+  });
+});
+```
+
+**Key Rules:**
+
+1. Use Modifiers for DOM access
+2. Use ember-concurrency tasks for async
+3. Bind external data to model fields
+4. Provide loading states
+
+**Task types:**
+
+- `task` - Concurrent execution
+- `restartableTask` - Cancel previous, start new
+- `enqueueTask` - Sequential queue
+- `dropTask` - Ignore new while running
+
+## Async loading from within components
+
+For fetching data from external APIs, use `ember-concurrency`. The core of this principle are "tasks", which are a cancelable alternative to promises. The most used ones are `task`, and `restartableTask`:
+
+- task: Tasks run concurrently without any coordination, allowing multiple instances to execute simultaneously.
+- restartableTask: Cancels any running task and immediately starts a new one when performed, ensuring only the latest task runs.
+- enqueueTask: Queues tasks to run sequentially one after another, ensuring no overlap but preserving all tasks.
+- dropTask: Ignores new task requests while one is already running, preventing any additional instances from starting.
+- keepLatest: Drops intermediate queued tasks but keeps the most recent one to run after the current task completes.
+
+Here is an example where we are:
+
+- loading data when component is first rendered,
+- reloading it when user clicks on a button,
+- adding some artificial delay using `await timeout(ms)` from `ember-concurrency`. Caution: do not use `setTimeout`.
+
+```
+import { CardDef, field, contains, Component } from 'https://cardstack.com/base/card-api';
+import StringField from 'https://cardstack.com/base/string';
+import { tracked } from '@glimmer/tracking';
+import { restartableTask, timeout } from 'ember-concurrency';
+import { Button } from '@cardstack/boxel-ui/components';
+import { on } from '@ember/modifier';
+import perform from 'ember-concurrency/helpers/perform';
+
+export class CurrencyLoader extends CardDef {
+  static displayName = 'Currency Loader';
+
+  @field loadingStatus = contains(StringField);
+  @field currencies = contains(StringField);
+
+  static isolated = class Isolated extends Component<typeof this> {
+    constructor(owner: any, args: any) {
+      super(owner, args);
+      this.loadCurrencies.perform();
+    }
+
+    private loadCurrencies = restartableTask(async () => {
+      this.args.model.loadingStatus = 'Loading...';
+      const response = await fetch('/api/currencies');
+      await timeout(1000); // Visual feedback
+
+      this.args.model.currencies = await response.json();
+      this.args.model.loadingStatus = "";
+    });
+
+    <template>
+      <div>
+        <p>Status: {{@model.loadingStatus}}</p>
+        <p>Data: {{@model.currencies}}</p>
+
+        <Button {{on 'click' (perform this.loadCurrencies)}}>
+          Reload Currencies
+        </Button>
+      </div>
+    </template>
+  };
+}
+```
+
+## External Libraries: Bringing Third-Party Power to Boxel
+
+**When to Use External Libraries:** Sometimes you need specialized functionality like 3D graphics (Three.js), data visualization (D3), or charts. Boxel plays well with external libraries when you follow the right patterns.
+
+**Key Rules:**
+
+1. **Always use Modifiers for DOM access** - Never manipulate DOM directly
+2. **Use ember-concurrency tasks** for async operations like loading libraries
+3. **Bind external data to model fields** for reactive updates
+4. **Use proper loading states** while libraries initialize

--- a/skills/boxel-development/references/dev-file-def.md
+++ b/skills/boxel-development/references/dev-file-def.md
@@ -1,0 +1,166 @@
+## FileDef — First-Class File Support
+
+`FileDef` is a **third kind of "def"** in Boxel, alongside `CardDef` and `FieldDef`. A FileDef instance represents a file that lives in the realm — an image, document, or other asset — with metadata automatically extracted during indexing.
+
+### Key Rules
+
+- **FileDef instances have their own identity** (like cards), so you reference them with `linksTo`, never `contains`
+- **Render them using the same display formats** — FileDefs have `isolated`, `embedded`, `fitted`, and `atom` templates
+- **Files are not editable via the card edit interface** — users replace them by uploading a new file
+
+---
+
+## Type Hierarchy
+
+```
+FileDef                          → any file
+  ├── ImageDef                   → any image (adds width, height)
+  │     ├── PngDef               → .png files
+  │     ├── JpgDef               → .jpg / .jpeg files
+  │     ├── SvgDef               → .svg files
+  │     ├── GifDef               → .gif files
+  │     ├── WebpDef              → .webp files
+  │     └── AvifDef              → .avif files
+  ├── MarkdownDef                → .md / .markdown (adds title, excerpt, content)
+  ├── TextFileDef                → .txt (adds title, excerpt, content)
+  ├── TsFileDef                  → .ts (adds title, excerpt, content)
+  ├── GtsFileDef                 → .gts (extends TsFileDef)
+  ├── JsonFileDef                → .json (adds title, excerpt, content)
+  └── CsvFileDef                 → .csv (adds title, excerpt, content, columns, columnCount, rowCount)
+```
+
+**Use the most specific type that fits.** Prefer `PngDef` over `ImageDef` when you specifically need PNG; prefer `ImageDef` over `FileDef` when any image format is acceptable.
+**This set is not extensible by Boxel users (currently).** The Boxel project provides these types and only new releases of boxel can add new ones. This may change in the future.
+
+---
+
+## Import Paths
+
+```gts
+import FileDef from 'https://cardstack.com/base/file-api';
+
+// Image types
+import ImageDef from 'https://cardstack.com/base/image-file-def';
+import PngDef from 'https://cardstack.com/base/png-image-def';
+import JpgDef from 'https://cardstack.com/base/jpg-image-def';
+import SvgDef from 'https://cardstack.com/base/svg-image-def';
+import GifDef from 'https://cardstack.com/base/gif-image-def';
+import WebpDef from 'https://cardstack.com/base/webp-image-def';
+import AvifDef from 'https://cardstack.com/base/avif-image-def';
+
+// Document / text types
+import MarkdownDef from 'https://cardstack.com/base/markdown-file-def';
+import TextFileDef from 'https://cardstack.com/base/text-file-def';
+import TsFileDef from 'https://cardstack.com/base/ts-file-def';
+import GtsFileDef from 'https://cardstack.com/base/gts-file-def';
+import JsonFileDef from 'https://cardstack.com/base/json-file-def';
+import CsvFileDef from 'https://cardstack.com/base/csv-file-def';
+```
+
+---
+
+## Available Fields
+
+Every FileDef instance exposes these base fields:
+
+| Field         | Type   | Description                  |
+| ------------- | ------ | ---------------------------- |
+| `id`          | string | URL identifier of the file   |
+| `url`         | string | Current URL of the file      |
+| `sourceUrl`   | string | Original source URL          |
+| `name`        | string | Filename (e.g. `photo.png`)  |
+| `contentType` | string | MIME type (e.g. `image/png`) |
+| `contentHash` | string | MD5 hash of file content     |
+| `contentSize` | number | File size in bytes           |
+
+Additional fields added by subtype:
+
+| Type                                                                   | Extra Fields                                                                |
+| ---------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| `ImageDef` + all image subtypes                                        | `width` (px), `height` (px)                                                 |
+| `MarkdownDef`, `TextFileDef`, `TsFileDef`, `GtsFileDef`, `JsonFileDef` | `title`, `excerpt`, `content` (full text)                                   |
+| `CsvFileDef`                                                           | `title`, `excerpt`, `content`, `columns` (array), `columnCount`, `rowCount` |
+
+---
+
+## Using FileDef in Cards
+
+```gts
+import { CardDef, field, linksTo } from 'https://cardstack.com/base/card-api';
+import ImageDef from 'https://cardstack.com/base/image-file-def';
+import PngDef from 'https://cardstack.com/base/png-image-def';
+import FileDef from 'https://cardstack.com/base/file-api';
+import MarkdownDef from 'https://cardstack.com/base/markdown-file-def';
+
+export class ProductListing extends CardDef {
+  @field photo = linksTo(PngDef); // Specifically PNG
+  @field banner = linksTo(ImageDef); // Any image format
+  @field attachment = linksTo(FileDef); // Any file type
+  @field readme = linksTo(MarkdownDef); // Markdown document
+}
+```
+
+---
+
+## Rendering File Fields in Templates
+
+Use `<@fields.fieldName />` exactly as with any other field. The built-in display components handle rendering automatically.
+
+```gts
+static isolated = class Isolated extends Component<typeof ProductListing> {
+  <template>
+    <div class='product'>
+      {{! Full image with filename and dimensions shown }}
+      <@fields.photo @format="isolated" />
+
+      {{! Responsive inline image filling its container }}
+      <@fields.banner @format="embedded" />
+
+      {{! Thumbnail + filename (good for lists/atom use) }}
+      <@fields.photo @format="atom" />
+
+      {{! Access raw metadata directly when needed }}
+      <p>{{@model.photo.name}} ({{@model.photo.width}}×{{@model.photo.height}}px)</p>
+      <p>Size: {{@model.attachment.contentSize}} bytes</p>
+    </div>
+  </template>
+};
+```
+
+**Image built-in formats:**
+
+- `isolated` → full-size image + filename + dimensions footer
+- `embedded` → responsive `<img>` that fills its container width
+- `fitted` → `background-image: cover` for fixed-size grid cells
+- `atom` → 20 px thumbnail + filename inline
+
+---
+
+## MarkdownDef vs MarkdownField
+
+These are completely different and are **not interchangeable**:
+
+|                          | `MarkdownDef`                                                                   | `MarkdownField`                                                             |
+| ------------------------ | ------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| **Kind**                 | FileDef — a `.md` file in the realm                                             | FieldDef — inline text stored in the card's JSON                            |
+| **Import**               | `https://cardstack.com/base/markdown-file-def`                                  | `https://cardstack.com/base/markdown`                                       |
+| **Declaration**          | `@field notes = linksTo(MarkdownDef)`                                           | `@field notes = contains(MarkdownField)`                                    |
+| **Stored as**            | Separate `.md` file referenced by URL                                           | String embedded in the card's `.json`                                       |
+| **Has own URL?**         | ✅ Yes — shareable and reusable                                                 | ❌ No — owned by the containing card                                        |
+| **Editable in card UI?** | ❌ No — replaced by uploading a new file                                        | ✅ Yes — inline markdown editor                                             |
+| **Extra fields**         | `title`, `excerpt`, `content` auto-extracted                                    | Raw markdown string only                                                    |
+| **Use when**             | Stand-alone documents, content shared across cards, files managed outside Boxel | Inline rich text that belongs to the card, like a description or body field |
+
+---
+
+## FileDef vs Base64ImageField
+
+**🚨 Do NOT use `Base64ImageField` for images.** Use an image FileDef type instead.
+
+|                     | FileDef (`ImageDef`, `PngDef`, etc.) | `Base64ImageField`                       |
+| ------------------- | ------------------------------------ | ---------------------------------------- |
+| **Storage**         | Separate file in the realm           | Base64 data embedded in the card's JSON  |
+| **AI context cost** | ✅ Minimal — just a URL reference    | ❌ Extremely large — can exhaust context |
+| **Shareable**       | ✅ Yes — has its own URL             | ❌ No — embedded in one card             |
+| **Performance**     | ✅ Standard HTTP caching             | ❌ Bloated JSON payloads                 |
+| **Use**             | ✅ Always prefer this                | ⚠️ Avoid                                 |

--- a/skills/boxel-development/references/dev-file-editing.md
+++ b/skills/boxel-development/references/dev-file-editing.md
@@ -1,0 +1,95 @@
+### SEARCH/REPLACE Essentials
+
+**Every .gts file line 1:**
+
+```gts
+// ═══ [EDIT TRACKING: ON] Mark all changes with ⁿ ═══
+```
+
+**Creating new file:**
+
+```gts
+http://realm/card.gts (new)
+╔═══ SEARCH ════╗
+╠═══════════════╣
+// ═══ [EDIT TRACKING: ON] Mark all changes with ⁿ ═══
+import { CardDef } from '...'; // ¹
+export class MyCard extends CardDef { } // ²
+╚═══ REPLACE ═══╝
+```
+
+╰ ¹⁻²
+
+**Modifying existing:**
+
+```gts
+https://realm/card.gts
+╔═══ SEARCH ════╗
+existing code with tracking markers
+╠═══════════════╣
+modified code with new markers // ⁵
+╚═══ REPLACE ═══╝
+```
+
+⁰ ⁵
+
+## File Editing System
+
+### Tracking Mode
+
+**MANDATORY for .gts Files:**
+
+1. All `.gts` files require tracking mode indicator on line 1:
+   ```gts
+   // ═══ [EDIT TRACKING: ON] Mark all changes with ⁿ ═══
+   ```
+2. Format: `// ⁿ description` using sequential superscripts: ¹, ², ³...
+3. Both SEARCH and REPLACE blocks must contain tracking markers
+
+### SEARCH/REPLACE Patterns
+
+#### Creating New File
+
+```gts
+http://realm/recipe-card.gts (new)
+╔═══ SEARCH ════╗
+╠═══════════════╣
+// ═══ [EDIT TRACKING: ON] Mark all changes with ⁿ ═══
+import { CardDef } from 'https://cardstack.com/base/card-api'; // ¹
+export class RecipeCard extends CardDef { // ²
+  static displayName = 'Recipe';
+}
+╚═══ REPLACE ═══╝
+```
+
+⁰ ¹⁻²
+
+#### Modifying Existing File
+
+```gts
+https://example.com/recipe-card.gts
+╔═══ SEARCH ════╗
+export class RecipeCard extends CardDef {
+  static displayName = 'Recipe';
+  @field recipeName = contains(StringField);
+╠═══════════════╣
+export class RecipeCard extends CardDef {
+  static displayName = 'Recipe';
+  @field recipeName = contains(StringField);
+  @field servings = contains(NumberField); // ¹⁸ Added servings
+╚═══ REPLACE ═══╝
+```
+
+⁰ ¹⁸
+
+### File Type Rules
+
+- **`.gts` files** → ALWAYS require tracking mode and markers
+- **`.json` files** → Never use tracking comments
+
+### Best Practices
+
+- Keep search blocks small and precise
+- Include tracking comments in SEARCH blocks for uniqueness
+- Search text must match EXACTLY
+- Use placeholder comments for easy insertion points

--- a/skills/boxel-development/references/dev-fitted-formats.md
+++ b/skills/boxel-development/references/dev-fitted-formats.md
@@ -1,0 +1,152 @@
+# Fitted Format — Container-Query Standard
+
+Distilled from the boxel-workspaces `container-query-fitted-layout.md`
+standard (the full 1000-line guide with worked examples). Everything here
+is CSS-only — no JS modifiers, no ResizeObserver.
+
+## The contract: the parent owns the cell size
+
+A fitted card never imposes its own size. The host wraps every fitted
+template in `.field-component-card.fitted-format` with
+`width: 100%; height: 100%; overflow: hidden; container-type: size;
+container-name: fitted-card`.
+
+**Query the host's `fitted-card` container. NEVER create your own
+container on the root.** (An older version of this reference prescribed a
+local `container-type: size` wrapper — that is WRONG and superseded: a
+container cannot be styled by its own queries, so grid-template/padding
+switches on your root silently stop working.)
+
+The template root is a single `.fit` grid that fills the host wrapper:
+
+```css
+.fit {
+  width: 100%; /* the ONE sanctioned sizing declaration on the root */
+  height: 100%;
+  display: grid;
+}
+@container fitted-card (max-height: 80px) {
+  .fit {
+    grid-template-rows: auto;
+  } /* queries against the HOST container style your root fine */
+}
+```
+
+Keep OFF the root: fixed/min/max dimensions, `border`, `border-radius`,
+`box-shadow`, `container-type`, `container-name` — the host owns all of
+them. Background/foreground pairing from the theme is fine
+(`background-color: var(--card); color: var(--card-foreground)`).
+
+## Prefer `<FittedCard>` for standard compositions
+
+For the standard composition — image/placeholder + eyebrow + title +
+subtitle + meta + footer + badges — use the `FittedCard` component from
+`@cardstack/boxel-ui/components` instead of hand-rolling. It implements
+this whole standard internally (host-container queries, aspect-ratio
+layout switching) and exposes `--fc-*` custom properties for tuning:
+
+```gts
+import { FittedCard } from '@cardstack/boxel-ui/components';
+
+<FittedCard @imageUrl={{@model.imageUrl}} @imageAlt={{@model.title}}>
+  <:placeholder><BookOpen width='24' height='24' /></:placeholder>
+  <:eyebrow>Non-fiction</:eyebrow>
+  <:title><@fields.cardTitle /></:title>
+  <:subtitle><@fields.cardDescription /></:subtitle>
+  <:meta><span>150 mins</span></:meta>
+  <:footer><span>320 pages</span><span>2024</span></:footer>
+</FittedCard>
+```
+
+No-media card types: omit `@imageUrl`, `:image`, AND `:placeholder` — the
+image column disappears and content switches to its no-image layout.
+Tune with `--fc-*` variables and `@container fitted-card (...)` overrides
+from your scoped CSS; don't fork the layout.
+
+**Hand-roll only special templates** (a dark terminal ticker, a ticket
+stub, a boarding pass with an SVG flight path) — then follow the rest of
+this reference.
+
+## Size classification — plan content per quantum BEFORE writing CSS
+
+Height quanta (what the host uses each size for):
+
+| Quantum | Range     | Visible regions                    | Host usage              |
+| ------- | --------- | ---------------------------------- | ----------------------- |
+| h40     | ≤50px     | head only                          | badges, inline mentions |
+| h65     | 50–80px   | head + meta                        | chooser dropdowns       |
+| h105    | 80–130px  | head + body + meta                 | strips, search results  |
+| h170    | 130–200px | head + body + [tags] + meta        | tiles                   |
+| h275    | 200–320px | hero + head + body + [tags] + meta | large tiles, cards      |
+| h445    | >320px    | all, spacious                      | expanded cards          |
+
+Width classes:
+
+| Class  | Range     | Behavior                                                       |
+| ------ | --------- | -------------------------------------------------------------- |
+| narrow | ≤170px    | hide tags, clamp meta to 1 line, hide subhead at small heights |
+| medium | 170–260px | hide tags, clamp meta to 1 line                                |
+| wide   | >260px    | show tags; horizontal thumbnails at h40/h65/h105               |
+
+Tags hide below 260px because wrapping pills consume unpredictable
+height. Write the **content matrix first** — for each quantum, decide
+which fields appear — then implement it as `@container fitted-card`
+rules. A fitted view that only looks right at one size is a defect.
+
+```css
+@container fitted-card (max-height: 50px) {
+  /* h40: head only */
+}
+@container fitted-card (min-height: 50.1px) and (max-height: 80px) {
+  /* h65 */
+}
+@container fitted-card (min-height: 80.1px) and (max-height: 130px) {
+  /* h105 */
+}
+@container fitted-card (min-height: 130.1px) and (max-height: 200px) {
+  /* h170 */
+}
+@container fitted-card (min-height: 200.1px) {
+  /* h275+: hero appears */
+}
+@container fitted-card (max-width: 260px) {
+  .r-tags {
+    display: none;
+  }
+}
+```
+
+## Overflow discipline (every region, no exceptions)
+
+- Body/content rows: `minmax(0, 1fr)` — never `auto` (auto rows grow
+  with content and blow the cell).
+- `overflow: hidden` on every region.
+- Text clamps: `display: -webkit-box; -webkit-box-orient: vertical;
+-webkit-line-clamp: N; overflow: hidden`.
+- `min-height: 0` on any nested flex/grid child that must shrink.
+
+## Container-query units caveat
+
+`cqw`/`cqh`/`cqmin` only resolve against an actual container. Inside a
+fitted template they resolve against the host's `fitted-card` container —
+fine. On other surfaces (isolated/embedded) they silently fall back to
+the VIEWPORT unless you establish a container on that surface with
+`container-type: inline-size` first.
+
+## Parent-side note
+
+When a parent embeds fitted children (`<@fields.x @format='fitted' />`),
+the parent sizes the cell (e.g. a grid of `160px × 180px` tiles) and may
+need `@displayContainer={{false}}` to suppress double chrome — see
+`dev-delegated-rendering.md`.
+
+## Media fields (cardinal rule, applies to ALL formats)
+
+An image on a card is `@field image = linksTo(() => ImageDef)` (or
+FileDef) pointing at a real realm file — write the binary into the
+workspace and reference it. NEVER design a field that stores
+`data:`/base64/blob strings in JSON attributes, not even "just a
+placeholder" — inline media bytes in instance JSON are a hard rule
+violation that corrupts diffs, bloats the index, and breaks the file's
+identity. No-media-yet instances leave the link empty and the template
+renders a placeholder block/icon.

--- a/skills/boxel-development/references/dev-query-systems.md
+++ b/skills/boxel-development/references/dev-query-systems.md
@@ -1,0 +1,95 @@
+## Query Essentials
+
+**The 'on' Rule (MEMORIZE THIS!):**
+
+```ts
+// ❌ WRONG - Missing 'on'
+{ range: { price: { lte: 100 } } }
+
+// ✅ CORRECT - Include 'on' for filters
+{
+  on: { module: new URL('./product', import.meta.url).href, name: 'Product' },
+  range: { price: { lte: 100 } }
+}
+```
+
+**⚠️ CRITICAL Path Rule:**
+
+- **In .gts files (queries):** Use `./` - you're in the same directory as the module
+- **In JSON files (`adoptsFrom`):** Use `../` - instances live in folders, need to navigate up
+- `./` means "same directory" when used with `import.meta.url`
+
+**Filter types needing 'on':**
+
+- `eq`, `in`, `contains`, `range` (except after type filter)
+- Sort on type-specific fields
+
+**Filter composition types:**
+
+- `any`: allows an "OR" union of other filters
+- `every`: allows an "AND" union of other filters
+- `not`: allow negating another filter
+
+**Basic query pattern:**
+
+```ts
+const query = {
+  filter: {
+    every: [
+      {
+        type: {
+          module: new URL('./product', import.meta.url).href,
+          name: 'Product',
+        },
+      },
+      {
+        on: {
+          module: new URL('./product', import.meta.url).href,
+          name: 'Product',
+        },
+        eq: { status: 'active' },
+      },
+    ],
+  },
+};
+```
+
+**Defining query-backed fields:**
+
+```ts
+@field shirts = linksToMany(Shirt, {
+  query: {
+    filter: {
+      // implicit clause merged during execution: on: { module: Shirt.module, name: 'Shirt' }
+      eq: { size: '$this.profile.shirtSize' },
+    },
+    realm: '$REALM',
+    sort: [
+      {
+        by: 'updatedAt',
+        direction: 'desc',
+      },
+    ],
+    page: { size: 12 },
+  },
+});
+
+@field profile = linksTo(Profile, {
+  query: {
+    filter: {
+      eq: { primary: true },
+    },
+    // `linksTo` takes the first matching card (post-sort) or null when no results.
+  },
+});
+```
+
+**When to use what to query cards:**
+
+- Efficient display-only → `PrerenderedCardSearch`
+- Need data manipulation → `getCards`
+- Treat query result as a field → query-backed fields
+
+```
+
+```

--- a/skills/boxel-development/references/dev-quick-reference.md
+++ b/skills/boxel-development/references/dev-quick-reference.md
@@ -1,0 +1,150 @@
+**Core imports:**
+
+```gts
+import {
+  CardDef,
+  FieldDef,
+  Component,
+  field,
+  contains,
+  linksTo,
+} from 'https://cardstack.com/base/card-api';
+import StringField from 'https://cardstack.com/base/string';
+import NumberField from 'https://cardstack.com/base/number';
+```
+
+**UI Components:**
+
+```gts
+import { Button, Pill, BoxelSelect } from '@cardstack/boxel-ui/components';
+```
+
+**Helpers:**
+
+```gts
+import { eq, gt, and, or, not } from '@cardstack/boxel-ui/helpers';
+import { formatDateTime, formatCurrency } from '@cardstack/boxel-ui/helpers';
+```
+
+## Quick Reference
+
+**File Types:** `.gts` (definitions) | `.json` (instances)  
+**Core Pattern:** CardDef/FieldDef → contains/linksTo → Templates → Instances  
+**Essential Formats:** Every CardDef MUST implement `isolated`, `embedded`, AND `fitted` formats
+
+```gts
+// ═══ [EDIT TRACKING: ON] Mark all changes with ⁿ ═══
+// ¹ Core imports - ALWAYS needed for definitions
+import {
+  CardDef,
+  FieldDef,
+  Component,
+  field,
+  contains,
+  containsMany,
+  linksTo,
+  linksToMany,
+} from 'https://cardstack.com/base/card-api';
+
+// ² Base field imports (only what you use)
+import StringField from 'https://cardstack.com/base/string';
+import NumberField from 'https://cardstack.com/base/number';
+import BooleanField from 'https://cardstack.com/base/boolean';
+import DateField from 'https://cardstack.com/base/date';
+import DateTimeField from 'https://cardstack.com/base/datetime';
+import MarkdownField from 'https://cardstack.com/base/markdown';
+import TextAreaField from 'https://cardstack.com/base/text-area';
+import BigIntegerField from 'https://cardstack.com/base/big-integer';
+import CodeRefField from 'https://cardstack.com/base/code-ref';
+import Base64ImageField from 'https://cardstack.com/base/base64-image'; // 🚨 NEVER USE - embeds binary in JSON, crashes AI context; use FileDef types instead
+
+// ⁸ FileDef imports - for file fields (use linksTo, never contains)
+import FileDef from 'https://cardstack.com/base/file-api';
+import ImageDef from 'https://cardstack.com/base/image-file-def'; // any image
+import PngDef from 'https://cardstack.com/base/png-image-def'; // .png
+import JpgDef from 'https://cardstack.com/base/jpg-image-def'; // .jpg/.jpeg
+import SvgDef from 'https://cardstack.com/base/svg-image-def'; // .svg
+import GifDef from 'https://cardstack.com/base/gif-image-def'; // .gif
+import WebpDef from 'https://cardstack.com/base/webp-image-def'; // .webp
+import AvifDef from 'https://cardstack.com/base/avif-image-def'; // .avif
+import MarkdownDef from 'https://cardstack.com/base/markdown-file-def'; // .md (NOT same as MarkdownField)
+import TextFileDef from 'https://cardstack.com/base/text-file-def'; // .txt
+import TsFileDef from 'https://cardstack.com/base/ts-file-def'; // .ts
+import GtsFileDef from 'https://cardstack.com/base/gts-file-def'; // .gts
+import JsonFileDef from 'https://cardstack.com/base/json-file-def'; // .json
+import CsvFileDef from 'https://cardstack.com/base/csv-file-def'; // .csv
+import ColorField from 'https://cardstack.com/base/color';
+import EmailField from 'https://cardstack.com/base/email';
+import PercentageField from 'https://cardstack.com/base/percentage';
+import PhoneNumberField from 'https://cardstack.com/base/phone-number';
+import UrlField from 'https://cardstack.com/base/url';
+import AddressField from 'https://cardstack.com/base/address';
+
+// ⚠️ EXTENDING BASE FIELDS: To customize a base field, import it and extend:
+// import BaseAddressField from 'https://cardstack.com/base/address';
+// export class FancyAddressField extends BaseAddressField { }
+// Never import and define the same field name - it causes conflicts!
+
+// ³ UI Component imports
+import {
+  Button,
+  Pill,
+  Avatar,
+  FieldContainer,
+  CardContainer,
+  BoxelSelect,
+  ViewSelector,
+} from '@cardstack/boxel-ui/components';
+
+// ⁴ Helper imports
+import {
+  eq,
+  gt,
+  gte,
+  lt,
+  lte,
+  and,
+  or,
+  not,
+  cn,
+  add,
+  subtract,
+  multiply,
+  divide,
+} from '@cardstack/boxel-ui/helpers';
+import {
+  currencyFormat,
+  formatDateTime,
+  optional,
+  pick,
+} from '@cardstack/boxel-ui/helpers';
+import { concat, fn } from '@ember/helper';
+import { get } from '@ember/helper';
+import { on } from '@ember/modifier';
+import Modifier from 'ember-modifier';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import { task, restartableTask } from 'ember-concurrency';
+// NOTE: 'if' is built into Glimmer templates - DO NOT import it
+
+// ⁶ TIMING RULE: NEVER use requestAnimationFrame
+// - DOM timing: Use Glimmer modifiers with cleanup
+// - Async coordination: Use task/restartableTask from ember-concurrency
+// - Delays: Use await timeout(ms) from ember-concurrency, not setTimeout
+
+// ⁵ Icon imports
+import EmailIcon from '@cardstack/boxel-icons/mail';
+import PhoneIcon from '@cardstack/boxel-icons/phone';
+import RocketIcon from '@cardstack/boxel-icons/rocket';
+// Available from Lucide, Lucide Labs, and Tabler icon sets
+// NOTE: Only use for static card/field type icons, NOT in templates
+
+// CRITICAL IMPORT RULES:
+// ⚠️ If you don't see an import in the approved lists above, DO NOT assume it exists!
+// ⚠️ Only use imports explicitly shown in this guide - no exceptions!
+// - Verify any import exists in the approved lists before using
+// - Do NOT assume similar imports exist (e.g., don't assume IntegerField exists because NumberField does)
+// - If needed functionality isn't in approved imports, define it directly with a comment:
+//   // Defining custom helper - not yet available in Boxel environment
+//   function customHelper() { ... }
+```

--- a/skills/boxel-development/references/dev-qunit-testing.md
+++ b/skills/boxel-development/references/dev-qunit-testing.md
@@ -1,0 +1,145 @@
+# QUnit Card Testing
+
+How to write `.test.gts` files for Boxel card definitions (run them with `boxel test`).
+
+## Where Files Live
+
+- **Test files** (`.test.gts`) are co-located with card definitions in the target realm (e.g., `sticky-note.gts` and `sticky-note.test.gts`)
+- **Card definitions** (`.gts`) and **Catalog Spec cards** (`Spec/*.json`) live in the target realm — tests reference them but don't modify them
+
+## Writing a Test File
+
+Every test file must:
+
+1. Import `module` and `test` from `'qunit'`
+2. Import `setupCardTest` from `'@cardstack/host/tests/helpers'`
+3. Import `renderCard` from `'@cardstack/host/tests/helpers/render-component'`
+4. Import `getService` from `'@universal-ember/test-support'`
+5. Use `import.meta.url` to resolve the co-located card definition — never hardcode realm URLs
+6. Export a `runTests()` function that registers QUnit modules and tests
+7. Keep all test data in browser memory — no external realm writes during tests
+8. Use `data-test-*` attributes for DOM assertions (not CSS classes)
+
+### Complete Example
+
+```typescript
+// sticky-note.test.gts — co-located with sticky-note.gts
+import { module, test } from 'qunit';
+import { setupCardTest } from '@cardstack/host/tests/helpers';
+import { renderCard } from '@cardstack/host/tests/helpers/render-component';
+import { getService } from '@universal-ember/test-support';
+
+let cardModuleUrl = new URL('./sticky-note', import.meta.url).href;
+
+export function runTests() {
+  module('StickyNote', function (hooks) {
+    setupCardTest(hooks);
+
+    test('renders title in fitted view', async function (assert) {
+      let loader = getService('loader-service').loader;
+      let { StickyNote } = await loader.import(cardModuleUrl);
+      let note = new StickyNote({ title: 'Test Note', body: 'Hello' });
+      await renderCard(loader, note, 'fitted');
+      assert.dom('[data-test-title]').hasText('Test Note');
+    });
+
+    test('renders body in isolated view', async function (assert) {
+      let loader = getService('loader-service').loader;
+      let { StickyNote } = await loader.import(cardModuleUrl);
+      let note = new StickyNote({ title: 'Test Note', body: 'Hello World' });
+      await renderCard(loader, note, 'isolated');
+      assert.dom('[data-test-body]').hasText('Hello World');
+    });
+  });
+}
+```
+
+## Available Shimmed Modules
+
+The following modules are available in the QUnit test environment (shimmed by `live-test.js`):
+
+- `qunit` — `module`, `test`, `skip`, `todo`, `only`
+- `@cardstack/host/tests/helpers` — General test helpers including `setupCardTest(hooks)`
+- `@cardstack/host/tests/helpers/setup` — `setupRenderingTest(hooks)`, `setupApplicationTest(hooks)`
+- `@cardstack/host/tests/helpers/render-component` — `renderCard(loader, card, format)`
+- `@cardstack/host/tests/helpers/mock-matrix` — Mock Matrix service helpers
+- `@cardstack/host/tests/helpers/adapter` — Test adapter utilities
+- `@cardstack/host/tests/helpers/base-realm` — Base realm helpers
+- `@universal-ember/test-support` — `getService`, `settled`, etc.
+- `@ember/owner` — Ember owner lookup
+- `@cardstack/runtime-common` — `baseRealm` and other runtime utilities
+
+## Key Patterns
+
+### Resolving Card Definitions with `import.meta.url`
+
+Always use `import.meta.url` to resolve co-located card definitions. This makes tests portable across realms:
+
+```typescript
+let cardModuleUrl = new URL('./sticky-note', import.meta.url).href;
+
+// Then in the test:
+let { StickyNote } = await loader.import(cardModuleUrl);
+```
+
+### `setupCardTest(hooks)`
+
+Call this in every module to set up the card runtime environment:
+
+```typescript
+module('MyCard', function (hooks) {
+  setupCardTest(hooks);
+  // tests go here
+});
+```
+
+This sets up rendering, local indexing, mock Matrix, card logs, and in-memory realm.
+
+### `renderCard(loader, card, format)`
+
+Render a card in a specific format for DOM assertions:
+
+```typescript
+let loader = getService('loader-service').loader;
+let { MyCard } = await loader.import(cardModuleUrl);
+let card = new MyCard({ title: 'Test' });
+await renderCard(loader, card, 'fitted');
+```
+
+Supported formats: `'fitted'`, `'isolated'`, `'embedded'`, `'edit'`
+
+### QUnit Assertions
+
+- `assert.dom('[data-test-*]').hasText('...')` — Check element text
+- `assert.dom('[data-test-*]').exists()` — Check element presence
+- `assert.dom('[data-test-*]').hasClass('...')` — Check CSS class
+- `assert.strictEqual(actual, expected, message)` — Strict equality
+- `assert.ok(value, message)` — Truthiness check
+- `assert.deepEqual(actual, expected, message)` — Deep equality
+
+### `data-test-*` Attribute Conventions
+
+Add `data-test-*` attributes to card templates for stable test selectors:
+
+```gts
+<template>
+  <div data-test-sticky-note>
+    <h2 data-test-title>{{@model.title}}</h2>
+    <p data-test-body>{{@model.body}}</p>
+  </div>
+</template>
+```
+
+## Debugging Test Failures
+
+When tests fail, the orchestrator feeds test failure details back to the agent. For more detail:
+
+- **TestRun cards** live in the target realm's `Validations/` folder with a `test_` prefix (e.g., `Validations/test_issue-slug-1.json`). To find all test runs, run `Glob` over `Validations/test_*.json` or shell out via `Bash` to `boxel search --realm <url>` filtered on the TestRun card type. Each TestRun has a `sequenceNumber` that increases with each iteration. Use native `Read` on a specific TestRun for full details — paths are workspace-relative.
+
+## Rules
+
+- **All test data lives in browser memory only** — never write to external realms during tests.
+- **Use `import.meta.url`** to resolve card definitions — never hardcode realm URLs.
+- **Use `data-test-*` attributes** for stable test selectors, not CSS classes.
+- **Every issue must have at least one test file** as `{card-name}.test.gts` co-located with the card definition.
+- **Test files live in the target realm** as realm files alongside the card definitions they test.

--- a/skills/boxel-development/references/dev-replicate-ai.md
+++ b/skills/boxel-development/references/dev-replicate-ai.md
@@ -1,0 +1,114 @@
+### Replicate API Essentials
+
+**Gateway URL Pattern:**
+
+```
+https://gateway.ai.cloudflare.com/v1/{account}/{gateway}/replicate/v1/models/{owner}/{model}/predictions
+```
+
+**Required Headers:**
+
+```typescript
+{
+  'Content-Type': 'application/json',
+  'Prefer': 'wait'  // CRITICAL: Synchronous response
+}
+```
+
+**Request Structure:**
+
+```typescript
+{
+  input: {
+    prompt: string,
+    // Model-specific parameters (see API docs)
+  }
+}
+```
+
+### Enum Fields for API Parameters
+
+**CRITICAL:** Enum `value` must exactly match API spec:
+
+```gts
+import enumField from 'https://cardstack.com/base/enum';
+
+const SizeField = enumField(StringField, {
+  options: [
+    { value: '1K', label: '1K (1024px)' },
+    { value: '2K', label: '2K (2048px)' },
+    { value: 'custom', label: 'Custom' },
+  ],
+});
+```
+
+### API Call Pattern
+
+```gts
+import SendRequestViaProxyCommand from '@cardstack/boxel-host/commands/send-request-via-proxy';
+import UploadImageCommand from 'https://realms-staging.stack.cards/catalog/commands/upload-image';
+import GetCardCommand from '@cardstack/boxel-host/commands/get-card';
+import { CloudflareImage } from 'https://realms-staging.stack.cards/catalog/cloudflare-image';
+
+// Build request
+const requestBody = {
+  input: { prompt: input.prompt },
+};
+
+// Add conditional parameters
+if (input.size) requestBody.input.size = input.size;
+if (input.aspectRatio && input.size !== 'custom') {
+  requestBody.input.aspect_ratio = input.aspectRatio;
+}
+
+// Call API
+const response = await new SendRequestViaProxyCommand(ctx).execute({
+  url: 'https://gateway.ai.cloudflare.com/v1/.../replicate/v1/models/{owner}/{model}/predictions',
+  method: 'POST',
+  requestBody: JSON.stringify(requestBody),
+  headers: { 'Content-Type': 'application/json', Prefer: 'wait' },
+});
+
+// Parse response
+const data = await response.response.json();
+let imageUrl = Array.isArray(data.output) ? data.output[0] : data.output;
+
+// Upload result
+const uploaded = await new UploadImageCommand(ctx).execute({
+  sourceImageUrl: imageUrl,
+  targetRealmUrl: input.realm,
+});
+
+return await new GetCardCommand(ctx).execute({ cardId: uploaded.cardId });
+```
+
+### Response Parsing
+
+```typescript
+// Handle multiple formats
+let imageUrl: string | undefined;
+
+if (data.output && Array.isArray(data.output)) {
+  imageUrl = data.output[0];
+} else if (typeof data.output === 'string') {
+  imageUrl = data.output;
+} else if (data.output?.url) {
+  imageUrl = data.output.url;
+}
+
+if (!imageUrl) throw new Error('No image URL in response');
+```
+
+### Common Mistakes
+
+❌ Missing `Prefer: wait` header → async URL instead of result  
+❌ Enum value mismatch → API rejects request  
+❌ Always sending optional params → API validation errors  
+❌ String booleans in API → Use actual `true`/`false`
+
+### Finding Model Schemas
+
+1. Visit `https://replicate.com/{owner}/{model}`
+2. Check API tab for exact schema
+3. Note required vs optional parameters
+4. Match enum values exactly

--- a/skills/boxel-development/references/dev-spec-usage.md
+++ b/skills/boxel-development/references/dev-spec-usage.md
@@ -1,0 +1,262 @@
+# Catalog Spec Card Instances
+
+For each top-level card definition, write a Catalog Spec card instance in the target realm's `Spec/` folder. This makes the card discoverable in the Boxel catalog.
+
+Specs adopt from the `Spec` class exported by `https://cardstack.com/base/spec` — that module lives in the base realm, not your target realm. Fetch the authoritative schema from the base realm module itself rather than guessing field names (environments with a schema tool, such as `get_card_schema`, can use that instead):
+
+```
+get_card_schema({ module: 'https://cardstack.com/base/spec', name: 'Spec' })
+```
+
+The result gives you the exact `attributes` and `relationships` shape. Write the JSON file with native `Write` (paths are workspace-relative, e.g. `Spec/sticky-note.json`); `boxel sync` pushes it to the realm between iterations.
+
+## Required Shape
+
+```json
+{
+  "data": {
+    "type": "card",
+    "attributes": {
+      "specType": "card",
+      "ref": { "module": "../sticky-note", "name": "StickyNote" },
+      "readMe": "...",
+      "cardInfo": { "name": "Sticky Note", "summary": "..." }
+    },
+    "relationships": {
+      "linkedExamples.0": { "links": { "self": "../StickyNote/welcome-note" } }
+    },
+    "meta": {
+      "adoptsFrom": {
+        "module": "https://cardstack.com/base/spec",
+        "name": "Spec"
+      }
+    }
+  }
+}
+```
+
+Key concepts:
+
+- `ref` — a CodeRef pointing to the card definition (module path + exported class name). The module path is relative from the Spec card to the `.gts` file (e.g., `../sticky-note` from `Spec/sticky-note.json`).
+- `specType` — `"card"` for CardDef, `"field"` for FieldDef, `"component"` for standalone components.
+- `linkedExamples` — a `linksToMany` relationship pointing to sample card instances. Use dotted keys (`linkedExamples.0`, `linkedExamples.1`, …) — the array form is rejected by the indexer. Create at least one sample instance and link it here.
+- **Do NOT call `run_instantiate` on the Spec file itself.** Spec's module lives in the base realm; the prerender enforces same-origin module loads and the call always fails. To validate Specs, call `run_instantiate` WITHOUT a `path`; it discovers Specs in the target realm and exercises their `linkedExamples` against the card classes you wrote.
+
+## Sample Card Instances
+
+Create at least one sample instance with realistic data for each top-level card. Sample instances serve as both catalog examples and test fixtures.
+
+Place sample instances in a folder named after the card type (e.g., `StickyNote/welcome-note.json`) and write them with native `Write`. The `linkedExamples` relationship in the Spec card points to these using a relative path without the `.json` suffix (e.g., `../StickyNote/welcome-note`).
+
+---
+
+# Spec Type Usage Patterns
+
+Below are usage patterns for each `specType`, showing how each type of definition is imported and used in code.
+
+**Card specs (linksTo/linksToMany):**
+
+```gts
+import { Author } from './author';
+@field author = linksTo(Author);
+@field contributors = linksToMany(Author);
+```
+
+**Field specs (contains/containsMany):**
+
+```gts
+import StringField from 'https://cardstack.com/base/string';
+import AddressField from 'https://cardstack.com/base/address-field';
+@field name = contains(StringField);
+@field addresses = containsMany(AddressField);
+```
+
+**Component specs (direct template usage):**
+
+```hbs
+<BoxelSelect @options={{this.options}} />
+<Button @kind='primary' @size='small'>Save</Button>
+```
+
+**Command specs (programmatic execution):**
+
+```ts
+const cmd = new MyCommand(commandContext);
+const result = await cmd.execute(input);
+```
+
+## Spec Usage Examples
+
+A Spec is a comprehensive documentation and metadata container for code within the Boxel ecosystem.
+
+This document provides real-world usage examples for each spec type based on actual implementations found in the Boxel repository.
+
+### Card Specs (`specType: 'card'`)
+
+(Cards are linked to using `linksTo` and `linksToMany` within consuming cards...)
+
+#### Import
+
+```typescript
+import { Author } from './author';
+import { Country } from 'https://cardstack.com/base/country';
+import { Skill } from 'https://cardstack.com/base/skill';
+```
+
+#### Usage as a Field
+
+```typescript
+export class BlogPost extends CardDef {
+  // Single card reference
+  @field author = linksTo(Author);
+  @field country = linksTo(Country);
+
+  // Multiple card references
+  @field enabledSkills = linksToMany(Skill);
+  @field attachedCards = linksToMany(CardDef);
+}
+```
+
+#### Template Usage
+
+```handlebars
+{{! Display linked card in different formats }}
+<@fields.author @format='embedded' />
+<@fields.author @format='atom' />
+
+{{! Display collection of linked cards }}
+<div class='skills-container'>
+  <@fields.enabledSkills @format='embedded' />
+</div>
+```
+
+### Field Specs (`specType: 'field'`)
+
+(Fields are embedded using `contains` and `containsMany` within cards.)
+
+#### Import
+
+```typescript
+import StringField from 'https://cardstack.com/base/string';
+import DateField from 'https://cardstack.com/base/date';
+import { SocialMediaLink } from './social-media-link';
+```
+
+#### Usage as a Field
+
+```typescript
+export class MinecraftInvite extends CardDef {
+  // Basic field types
+  @field celebrantName = contains(StringField);
+  @field age = contains(StringField);
+  @field date = contains(DateField);
+
+  // Custom field types
+  @field socialLinks = containsMany(SocialMediaLink);
+}
+```
+
+#### Template Usage
+
+```handlebars
+{{! Display contained fields }}
+<@fields.celebrantName />
+<@fields.date @format='atom' />
+
+{{! Display collection of contained fields }}
+<div class='social-links'>
+  <@fields.socialLinks @format='embedded' />
+</div>
+```
+
+### Component Specs (`specType: 'component'`)
+
+(Components are used directly in templates, extending GlimmerComponent...)
+
+#### Import
+
+```typescript
+import { BoxelSelect, Pill } from '@cardstack/boxel-ui/components';
+import { FilterDropdown } from './filter-dropdown';
+import { CardsGrid } from './cards-grid';
+```
+
+#### Usage in Templates
+
+```handlebars
+{{! Basic component usage }}
+<BoxelSelect
+  @placeholder='Select option'
+  @options={{this.options}}
+  @onChange={{this.onSelectOption}}
+/>
+
+{{! Custom components }}
+<FilterDropdown @filters={{this.filters}} />
+<CardsGrid @cards={{this.cards}} @columns={{3}} />
+
+{{! Component with content }}
+<Pill @variant='primary'>
+  Active Status
+</Pill>
+```
+
+### App Specs (`specType: 'app'`)
+
+(Apps extend AppCard and are typically linked to like regular cards...)
+
+#### Import
+
+```typescript
+import { AppCard } from '/experiments/app-card';
+import { GardenAppCard } from './garden-app';
+```
+
+#### Usage as a Field
+
+```typescript
+export class Dashboard extends CardDef {
+  @field primaryApp = linksTo(GardenAppCard);
+  @field availableApps = linksToMany(AppCard);
+}
+```
+
+#### Template Usage
+
+```handlebars
+{{! Display app in card context }}
+<@fields.primaryApp @format='fitted' />
+
+{{! App navigation }}
+<div class='app-grid'>
+  <@fields.availableApps @format='embedded' />
+</div>
+```
+
+### Command Specs (`specType: 'command'`)
+
+(Commands are instantiated and executed programmatically.)
+
+#### Import
+
+```typescript
+import { GenerateReadmeSpecCommand } from './generate-readme-spec';
+import { SwitchSubmodeCommand } from './switch-submode';
+import { UpdatePlaygroundSelectionCommand } from './update-playground-selection';
+```
+
+#### Template Usage
+
+When you need to execute commands in response to user interactions, you can just access the commandContext and invoke it as how you would a simple async function in javascript
+
+```typescript
+let commandContext = this.args.context?.commandContext;
+if (!commandContext) {
+  console.error('Command context not available');
+  return;
+}
+
+const someCommandInput = new CommandInput({ ...args });
+const myCommand = new MyCommand(commandContext);
+const result = await myCommand.execute(someCommandInput);
+```

--- a/skills/boxel-development/references/dev-styling-design.md
+++ b/skills/boxel-development/references/dev-styling-design.md
@@ -1,0 +1,125 @@
+## CSS Safety Essentials
+
+**Always scoped:**
+
+```gts
+<template>
+  <div class='my-card'>...</div>
+  <style scoped>
+    /* MANDATORY */
+    .my-card {
+    }
+  </style>
+</template>
+```
+
+**CSS comments (NEVER use //):**
+
+```css
+/* ✅ CORRECT: Block comments */
+.card { color: blue; }
+
+// ❌ WRONG: Single-line breaks parsing
+```
+
+**Never use global selectors:**
+
+```css
+/* ❌ WRONG */
+:root {
+  --color: blue;
+}
+body {
+  margin: 0;
+}
+
+/* ✅ CORRECT */
+.my-component {
+  --color: blue;
+}
+```
+
+**Formatters for display:**
+
+```hbs
+{{formatCurrency @model.price currency='USD'}}
+{{formatDateTime @model.date size='medium'}}
+{{formatNumber @model.count size='tiny'}}
+```
+
+## Design Philosophy and Competitive Styling
+
+Design and implement your stylesheet to fit the domain you are generating. Research the top 2 products/services in that area and design your card as if you are the 3rd competitor looking to one-up the market in terms of look and feel, functionality, and user-friendliness.
+
+Approach: Study the leading players' design patterns, then create something that feels more modern, intuitive, and polished. Focus on micro-interactions, thoughtful spacing, superior visual hierarchy, and removing friction from user workflows.
+
+Key Areas to Compete On:
+
+- Visual polish: better typography, spacing, and color schemes
+- Interaction design: smoother animations, better feedback, clearer affordances
+- Information architecture: more logical organization, better progressive disclosure
+- Accessibility: superior contrast, keyboard navigation, screen reader support
+- Performance: faster loading, responsive design
+
+Typography Guidance (detailed): Choose modern, readable fonts that match your domain. For body text, consider Inter, Roboto, Open Sans, Source Sans Pro, DM Sans, Work Sans, Manrope, or Plus Jakarta Sans. For headings, Poppins, Montserrat, Space Grotesk, Raleway, Archivo Black, Oswald, Anton, Playfair Display, Lora, or Merriweather. Balance readability with character; ensure sufficient contrast and legible sizes across formats.
+
+## Design Token Foundation
+
+Dense professional layouts with thoughtful scaling:
+
+- Typography scale: start at 0.875rem base; headings 1rem–1.375rem; labels 0.75rem
+- Spacing scale: 0.25rem increments; inline 0.25–0.5rem; sections 0.75–1rem; major 1.5–2rem
+- Colors: define background, foreground, muted, muted-foreground, primary, primary-foreground, secondary, secondary-foreground, accent, accent-foreground, card, card-foreground, sidebar, sidebar-foreground, and border tokens
+- Radius: match the aesthetic (sharp for technical, soft for friendly)
+- Shadows: subtle elevation for interactive elements; keep z-index conservative (<10)
+
+Implementation tip: Define CSS variables at component root and use fallbacks.
+
+```css
+.component {
+  --card-padding: var(--boxel-sp, 1rem);
+  --card-radius: var(--boxel-border-radius-sm, 0.5rem);
+  --card-shadow: var(--boxel-box-shadow, 0 2px 4px rgba(0, 0, 0, 0.1));
+  padding: var(--card-padding);
+  border-radius: var(--card-radius);
+  box-shadow: var(--card-shadow);
+}
+```
+
+## Typography Guidance (Detailed)
+
+- Base size: 14px (0.875rem) for dense UIs; increase in larger formats
+- Hierarchy cascade: each level 80–87% of the previous; adjust weight 100–200 units per level
+- Line-height: 1.2–1.5 depending on density; tighter for tiles, looser for isolated
+- Clamping: use `clamp()` for responsive sizes across fitted/embedded/isolated
+- Accessibility: aim for WCAG AA contrast; avoid ultra-light weights below 16px
+- Numbers: tabular-nums for data tables and metrics when available
+
+Example:
+
+```css
+.title {
+  font-size: clamp(1rem, 2.5vw, 1.25rem);
+  font-weight: 700;
+}
+.subtle {
+  font-size: 0.75rem;
+  opacity: 0.8;
+}
+```
+
+## Format Dimensions Comparison
+
+| Format   | Width             | Height           | Parent Sets | Key Behavior                                 |
+| -------- | ----------------- | ---------------- | ----------- | -------------------------------------------- |
+| Isolated | Max-width, center | Natural + scroll | No          | Full detail, scrollable content              |
+| Embedded | Fills container   | Natural          | Width only  | Truncation/expand controls handled by parent |
+| Fitted   | Fills exactly     | Fills exactly    | Both        | Must adapt to fixed grid slots               |
+| Atom     | Inline            | Inline           | No          | Minimal inline representation                |
+| Edit     | Fills container   | Natural form     | Width only  | Form layout, grows with fields               |
+
+Notes:
+
+- Fitted requires internal subformats (badge, strip, tile, card) via container queries
+- Embedded should be height-flexible; parents may clamp and offer "view more"
+- Isolated should ensure comfortable reading with scrollable mat and generous padding

--- a/skills/boxel-development/references/dev-technical-rules.md
+++ b/skills/boxel-development/references/dev-technical-rules.md
@@ -1,0 +1,173 @@
+### The Cardinal Rule
+
+**MOST CRITICAL RULE:**
+
+```gts
+// ✅ CORRECT
+@field author = linksTo(Author);          // CardDef
+@field address = contains(AddressField);  // FieldDef
+
+// ❌ WRONG - Will break everything
+@field author = contains(Author);         // NEVER!
+@field address = linksTo(AddressField);   // NEVER!
+```
+
+**Must export ALL classes:**
+
+```gts
+export class MyCard extends CardDef { }  // ✅
+class MyCard extends CardDef { }         // ❌ Missing export
+```
+
+**Computed fields:**
+
+- Keep simple and unidirectional
+- No self-reference or cycles
+- Wrap cross-card access in try-catch
+
+## Technical Rules
+
+### THE CARDINAL RULE: contains vs linksTo
+
+**THIS IS THE #1 MOST CRITICAL RULE IN BOXEL:**
+
+| Type                 | MUST Use                    | NEVER Use                      | Why                                             |
+| -------------------- | --------------------------- | ------------------------------ | ----------------------------------------------- |
+| **Extends CardDef**  | `linksTo` / `linksToMany`   | ❌ `contains` / `containsMany` | CardDef = independent entity with own JSON file |
+| **Extends FieldDef** | `contains` / `containsMany` | ❌ `linksTo` / `linksToMany`   | FieldDef = embedded data, no separate identity  |
+
+```gts
+// ✅ CORRECT
+@field author = linksTo(Author);              // Author extends CardDef
+@field address = contains(AddressField);      // AddressField extends FieldDef
+
+// ❌ WRONG
+@field author = contains(Author);             // NEVER!
+@field address = linksTo(AddressField);       // NEVER!
+```
+
+### MANDATORY TECHNICAL REQUIREMENTS
+
+1. **Always use SEARCH/REPLACE with tracking for .gts files**
+2. **Export ALL CardDef and FieldDef classes inline**
+3. **Never use reserved words as field names**
+4. **Keep computed fields simple and unidirectional**
+5. **No JavaScript in templates**
+6. **Wrap delegated collections with spacing containers**
+
+### TECHNICAL VALIDATION CHECKLIST
+
+Before generating ANY code:
+
+- [ ] SEARCH/REPLACE blocks with tracking markers
+- [ ] Every CardDef field uses `linksTo`/`linksToMany`
+- [ ] Every FieldDef field uses `contains`/`containsMany`
+- [ ] All classes have `export` keyword inline
+- [ ] No reserved words as field names
+- [ ] No duplicate field definitions
+- [ ] Computed fields are simple (no cycles!)
+- [ ] Try-catch blocks wrap cross-card data access
+- [ ] No JavaScript operations in templates
+- [ ] ALL THREE FORMATS: isolated, embedded, fitted
+
+### Glint (ember-tsc) Type Checking Patterns
+
+Boxel type checking (`boxel parse`) runs `ember-tsc` (glint) on all `.gts` and `.ts` files to catch type errors. These patterns avoid common glint failures:
+
+#### Decorators inside inline class assignments
+
+Glint does not support decorators (`@tracked`, etc.) on fields inside an inline class expression assigned to a static property. Declare the component class separately:
+
+```gts
+// ❌ WRONG — "Decorators are not valid here"
+export class StickyNote extends CardDef {
+  static isolated = class Isolated extends Component<typeof StickyNote> {
+    @tracked editMode = false;  // glint error!
+    <template>...</template>
+  };
+}
+
+// ✅ CORRECT — declare the class outside the assignment
+class Isolated extends Component<typeof StickyNote> {
+  @tracked editMode = false;
+  <template>...</template>
+}
+
+export class StickyNote extends CardDef {
+  static isolated = Isolated;
+}
+```
+
+Note: `@field` decorators on `CardDef`/`FieldDef` classes work fine — this restriction only applies to component classes using `@tracked` or similar decorators.
+
+#### Typing dynamic imports in test files
+
+When test files use `loader.import()`, the return type is `{}` by default. Destructuring a named export from it causes "Property does not exist on type '{}'":
+
+```gts
+// ❌ WRONG — "Property 'StickyNote' does not exist on type '{}'"
+let { StickyNote } = await loader.import(cardModuleUrl);
+
+// ✅ CORRECT — cast the import result
+let { StickyNote } = (await loader.import(cardModuleUrl)) as Record<string, any>;
+```
+
+#### Accessing cardInfo properties in computeVia
+
+`CardDef.cardInfo` is a `CardInfoField` (FieldDef) with these fields: `name`, `summary`, `cardThumbnailURL`, `cardThumbnail`, `theme`, `notes`. Access them directly — they are properly typed:
+
+```gts
+// ✅ CORRECT — access cardInfo fields directly (they are typed)
+@field cardTitle = contains(StringField, {
+  computeVia: function (this: MyCard): string {
+    return this.cardInfo?.name?.trim()?.length
+      ? this.cardInfo.name
+      : this.headline ?? 'Untitled';
+  },
+});
+
+// ❌ WRONG — these fields don't exist on CardInfoField
+this.cardInfo.title       // use .name instead
+this.cardInfo.description // use .summary instead
+this.cardInfo.thumbnailURL // use .cardThumbnailURL instead
+```
+
+**Note:** The computed pass-through fields on CardDef are named `cardTitle` (not `title`), `cardDescription` (not `description`), and `cardThumbnailURL`. Override these — not fields named `title`/`description`.
+
+#### Explicit types for function parameters
+
+Glint enforces strict mode. Always type function parameters and return values:
+
+```gts
+// ❌ WRONG — implicit any
+greet = (name) => `Hello, ${name}!`;
+
+// ✅ CORRECT
+greet = (name: string): string => `Hello, ${name}!`;
+```
+
+#### Unused imports from Ember shims
+
+If you import from `@ember/helper`, `@ember/modifier`, or `@glimmer/tracking`, only import what you actually use. Glint enforces `noUnusedLocals` in the type checking configuration. Remove unused imports rather than suppressing the error.
+
+### Common Mistakes
+
+#### Using contains with CardDef
+
+```gts
+// ❌ WRONG
+@field items = containsMany(Item); // Item is CardDef
+
+// ✅ CORRECT
+@field items = linksToMany(Item);
+```
+
+#### Missing Exports
+
+```gts
+// ❌ WRONG
+class BlogPost extends CardDef { }
+
+// ✅ CORRECT
+export class BlogPost extends CardDef { }
+```

--- a/skills/boxel-development/references/dev-template-patterns.md
+++ b/skills/boxel-development/references/dev-template-patterns.md
@@ -1,0 +1,405 @@
+### Template Essentials
+
+#### ⚠️ CRITICAL: Strict Mode — Import Every Helper and Modifier
+
+Boxel `.gts` templates run in **strict mode**. Every helper, modifier, and component used in a `<template>` tag must be explicitly imported at the top of the file. Unlike loose-mode Ember templates, there are no globals — if it's not imported, you get "Attempted to resolve a helper in a strict mode template, but that value was not in scope."
+
+```gts
+// ❌ WRONG — "eq" is not in scope
+<template>{{#if (eq @model.status 'active')}}Active{{/if}}</template>
+
+// ✅ CORRECT — import every helper you use
+import { eq } from '@cardstack/boxel-ui/helpers';
+import { fn } from '@ember/helper';
+import { on } from '@ember/modifier';
+
+// Now these are in scope for the template:
+<template>
+  {{#if (eq @model.status 'active')}}Active{{/if}}
+  <button {{on 'click' (fn this.handleClick @model.id)}}>Click</button>
+</template>
+```
+
+**Common helper imports:**
+
+| Helper/Modifier                                         | Import from                   |
+| ------------------------------------------------------- | ----------------------------- |
+| `eq`, `not`, `or`, `and`, `gt`, `lt`, `subtract`, `add` | `@cardstack/boxel-ui/helpers` |
+| `fn`, `get`, `concat`, `array`, `hash`                  | `@ember/helper`               |
+| `on`                                                    | `@ember/modifier`             |
+| `tracked`                                               | `@glimmer/tracking`           |
+
+**Field access patterns:**
+
+```hbs
+{{@model.title}}
+<!-- Raw data -->
+<@fields.title />
+<!-- Field's template -->
+<@fields.phone @format='atom' />
+<!-- Compound field -->
+<@fields.items @format='embedded' />
+<!-- Auto-collection -->
+```
+
+For theming, CSS variables, spacing scales, and CSS safety rules, see Module 3: Theme-First Design System.
+
+#### ⚠️ CRITICAL: @model Iteration vs @fields Delegation
+
+**Once you iterate with @model, you CANNOT delegate to @fields within that iteration.**
+
+```hbs
+<!-- ❌ BREAKS: Mixing @model iteration with @fields delegation -->
+{{#each @model.teamMembers as |member|}}
+  <@fields.member @format='embedded' />
+  <!-- NO ACCESS to @fields.member -->
+{{/each}}
+
+<!-- ✅ OPTION 1: Use delegated rendering for the whole collection -->
+<@fields.teamMembers @format='embedded' />
+
+<!-- ✅ OPTION 2: Commit to full @model control -->
+{{#each @model.teamMembers as |member|}}
+  <div class='custom-member'>{{member.name}}</div>
+{{/each}}
+
+<!-- ✅ OPTION 3: If filtering needed, use query patterns -->
+<!-- Use PrerenderedCardSearch or getCards for filtered collections -->
+```
+
+**Why this breaks:** @fields provides field-level components. Once you're iterating with @model, you're working with raw data, not field components.
+
+**Decision Rule:** Before iterating, decide:
+
+- Need composability? → Use delegated rendering
+- Need filtering? → Use query patterns (PrerenderedCardSearch/getCards)
+- Need custom control? → Use @model but handle ALL rendering yourself
+
+### Accessing @fields by Index: The Bridge Pattern
+
+**Use Case:** You need to use `@model` data to find specific items in a `containsMany` or `linksToMany` collection, then render those items using their field templates for proper delegated rendering.
+
+**Key Concept:** The `get` helper allows you to access `@fields` array elements by index, creating a bridge between data-driven iteration and component-based rendering.
+
+#### When to Use This Pattern
+
+- **Filtering:** Show only items matching certain criteria
+- **Conditional rendering:** Display items based on model data
+- **Custom ordering:** Reorder items based on computed logic
+- **Highlighted selection:** Emphasize specific items in a collection
+
+#### Basic Pattern
+
+```hbs
+{{! Access a specific field by index }}
+{{#let (get @fields.shoppingList 0) as |firstItem|}}
+  {{#if firstItem}}
+    <firstItem @format='embedded' />
+  {{else}}
+    <div class='no-item'>No first item</div>
+  {{/if}}
+{{/let}}
+
+{{! Access last item using subtract helper }}
+{{#let (get @fields.items (subtract @model.items.length 1)) as |lastItem|}}
+  {{#if lastItem}}
+    <lastItem @format='fitted' />
+  {{/if}}
+{{/let}}
+```
+
+#### Displaying Compound Fields
+
+**CRITICAL:** When displaying compound fields (FieldDef types) like `PhoneNumberField`, `AddressField`, or custom field definitions, you must use their format templates, not raw model access:
+
+```hbs
+<!-- ❌ WRONG: Shows [object Object] -->
+<p>Phone: {{@model.phone}}</p>
+
+<!-- ✅ CORRECT: Uses the field's atom format -->
+<p>Phone: <@fields.phone @format='atom' /></p>
+
+<!-- ✅ CORRECT: For full field display -->
+<div class='contact-info'>
+  <@fields.phone @format='embedded' />
+</div>
+```
+
+**💡 Line-saving tip:** Keep self-closing tags compact:
+
+```hbs
+<!-- Good: Saves vertical space -->
+<@fields.author @format='embedded' />
+<@fields.phone @format='atom' />
+```
+
+#### @fields Delegation Rule
+
+**CRITICAL:** When delegating to embedded/fitted formats, you must iterate through `@fields`, not `@model`. Always use `@fields` for delegation, even for singular fields.
+
+```hbs
+<!-- ✅ CORRECT: Using @fields for both singular and collection fields -->
+<@fields.author @format='embedded' />
+<@fields.items @format='embedded' />
+{{#each @fields.items as |item|}}
+  <item @format='embedded' />
+{{/each}}
+
+<!-- ❌ WRONG: Can't iterate @model then try to delegate to @fields -->
+{{#each @model.items as |item|}}
+  <@fields.??? @format='embedded' />
+  <!-- This won't work -->
+{{/each}}
+```
+
+**containsMany Spacing Pattern:** Due to an additional wrapper div, target `.containsMany-field`:
+
+```css
+/* For grids */
+.products-grid > .containsMany-field {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+/* For lists */
+.items-list > .containsMany-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+```
+
+### Template Fallback Value Patterns
+
+**CRITICAL:** Boxel cards boot with no data by default. Templates must gracefully handle null, undefined, and empty string values at ALL levels of data access to prevent runtime errors and provide meaningful visual fallbacks.
+
+#### Three Primary Patterns for Fallbacks
+
+**1. Inline if/else (for simple display fallbacks):**
+
+```hbs
+<span>{{if
+    @model.eventTime
+    (formatDateTime @model.eventTime 'MMM D, h:mm A')
+    'Event time to be announced'
+  }}</span>
+<h2>{{if @model.title @model.title 'Untitled Document'}}</h2>
+<p>Status: {{if @model.status @model.status 'Status pending'}}</p>
+```
+
+**2. Block-based if/else (for complex content):**
+
+```hbs
+<div class='event-time'>
+  {{#if @model.eventTime}}
+    <strong>{{formatDateTime @model.eventTime 'MMM D, h:mm A'}}</strong>
+  {{else}}
+    <em class='placeholder'>Event time to be announced</em>
+  {{/if}}
+</div>
+
+{{#if @model.description}}
+  <div class='description'>
+    <@fields.description />
+  </div>
+{{else}}
+  <div class='empty-description'>
+    <p>No description provided yet. Click to add one.</p>
+  </div>
+{{/if}}
+```
+
+**3. Unless for safety/validation checks (composed with other helpers):**
+
+```hbs
+{{unless
+  (and @model.isValid @model.hasPermission)
+  '⚠️ Cannot proceed - missing validation or permission'
+}}
+{{unless (or @model.email @model.phone) 'Contact information required'}}
+{{unless (gt @model.items.length 0) 'No items available'}}
+{{unless (eq @model.status 'active') 'Service unavailable'}}
+```
+
+**Best Practices:** Use descriptive placeholder text rather than generic "N/A", style placeholder text differently (lighter color, italic), use `unless` for safety checks and `if` for display fallbacks.
+
+**Icon Usage:** Avoid emoji in templates (unless the application specifically calls for it) due to OS/platform variations that cause legibility issues. Use Boxel icons only for static card/field type icons (`static icon` property). In templates, use inline SVG instead since we can't be sure which Boxel icons exist.
+
+### Template Array Handling Patterns
+
+**CRITICAL:** Templates must gracefully handle all array states to prevent errors. Arrays can be undefined, null, empty, or populated.
+
+#### The Three Array States
+
+Your templates must handle:
+
+1. **Completely undefined arrays** - Field doesn't exist or is null
+2. **Empty arrays** - Field exists but has no items (`[]`)
+3. **Arrays with actual data** - Field has one or more items
+
+#### Array Logic Pattern
+
+**❌ WRONG - Only checks for existence:**
+
+```hbs
+{{#if @model.goals}}
+  <ul class='goals-list'>
+    {{#each @model.goals as |goal|}}
+      <li>{{goal}}</li>
+    {{/each}}
+  </ul>
+{{/if}}
+```
+
+**✅ CORRECT - Checks for length and provides empty state:**
+
+```hbs
+{{#if @model.goals.length}}
+  <div class='goals-section'>
+    <h4>
+      <svg
+        width='16'
+        height='16'
+        class='section-icon'
+        viewBox='0 0 24 24'
+        fill='none'
+        stroke='currentColor'
+        stroke-width='2'
+      >
+        <circle cx='12' cy='12' r='10' />
+        <circle cx='12' cy='12' r='6' />
+        <circle cx='12' cy='12' r='2' />
+      </svg>
+      Daily Goals
+    </h4>
+    <ul class='goals-list'>
+      {{#each @model.goals as |goal|}}
+        <li>{{goal}}</li>
+      {{/each}}
+    </ul>
+  </div>
+{{else}}
+  <div class='goals-section'>
+    <h4>
+      <svg
+        width='16'
+        height='16'
+        class='section-icon'
+        viewBox='0 0 24 24'
+        fill='none'
+        stroke='currentColor'
+        stroke-width='2'
+      >
+        <circle cx='12' cy='12' r='10' />
+        <circle cx='12' cy='12' r='6' />
+        <circle cx='12' cy='12' r='2' />
+      </svg>
+      Daily Goals
+    </h4>
+    <p class='empty-state'>No goals set yet. What would you like to accomplish?</p>
+  </div>
+{{/if}}
+```
+
+**Remember:** When implementing templates via SEARCH/REPLACE, include tracking markers ⁿ for style blocks
+
+### Real-World Example: Shopping List with Featured Items
+
+```gts
+import {
+  CardDef,
+  FieldDef,
+  field,
+  contains,
+  containsMany,
+  Component,
+} from 'https://cardstack.com/base/card-api';
+import StringField from 'https://cardstack.com/base/string';
+import NumberField from 'https://cardstack.com/base/number';
+import { get } from '@ember/helper';
+import { subtract } from '@cardstack/boxel-ui/helpers';
+
+export class FruitItem extends FieldDef {
+  static displayName = 'Fruit';
+  @field title = contains(StringField);
+  @field quantity = contains(NumberField);
+
+  static embedded = class Embedded extends Component<typeof this> {
+    <template>
+      <div class='fruit-item'>
+        <span>{{if @model.title @model.title 'Unknown'}}</span>
+        <span>{{if @model.quantity @model.quantity 0}} units</span>
+      </div>
+    </template>
+  };
+}
+
+export class ShoppingList extends CardDef {
+  static displayName = 'Shopping List';
+  @field items = containsMany(FruitItem);
+
+  static isolated = class Isolated extends Component<typeof this> {
+    <template>
+      <article>
+        <h1>{{@model.title}}</h1>
+
+        {{! Show first and last items using get helper }}
+        <section class='featured'>
+          <h2>First Item</h2>
+          {{#let (get @fields.items 0) as |item|}}
+            {{#if item}}
+              <item @format='embedded' />
+            {{else}}
+              <p>No items</p>
+            {{/if}}
+          {{/let}}
+
+          <h2>Last Item</h2>
+          {{#let
+            (get @fields.items (subtract @model.items.length 1))
+            as |item|
+          }}
+            {{#if item}}
+              <item @format='embedded' />
+            {{/if}}
+          {{/let}}
+        </section>
+
+        {{! Full list }}
+        <section>
+          <h2>All Items</h2>
+          {{#if @model.items.length}}
+            <@fields.items @format='embedded' class='items-container' />
+          {{else}}
+            <p>No items</p>
+          {{/if}}
+        </section>
+      </article>
+
+      <style scoped>
+        .items-container {
+          gap: var(--boxel-sp-2xs);
+        }
+      </style>
+    </template>
+  };
+}
+```
+
+#### Important Notes
+
+**CRITICAL Safety Checks:**
+
+- Always wrap `get` results in `{{#if}}` to handle undefined indices
+- Use `subtract` helper for negative indexing (e.g., last item)
+- Validate array length before accessing by index
+
+**When NOT to Use:**
+
+- If you need to iterate all items → use `<@fields.items />` delegation
+- If you need custom rendering for each → use `{{#each @model.items}}` pattern
+- For simple filtering → use query patterns with PrerenderedCardSearch
+
+**Performance Consideration:**
+The `get` helper is efficient for accessing specific indices. For complex filtering or transformation, consider using query patterns or computed properties instead.

--- a/skills/boxel-development/references/dev-theme-design-system.md
+++ b/skills/boxel-development/references/dev-theme-design-system.md
@@ -1,0 +1,520 @@
+### Theme-First Principle
+
+- Always link a Theme before generating code or styling. (See 3.1 Theme Linking Rules)
+- All CSS in card templates must use theme variables (no hardcoded colors/spacing/fonts). (See 3.2 Canonical Theme Variables)
+- Theme linkage lives at `relationships.cardInfo.theme` on the card instance.
+
+### 3.1 Theme Linking Rules
+
+- Set this as the Default Theme for all new, non-ThemeCard instances:
+
+```json
+"relationships": {
+  "cardInfo.theme": {
+    "links": {
+      "self": "https://cardstack.com/base/Theme/cardstack-brand-guide"
+    }
+  }
+}
+```
+
+- You must also set the remaining cardInfo properties in the card data attributes. Example:
+
+```json
+"attributes": {
+  "cardInfo": {
+    "notes": null,
+    "name": "[card title here]",
+    "summary": "[brief card description here]",
+    "cardThumbnailURL": "[card thumbnail url here]"
+  },
+}
+```
+
+- IMPORTANT: Never set `cardInfo.theme` on ThemeCards (cards adopting from `https://cardstack.com/base/theme/default` or its subclasses) to avoid cycles.
+
+#### ThemeCard Types
+
+A ThemeCard is an instance of a card definition that inherits from `https://cardstack.com/base/theme/default` or from one of its subclasses.
+
+| Type                     | URL                                                           | Description                                                                                  |
+| ------------------------ | ------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| Base Theme               | `https://cardstack.com/base/theme/default`                    | Root base class                                                                              |
+| Structured Theme         | `https://cardstack.com/base/structured-theme/default`         | MINIMUM template — includes all theme variables (except Brand variables)                     |
+| Style Reference          | `https://cardstack.com/base/style-reference/default`          | Extends `StructuredTheme` — adds fields for inspiration images, terms, and style description |
+| Detailed Style Reference | `https://cardstack.com/base/detailed-style-reference/default` | **PREFERRED** — extends `StyleReference` with detailed design system description             |
+| Brand Guide              | `https://cardstack.com/base/brand-guide/default`              | Extends `DetailedStyleReference` — adds brand-specific variables for colors and typography   |
+
+> **When creating a Theme card:** Prefer `DetailedStyleReference`. At minimum, fill in `rootVariables` and `typography`. Add font URLs to `cssImports` as a string array — no `@import` needed (the system handles imports).
+
+### 3.2 Canonical Theme Variables
+
+Use the variables directly (do not wrap with `hsl(var(...))`). Pair backgrounds with their foregrounds for contrast.
+
+Our design system is compatible with shadcn css variables.
+
+- Background Colors:
+
+```css
+--background
+--card
+--popover
+--primary
+--secondary
+--muted
+--accent
+--destructive
+--input
+--sidebar
+--sidebar-primary
+--sidebar-accent
+```
+
+- Foreground Colors:
+
+```css
+--foreground
+--card-foreground
+--popover-foreground
+--primary-foreground
+--secondary-foreground
+--muted-foreground
+--accent-foreground
+--destructive-foreground
+--sidebar-foreground
+--sidebar-primary-foreground
+--sidebar-accent-foreground
+```
+
+- Border Colors:
+
+```css
+--border
+--sidebar-border
+```
+
+- Css Outline Colors:
+
+```css
+--ring
+--sidebar-ring
+```
+
+- Chart Colors:
+
+```css
+--chart-1
+--chart-2
+--chart-3
+--chart-4
+--chart-5
+```
+
+- Fonts: (`font-family`)
+
+```css
+--font-sans
+--font-serif
+--font-mono
+```
+
+- Radius: (`border-radius`)
+
+```css
+--radius
+--boxel-border-radius-xxs
+--boxel-border-radius-xs
+--boxel-border-radius-sm
+--boxel-border-radius
+--boxel-border-radius-lg
+--boxel-border-radius-xl
+--boxel-border-radius-xxl
+```
+
+- Spacing:
+
+```css
+--spacing
+--boxel-sp-6xs
+--boxel-sp-5xs
+--boxel-sp-4xs
+--boxel-sp-3xs
+--boxel-sp-2xs
+--boxel-sp-xs
+--boxel-sp-sm
+--boxel-sp
+--boxel-sp-lg
+--boxel-sp-xl
+--boxel-sp-2xl
+--boxel-sp-3xl
+--boxel-sp-4xl
+--boxel-sp-5xl
+--boxel-sp-6xl
+```
+
+- Letter-spacing:
+
+```css
+--tracking-normal
+--boxel-lsp-xxl
+--boxel-lsp-xl
+--boxel-lsp-lg
+--boxel-lsp
+--boxel-lsp-sm
+--boxel-lsp-xs
+--boxel-lsp-xxs
+```
+
+- Shadows: (`box-shadow`)
+
+```css
+--shadow-2xs
+--shadow-xs
+--shadow-sm
+--shadow
+--shadow-md
+--shadow-lg
+--shadow-xl
+--shadow-2xl
+--boxel-box-shadow
+--boxel-box-shadow-hover
+--boxel-deep-box-shadow
+```
+
+- Font Sizes: (`font-size`)
+
+```css
+--boxel-font-size-2xl
+--boxel-font-size-xl
+--boxel-font-size-lg
+--boxel-font-size-md
+--boxel-font-size
+--boxel-font-size-sm
+--boxel-font-size-xs
+--boxel-heading-font-size
+--boxel-section-heading-font-size
+--boxel-subheading-font-size
+--boxel-body-font-size
+--boxel-caption-font-size
+```
+
+#### CSS Usage Examples:
+
+✅ Correct:
+
+```css
+background-color: var(--card);
+color: var(--card-foreground);
+border-color: var(--border);
+font-family: var(--font-serif);
+border-radius: var(--radius);
+padding: var(--spacing);
+margin-top: calc(var(--spacing) * 2);
+box-shadow: var(--shadow-lg);
+```
+
+❌ Incorrect:
+
+```css
+background-color: hsl(var(--background)); /* DO NOT wrap in hsl() */
+```
+
+### CSS Safety (All Formats)
+
+- Always use `<style scoped>`; only `/* */` comments (never `//`).
+- No global selectors (`:root`, `body`, `html`). Define variables at component root.
+- Conservative z-index (< 10). No fixed overlays beyond card bounds.
+- Prefer inline SVG; always avoid `url(#id)` in SVG.
+
+### Format Responsibilities (Theming-Aware)
+
+- Isolated: comfortable reading; scrollable surface; theme tokens for padding/typography.
+- Embedded: parent may clamp height; child respects theme tokens.
+- Fitted: no borders or border-radius (parent draws chrome); internal layout uses theme spacing/typography.
+- Spacing for collections: `.container > .containsMany-field { gap: var(--boxel-sp); }`
+
+### Sample Themed Template
+
+```gts
+<template>
+  <article class='my-card' aria-labelledby='mc-title'>
+    <header class='mc-header'>
+      <h1 class='mc-title' id='mc-title'><@fields.cardTitle /></h1>
+      <p class='mc-summary'><@fields.cardDescription /></p>
+    </header>
+
+    <div class='mc-body'>
+      <div class='mc-main'>
+        <section aria-labelledby='mc-section-1'>
+          <h2 class='mc-section-heading' id='mc-section-1'>Section 1 Title</h2>
+          <p class='mc-prose'>Paragraph</p>
+          <ul class='items-grid'>
+            <li class='section-item'>
+              <h3 class='item-title'>Item 1</h3>
+              <p class='item-content'>Item 1 content</p>
+            </li>
+            <li class='section-item'>
+              <h3 class='item-title'>Item 2</h3>
+              <p class='item-content'>Item 2 content</p>
+            </li>
+            <li class='section-item'>
+              <h3 class='item-title'>Item 3</h3>
+              <p class='item-content'>Item 3 content</p>
+            </li>
+          </ul>
+        </section>
+        <section aria-labelledby='mc-section-2'>
+          <h2 class='mc-section-heading' id='mc-section-2'>Section 2 Title</h2>
+          <p class='mc-prose'>Paragraph</p>
+        </section>
+      </div>
+
+      <aside class='mc-sidebar'>
+        <section class='sidebar-section' aria-labelledby='sidebar-heading-1'>
+          <h2 class='sidebar-heading' id='sidebar-heading-1'>Sidebar Title 1</h2>
+          <ul class='sidebar-list'>
+            <li class='sidebar-item'>
+              <span>Sidebar item 1</span>
+            </li>
+            <li class='sidebar-item'>
+              <span>Sidebar item 2</span>
+            </li>
+            <li class='sidebar-item'>
+              <span>Sidebar item 3</span>
+            </li>
+          </ul>
+        </section>
+
+        <section class='sidebar-section' aria-labelledby='sidebar-heading-2'>
+          <h2 class='sidebar-heading' id='sidebar-heading-2'>Sidebar Title 2</h2>
+          <dl class='sidebar-dl'>
+            <div class='sidebar-dl-row'>
+              <dt>Sidebar item 1</dt>
+              <dd>Content</dd>
+            </div>
+            <div class='sidebar-dl-row'>
+              <dt>Sidebar item 2</dt>
+              <dd>Content</dd>
+            </div>
+          </dl>
+        </section>
+      </aside>
+    </div>
+
+    <footer class='mc-footer'>
+      <p>Footer text</p>
+      <nav aria-label='Footer links'>
+        <ul class='footer-links'>
+          <li><a href='#'>Link 1</a></li>
+          <li><a href='#'>Link 2</a></li>
+          <li><a href='#'>Link 3</a></li>
+        </ul>
+      </nav>
+    </footer>
+  </article>
+  <style scoped>
+    .my-card {
+      container-type: inline-size;
+      height: 100%;
+      overflow-y: auto;
+      padding: var(--boxel-sp-xl);
+      background-color: var(--background);
+      color: var(--foreground);
+      display: flex;
+      flex-direction: column;
+      gap: var(--boxel-sp-lg);
+      box-sizing: border-box;
+    }
+
+    /* Header */
+    .mc-header {
+      display: flex;
+      flex-direction: column;
+      gap: var(--boxel-sp-xs);
+      border-bottom: 1px solid var(--border);
+      padding-bottom: var(--boxel-sp-lg);
+    }
+    .mc-title {
+      font-size: var(--boxel-font-size-xl);
+      font-weight: 700;
+      letter-spacing: var(--boxel-lsp-xs);
+      margin: 0;
+    }
+    .mc-summary {
+      font-size: var(--boxel-font-size-sm);
+      line-height: var(--boxel-line-height-sm);
+      color: var(--muted-foreground);
+      margin: 0;
+    }
+
+    /* Body: main + sidebar */
+    .mc-body {
+      display: grid;
+      grid-template-columns: 1fr 16rem;
+      gap: var(--boxel-sp-lg);
+      align-items: start;
+    }
+
+    /* Main column */
+    .mc-main {
+      display: flex;
+      flex-direction: column;
+      gap: var(--boxel-sp-xl);
+    }
+    .mc-main section {
+      display: flex;
+      flex-direction: column;
+      gap: var(--boxel-sp-sm);
+    }
+    .mc-prose {
+      font-size: var(--boxel-font-size-sm);
+      line-height: var(--boxel-line-height);
+      color: var(--foreground);
+      margin: 0;
+    }
+    .mc-section-heading {
+      font-size: var(--boxel-font-size-lg);
+      font-weight: 600;
+      margin: 0;
+    }
+
+    /* Items grid */
+    .items-grid {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(12rem, 1fr));
+      gap: var(--boxel-sp);
+    }
+    .section-item {
+      display: flex;
+      flex-direction: column;
+      gap: var(--boxel-sp-xs);
+      background-color: var(--card);
+      color: var(--card-foreground);
+      padding: var(--boxel-sp);
+      border: 1px solid var(--border);
+      border-radius: var(--boxel-border-radius);
+      box-shadow: var(--shadow);
+    }
+    .item-title {
+      font-size: var(--boxel-font-size-sm);
+      font-weight: 600;
+      margin: 0;
+    }
+    .item-content {
+      font-size: var(--boxel-font-size-xs);
+      color: var(--muted-foreground);
+      margin: 0;
+      line-height: var(--boxel-line-height-sm);
+    }
+
+    /* Sidebar */
+    .mc-sidebar {
+      display: flex;
+      flex-direction: column;
+      gap: var(--boxel-sp);
+      background-color: var(--sidebar);
+      color: var(--sidebar-foreground);
+      border: 1px solid var(--sidebar-border);
+      border-radius: var(--boxel-border-radius);
+      padding: var(--boxel-sp);
+    }
+    .sidebar-section {
+      display: flex;
+      flex-direction: column;
+      gap: var(--boxel-sp-xs);
+    }
+    .sidebar-section + .sidebar-section {
+      border-top: 1px solid var(--sidebar-border);
+      padding-top: var(--boxel-sp);
+    }
+    .sidebar-heading {
+      font-size: var(--boxel-font-size-xs);
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: var(--boxel-lsp-lg);
+      margin: 0;
+    }
+    .sidebar-list {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: flex;
+      flex-direction: column;
+      gap: var(--boxel-sp-5xs);
+    }
+    .sidebar-item {
+      display: flex;
+      align-items: center;
+      gap: var(--boxel-sp-5xs);
+      font-size: var(--boxel-font-size-sm);
+    }
+
+    /* Definition list */
+    .sidebar-dl {
+      display: flex;
+      flex-direction: column;
+      gap: var(--boxel-sp-5xs);
+      margin: 0;
+    }
+    .sidebar-dl-row {
+      display: flex;
+      justify-content: space-between;
+      font-size: var(--boxel-font-size-xs);
+    }
+    .sidebar-dl-row dt {
+      color: var(--muted-foreground);
+    }
+    .sidebar-dl-row dd {
+      margin: 0;
+      font-weight: 500;
+    }
+
+    /* Footer */
+    .mc-footer {
+      border-top: 1px solid var(--border);
+      padding-top: var(--boxel-sp-sm);
+      font-size: var(--boxel-font-size-xs);
+      color: var(--muted-foreground);
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      justify-content: center;
+      gap: var(--boxel-sp-xs);
+    }
+    .mc-footer p {
+      font-size: inherit;
+      margin: 0;
+    }
+    .footer-links {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: flex;
+      align-items: center;
+      gap: 0;
+    }
+    .footer-links li + li::before {
+      content: '·';
+      margin-inline: var(--boxel-sp-xs);
+    }
+    .mc-footer a {
+      color: var(--muted-foreground);
+      text-decoration: underline;
+      text-underline-offset: 2px;
+    }
+    .mc-footer a:hover {
+      color: var(--foreground);
+    }
+
+    /* Responsive: stack on narrow containers */
+    @container (max-width: 600px) {
+      .mc-body {
+        grid-template-columns: 1fr;
+      }
+    }
+  </style>
+</template>
+```

--- a/skills/boxel-ui-component-discovery/SKILL.md
+++ b/skills/boxel-ui-component-discovery/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: boxel-ui-component-discovery
+description: MANDATORY before writing any UI in a `.gts` template. Search the catalog for a boxel-ui component Spec and reuse it. Fall back to raw HTML only when no matching spec exists, and surface the gap when you do.
+boxel:
+  kind: skill
+---
+
+# Boxel UI Component Discovery
+
+## Mandatory rule
+
+Before you write any UI in a `.gts` template — anything you'd describe
+as a UI primitive (button, input, dropdown, modal, tooltip, pill, menu,
+accordion, …) — **you must first search the catalog for an existing
+boxel-ui component Spec and reuse it.**
+
+- A matching spec exists → import it via `attributes.ref` and follow
+  the API table in `attributes.readMe`. No raw `<button>`, `<input>`,
+  `<textarea>`, `<select>`, `<details>`, etc. Visual styling — even
+  unconventional aesthetics — is never a reason to drop down to raw
+  HTML. Restyle via the component's documented CSS-variable surface.
+- No spec matches → write minimal idiomatic HTML and record the gap
+  where your workflow keeps notes (tell the user, or note it on the
+  task you are working), so the gap is visible. Don't invent a
+  `@cardstack/boxel-ui/components` import that wasn't in the search
+  results — names not present in the catalog don't exist for your
+  purposes.
+
+This rule is intentionally not a fixed HTML→component mapping. The
+catalog's inventory changes over time and the spec readMe is the source
+of truth for what's available and what each component is called.
+
+## Procedure
+
+1. **Enumerate first.** Before any search, read the brief and your
+   planned template and list every UI primitive it implies — in plain
+   language ("button", "dropdown", "tag-style indicator", "expandable
+   section"). The partial-compliance failure mode is "agent finds one
+   match, uses it, hand-rolls everything else" — enumerating up front
+   prevents it.
+
+2. **Query the catalog once, broadly.** Use the catalog realm for the
+   environment you are working against — take it from your context if
+   one is provided, otherwise check `boxel realm ls` or ask; do not
+   invent a host.
+
+   ```sh
+   boxel search --realm <catalog-realm-url> --query '{
+     "filter": {
+       "item.on": { "module": "https://cardstack.com/base/spec", "name": "Spec" },
+       "eq":      { "item.specType": "component" }
+     }
+   }' --json
+   ```
+
+   One broad query returns the full inventory (~50 specs). Match each
+   item in your enumeration to a result by reading `attributes.cardTitle`
+   and `attributes.cardDescription`. Narrow with `contains` on the title
+   or `matches` (full-text over the readMe) if the inventory is large
+   enough to be noisy. See `boxel-api` for full query syntax.
+
+3. **Read each chosen spec's `attributes.readMe`** — it has the Import
+   line, the API table (arg / type / required / default / options /
+   description), an example snippet, and CSS variables. The readMe
+   rides on the search response; no follow-up fetch needed.
+
+4. **Use the components.** Translate each `attributes.ref` to an
+   import line directly (the `Import` section of the readMe gives you
+   the exact statement). Copy the example as a template and substitute
+   your own args following the API table. Required args must be
+   present; defaults are listed for every optional arg.
+
+## Self-audit before finishing
+
+Re-read your finished template. For each interactive or form-shaped
+HTML element it contains, ask: would I have searched the catalog for
+this if I were writing it from scratch? If yes, did I? Replace any raw
+HTML primitive that has a spec'd equivalent, re-run lint/parse, and
+only then call it done. Raw `<input>` / `<select>` / `<details>` lint
+and parse clean — only this audit catches them.

--- a/skills/boxel-workspace-cardinal-rules/SKILL.md
+++ b/skills/boxel-workspace-cardinal-rules/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: boxel-workspace-cardinal-rules
+description: Silent-failure traps in Boxel card authoring — rules that pass lint and often indexing, then corrupt the realm index, crash at render, or drop data with no error (DateField vs DateTimeField formats, external URLs in relationship links, and more). Check every card and field against this list before finishing.
+boxel:
+  kind: skill
+---
+
+# Boxel cardinal rules — silent-failure traps
+
+Rules discovered the hard way in a downstream Boxel workspace: each one passes lint and
+often passes indexing too, then breaks silently — corrupting the realm's index,
+crashing at render, or dropping data with no error. Check every card/field you write
+against this list before finishing an issue.
+
+## 1. DateField vs DateTimeField value format
+
+`DateField` values are `YYYY-MM-DD` (no `T`). `DateTimeField` values are full ISO
+datetimes (`2026-07-16T14:30:00.000Z`, with `T`). Putting a datetime string in a
+`DateField` (or vice versa) passes lint and indexes fine, then **crashes at render**
+with `RangeError: Invalid time value` when a user actually opens the card. Naming
+convention to follow when picking the field type: a `*At` suffix (`createdAt`,
+`publishedAt`) means `DateTimeField`; a `*Date`/`*On` suffix or bare `dob` means
+`DateField`.
+
+## 2. Never put an external URL in `relationships.<field>.links.self`
+
+If a `linksTo`/`linksToMany` field's JSON `links.self` points at a URL the indexer
+can't parse as a card (an external website, an image CDN URL, anything not a card
+resource), **the failed parse poisons the JSONB write and rolls back the WHOLE
+REALM's indexing transaction** — every other file in the same push silently fails to
+index too, with no error pointing at the actual bad file. For an external image/URL,
+use the pair pattern instead: `linksTo(ImageDef)` (or a similar file/media field) +
+`contains(UrlField)` as two separate fields, never one relationship pointing straight
+at an external URL.
+
+## 3. `linksToMany` JSON uses indexed top-level keys, never an array
+
+Correct:
+
+```json
+"relationships": {
+  "items.0": { "links": { "self": "../foo" } },
+  "items.1": { "links": { "self": "../bar" } }
+}
+```
+
+Wrong (rejected outright — "instance ... is not a card resource document"):
+
+```json
+"relationships": {
+  "items": { "links": { "self": ["../foo", "../bar"] } }
+}
+```
+
+## 4. Never inline media or binary bytes in card JSON
+
+No `data:` URIs, `blob:` URIs, base64, or raw media bytes in any JSON string field or
+attribute. Store media as a realm file linked via `linksTo(FileDef)` (or a FileDef
+subtype: `ImageDef`, `CsvFileDef`, etc.) instead — never embed the bytes directly in
+the instance JSON.
+
+## 5. Every query needs a realm scope, and don't start it before the realm is known
+
+A card-owned query with a missing or empty `realm` argument silently falls back to
+searching **every realm the server can see**, not just the current one. Always scope
+queries to the current card's own realm, and don't kick off the query before that
+realm URL is actually resolved. Cap general-purpose result sets (~100) rather than
+pulling unbounded result sets.
+
+## 6. Query-filter shape: `type` selects instances, `on` only scopes predicates
+
+To select every instance of a type, filter on `{ type: <ref> }` directly — never wrap
+it in `{ on: <ref> }` alone (`on` only scopes _other_ predicates like `eq`/`contains`;
+a bare `{ on: ref }` with nothing else matches nothing). Build refs with a `codeRef()`
+helper, not a manually-constructed object.
+
+## 7. Don't push more than ~30 files through one atomic batch to a fresh realm
+
+Large atomic pushes (30+ files via a single bulk-write endpoint) can report success
+while silently dropping some files' indexing jobs. For bulk kit/asset installs, push
+in smaller batches and verify each batch's expected file count actually shows up in a
+realm search before pushing the next batch.
+
+## 8. NEVER curl / HTTP-GET a `https://cardstack.com/base/*` module URL to inspect a base card
+
+Base card module URLs (`https://cardstack.com/base/theme`, `.../base/card-api`,
+`.../base/cards/structured-theme`, etc.) are **loader-resolved module references, not
+fetchable HTTP resources.** `cardstack.com` is a marketing site — a direct GET or a
+realm op (`_mtimes`, `boxel file read`) against `cardstack.com/base/...` returns a
+generic Webflow **404 HTML page** (`data-wf-domain=... %%PUBLISH_URL_REPLACEMENT%%`),
+NOT the card. Do not keep retrying it — that page will never become the schema. To
+learn a base card's fields/shape, use the **`get_card_schema` tool** (it resolves
+through the realm server), or read an existing instance of that card already in the
+target realm. Same rule for any published `*.boxel.site` / `*.boxel.build` URL: those
+are Webflow-published sites, not realms — never point realm operations at them.
+
+Also: many base cards are **default exports**, so the schema ref is `name: "default"`,
+NOT the class name. The base **Theme** card is the default export of
+`https://cardstack.com/base/theme` (the module is `export default Theme`) — query it as
+module `https://cardstack.com/base/theme`, name `default` (querying `#Theme` fails).
+`StructuredTheme` is likewise the default export of `base/structured-theme`. When a
+`get_card_schema` call fails with "named export is a CardDef", retry with `name:
+"default"` before assuming the card is unreachable — do NOT fall back to curling the URL.

--- a/skills/ember-best-practices/AGENTS.md
+++ b/skills/ember-best-practices/AGENTS.md
@@ -1,0 +1,8579 @@
+# Ember Best Practices
+
+**Version 1.0.0**  
+Ember.js Community  
+January 2026
+
+> **Note:**  
+> This document is mainly for agents and LLMs to follow when maintaining,  
+> generating, or refactoring Ember.js codebases. Humans  
+> may also find it useful, but guidance here is optimized for automation  
+> and consistency by AI-assisted workflows.
+
+---
+
+## Abstract
+
+Comprehensive performance optimization and accessibility guide for Ember.js applications, designed for AI agents and LLMs. Contains 42 rules across 7 categories, prioritized by impact from critical (route loading optimization, build performance) to advanced patterns (Resources, ember-concurrency, modern testing, composition patterns, owner/linkage management). Each rule includes detailed explanations, real-world examples comparing incorrect vs. correct implementations, and specific impact metrics to guide automated refactoring and code generation. Uses WarpDrive for modern data management, includes accessibility best practices leveraging ember-a11y-testing and other OSS tools, and comprehensive coverage of reactive composition, data derivation, controlled forms, conditional rendering, data requesting patterns, built-in helpers, and service architecture patterns.
+
+---
+
+## Table of Contents
+
+1. [Route Loading and Data Fetching](#1-route-loading-and-data-fetching) — **CRITICAL**
+   - 1.1 [Implement Smart Route Model Caching](#11-implement-smart-route-model-caching)
+   - 1.2 [Parallel Data Loading in Model Hooks](#12-parallel-data-loading-in-model-hooks)
+   - 1.3 [Use Loading Substates for Better UX](#13-use-loading-substates-for-better-ux)
+   - 1.4 [Use Route Templates with Co-located Syntax](#14-use-route-templates-with-co-located-syntax)
+   - 1.5 [Use Route-Based Code Splitting](#15-use-route-based-code-splitting)
+2. [Build and Bundle Optimization](#2-build-and-bundle-optimization) — **CRITICAL**
+   - 2.1 [Avoid Importing Entire Addon Namespaces](#21-avoid-importing-entire-addon-namespaces)
+   - 2.2 [Lazy Load Heavy Dependencies](#22-lazy-load-heavy-dependencies)
+   - 2.3 [Use Embroider Build Pipeline](#23-use-embroider-build-pipeline)
+3. [Component and Reactivity Optimization](#3-component-and-reactivity-optimization) — **HIGH**
+   - 3.1 [Avoid Constructors in Components](#31-avoid-constructors-in-components)
+   - 3.2 [Avoid CSS Classes in Learning Examples](#32-avoid-css-classes-in-learning-examples)
+   - 3.3 [Avoid Legacy Lifecycle Hooks (did-insert, will-destroy, did-update)](#33-avoid-legacy-lifecycle-hooks-did-insert-will-destroy-did-update)
+   - 3.4 [Avoid Unnecessary Tracking](#34-avoid-unnecessary-tracking)
+   - 3.5 [Build Reactive Chains with Dependent Getters](#35-build-reactive-chains-with-dependent-getters)
+   - 3.6 [Component File Naming and Export Conventions](#36-component-file-naming-and-export-conventions)
+   - 3.7 [Prefer Named Exports, Fallback to Default for Implicit Template Lookup](#37-prefer-named-exports-fallback-to-default-for-implicit-template-lookup)
+   - 3.8 [Prevent Memory Leaks in Components](#38-prevent-memory-leaks-in-components)
+   - 3.9 [Use {{on}} Modifier for Event Handling](#39-use-on-modifier-for-event-handling)
+   - 3.10 [Use @cached for Expensive Getters](#310-use-cached-for-expensive-getters)
+   - 3.11 [Use Class Fields for Component Composition](#311-use-class-fields-for-component-composition)
+   - 3.12 [Use Component Composition Patterns](#312-use-component-composition-patterns)
+   - 3.13 [Use Glimmer Components Over Classic Components](#313-use-glimmer-components-over-classic-components)
+   - 3.14 [Use Native Forms with Platform Validation](#314-use-native-forms-with-platform-validation)
+   - 3.15 [Use Strict Mode and Template-Only Components](#315-use-strict-mode-and-template-only-components)
+   - 3.16 [Use Tracked Toolbox for Complex State](#316-use-tracked-toolbox-for-complex-state)
+   - 3.17 [Validate Component Arguments](#317-validate-component-arguments)
+4. [Accessibility Best Practices](#4-accessibility-best-practices) — **HIGH**
+   - 4.1 [Announce Route Transitions to Screen Readers](#41-announce-route-transitions-to-screen-readers)
+   - 4.2 [Form Labels and Error Announcements](#42-form-labels-and-error-announcements)
+   - 4.3 [Keyboard Navigation Support](#43-keyboard-navigation-support)
+   - 4.4 [Semantic HTML and ARIA Attributes](#44-semantic-html-and-aria-attributes)
+   - 4.5 [Use ember-a11y-testing for Automated Checks](#45-use-ember-a11y-testing-for-automated-checks)
+5. [Service and State Management](#5-service-and-state-management) — **MEDIUM-HIGH**
+   - 5.1 [Cache API Responses in Services](#51-cache-api-responses-in-services)
+   - 5.2 [Implement Robust Data Requesting Patterns](#52-implement-robust-data-requesting-patterns)
+   - 5.3 [Manage Service Owner and Linkage Patterns](#53-manage-service-owner-and-linkage-patterns)
+   - 5.4 [Optimize WarpDrive Queries](#54-optimize-warpdrive-queries)
+   - 5.5 [Use Services for Shared State](#55-use-services-for-shared-state)
+6. [Template Optimization](#6-template-optimization) — **MEDIUM**
+   - 6.1 [Avoid Heavy Computation in Templates](#61-avoid-heavy-computation-in-templates)
+   - 6.2 [Compose Helpers for Reusable Logic](#62-compose-helpers-for-reusable-logic)
+   - 6.3 [Import Helpers Directly in Templates](#63-import-helpers-directly-in-templates)
+   - 6.4 [No helper() Wrapper for Plain Functions](#64-no-helper-wrapper-for-plain-functions)
+   - 6.5 [Optimize Conditional Rendering](#65-optimize-conditional-rendering)
+   - 6.6 [Template-Only Components with In-Scope Functions](#66-template-only-components-with-in-scope-functions)
+   - 6.7 [Use {{#each}} with @key for Lists](#67-use-each-with-key-for-lists)
+   - 6.8 [Use {{#let}} to Avoid Recomputation](#68-use-let-to-avoid-recomputation)
+   - 6.9 [Use {{fn}} for Partial Application Only](#69-use-fn-for-partial-application-only)
+   - 6.10 [Use Helper Libraries Effectively](#610-use-helper-libraries-effectively)
+7. [Performance Optimization](#7-performance-optimization) — **MEDIUM**
+   - 7.1 [Use {{on}} Modifier Instead of Event Handler Properties](#71-use-on-modifier-instead-of-event-handler-properties)
+8. [Testing Best Practices](#8-testing-best-practices) — **MEDIUM**
+   - 8.1 [MSW (Mock Service Worker) Setup for Testing](#81-msw-mock-service-worker-setup-for-testing)
+   - 8.2 [Provide DOM-Abstracted Test Utilities for Library Components](#82-provide-dom-abstracted-test-utilities-for-library-components)
+   - 8.3 [Use Appropriate Render Patterns in Tests](#83-use-appropriate-render-patterns-in-tests)
+   - 8.4 [Use Modern Testing Patterns](#84-use-modern-testing-patterns)
+   - 8.5 [Use qunit-dom for Better Test Assertions](#85-use-qunit-dom-for-better-test-assertions)
+   - 8.6 [Use Test Waiters for Async Operations](#86-use-test-waiters-for-async-operations)
+9. [Tooling and Configuration](#9-tooling-and-configuration) — **MEDIUM**
+   - 9.1 [VSCode Extensions and MCP Configuration for Ember Projects](#91-vscode-extensions-and-mcp-configuration-for-ember-projects)
+10. [Advanced Patterns](#10-advanced-patterns) — **MEDIUM-HIGH**
+   - 10.1 [Use Ember Concurrency Correctly - User Concurrency Not Data Loading](#101-use-ember-concurrency-correctly---user-concurrency-not-data-loading)
+   - 10.2 [Use Ember Concurrency for User Input Concurrency](#102-use-ember-concurrency-for-user-input-concurrency)
+   - 10.3 [Use Helper Functions for Reusable Logic](#103-use-helper-functions-for-reusable-logic)
+   - 10.4 [Use Modifiers for DOM Side Effects](#104-use-modifiers-for-dom-side-effects)
+   - 10.5 [Use Reactive Collections from @ember/reactive/collections](#105-use-reactive-collections-from-emberreactivecollections)
+
+---
+
+## 1. Route Loading and Data Fetching
+
+**Impact: CRITICAL**
+
+Efficient route loading and parallel data fetching eliminate waterfalls. Using route model hooks effectively and loading data in parallel yields the largest performance gains.
+
+### 1.1 Implement Smart Route Model Caching
+
+**Impact: MEDIUM-HIGH (Reduce redundant API calls and improve UX)**
+
+Implement intelligent model caching strategies to reduce redundant API calls and improve user experience.
+
+**Incorrect: always fetches fresh data**
+
+```glimmer-js
+// app/routes/post.gjs
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class PostRoute extends Route {
+  @service store;
+
+  model(params) {
+    // Always makes API call, even if we just loaded this post
+    return this.store.request({ url: `/posts/${params.post_id}` });
+  }
+
+  <template>
+    <article>
+      <h1>{{@model.title}}</h1>
+      <div>{{@model.content}}</div>
+    </article>
+    {{outlet}}
+  </template>
+}
+```
+
+**Correct: with smart caching**
+
+```glimmer-js
+// app/routes/post.gjs
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class PostRoute extends Route {
+  @service store;
+
+  model(params) {
+    // Check cache first
+    const cached = this.store.cache.peek({
+      type: 'post',
+      id: params.post_id
+    });
+
+    // Return cached if fresh (less than 5 minutes old)
+    if (cached && this.isCacheFresh(cached)) {
+      return cached;
+    }
+
+    // Fetch fresh data
+    return this.store.request({
+      url: `/posts/${params.post_id}`,
+      options: { reload: true }
+    });
+  }
+
+  isCacheFresh(record) {
+    const cacheTime = record.meta?.cachedAt || 0;
+    const fiveMinutes = 5 * 60 * 1000;
+    return (Date.now() - cacheTime) < fiveMinutes;
+  }
+
+  <template>
+    <article>
+      <h1>{{@model.title}}</h1>
+      <div>{{@model.content}}</div>
+    </article>
+    {{outlet}}
+  </template>
+}
+```
+
+**Service-based caching layer:**
+
+```glimmer-js
+// app/routes/post.gjs
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class PostRoute extends Route {
+  @service postCache;
+
+  model(params) {
+    return this.postCache.getPost(params.post_id);
+  }
+
+  // Refresh data when returning to route
+  async activate() {
+    super.activate(...arguments);
+    const params = this.paramsFor('post');
+    await this.postCache.getPost(params.post_id, { forceRefresh: true });
+  }
+
+  <template>
+    <article>
+      <h1>{{@model.title}}</h1>
+      <div>{{@model.content}}</div>
+    </article>
+    {{outlet}}
+  </template>
+}
+```
+
+**Using query params for cache control:**
+
+```glimmer-js
+// app/routes/posts.gjs
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class PostsRoute extends Route {
+  @service store;
+
+  queryParams = {
+    refresh: { refreshModel: true }
+  };
+
+  model(params) {
+    const options = params.refresh
+      ? { reload: true }
+      : { backgroundReload: true };
+
+    return this.store.request({
+      url: '/posts',
+      options
+    });
+  }
+
+  <template>
+    <div class="posts">
+      <button {{on "click" (fn this.refresh)}}>
+        Refresh
+      </button>
+
+      <ul>
+        {{#each @model as |post|}}
+          <li>{{post.title}}</li>
+        {{/each}}
+      </ul>
+    </div>
+    {{outlet}}
+  </template>
+}
+```
+
+**Background refresh pattern:**
+
+```glimmer-js
+// app/routes/dashboard.gjs
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class DashboardRoute extends Route {
+  @service store;
+
+  async model() {
+    // Return cached data immediately
+    const cached = this.store.cache.peek({ type: 'dashboard' });
+
+    // Refresh in background
+    this.store.request({
+      url: '/dashboard',
+      options: { backgroundReload: true }
+    });
+
+    return cached || this.store.request({ url: '/dashboard' });
+  }
+
+  <template>
+    <div class="dashboard">
+      <h1>Dashboard</h1>
+      <div>Stats: {{@model.stats}}</div>
+    </div>
+    {{outlet}}
+  </template>
+}
+```
+
+Smart caching reduces server load, improves perceived performance, and provides better offline support while keeping data fresh.
+
+Reference: [https://warp-drive.io/](https://warp-drive.io/)
+
+### 1.2 Parallel Data Loading in Model Hooks
+
+**Impact: CRITICAL (2-10× improvement)**
+
+When fetching multiple independent data sources in a route's model hook, use `Promise.all()` or RSVP.hash() to load them in parallel instead of sequentially.
+
+`export default` in these route examples is intentional because route modules are discovered through resolver lookup. In hybrid `.gjs`/`.hbs` codebases, keep route defaults and add named exports only when you need explicit imports elsewhere.
+
+**Incorrect: sequential loading, 3 round trips**
+
+```javascript
+// app/routes/dashboard.js
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class DashboardRoute extends Route {
+  @service store;
+
+  async model() {
+    const user = await this.store.request({ url: '/users/me' });
+    const posts = await this.store.request({ url: '/posts?recent=true' });
+    const notifications = await this.store.request({ url: '/notifications?unread=true' });
+
+    return { user, posts, notifications };
+  }
+}
+```
+
+**Correct: parallel loading, 1 round trip**
+
+```javascript
+// app/routes/dashboard.js
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+import { hash } from 'rsvp';
+
+export default class DashboardRoute extends Route {
+  @service store;
+
+  model() {
+    return hash({
+      user: this.store.request({ url: '/users/me' }),
+      posts: this.store.request({ url: '/posts?recent=true' }),
+      notifications: this.store.request({ url: '/notifications?unread=true' }),
+    });
+  }
+}
+```
+
+Using `hash()` from RSVP allows Ember to resolve all promises concurrently, significantly reducing load time.
+
+### 1.3 Use Loading Substates for Better UX
+
+**Impact: CRITICAL (Perceived performance improvement)**
+
+Implement loading substates to show immediate feedback while data loads, preventing blank screens and improving perceived performance.
+
+**Incorrect: no loading state**
+
+```javascript
+// app/routes/posts.js
+export default class PostsRoute extends Route {
+  async model() {
+    return this.store.request({ url: '/posts' });
+  }
+}
+```
+
+**Correct: with loading substate**
+
+```javascript
+// app/routes/posts.js
+export default class PostsRoute extends Route {
+  model() {
+    // Return promise directly - Ember will show posts-loading template
+    return this.store.request({ url: '/posts' });
+  }
+}
+```
+
+Ember automatically renders `{route-name}-loading` route templates while the model promise resolves, providing better UX without extra code.
+
+### 1.4 Use Route Templates with Co-located Syntax
+
+**Impact: MEDIUM-HIGH (Better code organization and maintainability)**
+
+Use co-located route templates with modern gjs syntax for better organization and maintainability.
+
+**Incorrect: separate template file - old pattern**
+
+```glimmer-js
+// app/routes/posts.js (separate file)
+import Route from '@ember/routing/route';
+
+export default class PostsRoute extends Route {
+  model() {
+    return this.store.request({ url: '/posts' });
+  }
+}
+
+// app/templates/posts.gjs (separate template file)
+<template>
+  <h1>Posts</h1>
+  <ul>
+    {{#each @model as |post|}}
+      <li>{{post.title}}</li>
+    {{/each}}
+  </ul>
+</template>
+```
+
+**Correct: co-located route template**
+
+```glimmer-js
+// app/routes/posts.gjs
+import Route from '@ember/routing/route';
+
+export default class PostsRoute extends Route {
+  model() {
+    return this.store.request({ url: '/posts' });
+  }
+
+  <template>
+    <h1>Posts</h1>
+    <ul>
+      {{#each @model as |post|}}
+        <li>{{post.title}}</li>
+      {{/each}}
+    </ul>
+
+    {{outlet}}
+  </template>
+}
+```
+
+**With loading and error states:**
+
+```glimmer-js
+// app/routes/posts.gjs
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class PostsRoute extends Route {
+  @service store;
+
+  model() {
+    return this.store.request({ url: '/posts' });
+  }
+
+  <template>
+    <div class="posts-page">
+      <h1>Posts</h1>
+
+      {{#if @model}}
+        <ul>
+          {{#each @model as |post|}}
+            <li>{{post.title}}</li>
+          {{/each}}
+        </ul>
+      {{/if}}
+
+      {{outlet}}
+    </div>
+  </template>
+}
+```
+
+**Template-only routes:**
+
+```glimmer-js
+// app/routes/about.gjs
+<template>
+  <div class="about-page">
+    <h1>About Us</h1>
+    <p>Welcome to our application!</p>
+  </div>
+</template>
+```
+
+Co-located route templates keep route logic and presentation together, making the codebase easier to navigate and maintain.
+
+Reference: [https://guides.emberjs.com/release/routing/](https://guides.emberjs.com/release/routing/)
+
+### 1.5 Use Route-Based Code Splitting
+
+**Impact: CRITICAL (30-70% initial bundle reduction)**
+
+With Embroider's route-based code splitting, routes and their components are automatically split into separate chunks, loaded only when needed.
+
+**Incorrect: everything in main bundle**
+
+```javascript
+// ember-cli-build.js
+const EmberApp = require('ember-cli/lib/broccoli/ember-app');
+
+module.exports = function (defaults) {
+  const app = new EmberApp(defaults, {
+    // No optimization
+  });
+
+  return app.toTree();
+};
+```
+
+**Correct: Embroider with Vite and route splitting**
+
+```javascript
+// ember-cli-build.js
+const { Vite } = require('@embroider/vite');
+
+module.exports = require('@embroider/compat').compatBuild(app, Vite, {
+  staticAddonTestSupportTrees: true,
+  staticAddonTrees: true,
+  staticHelpers: true,
+  staticModifiers: true,
+  staticComponents: true,
+  splitAtRoutes: ['admin', 'reports', 'settings'], // Routes to split
+});
+```
+
+Embroider with `splitAtRoutes` creates separate bundles for specified routes, reducing initial load time by 30-70%.
+
+Reference: [https://github.com/embroider-build/embroider](https://github.com/embroider-build/embroider)
+
+---
+
+## 2. Build and Bundle Optimization
+
+**Impact: CRITICAL**
+
+Using Embroider with static build optimizations, route-based code splitting, and proper imports reduces bundle size and improves Time to Interactive.
+
+### 2.1 Avoid Importing Entire Addon Namespaces
+
+**Impact: CRITICAL (200-500ms import cost reduction)**
+
+Import specific utilities and components directly rather than entire addon namespaces to enable better tree-shaking and reduce bundle size.
+
+**Incorrect: imports entire namespace**
+
+```javascript
+import { tracked } from '@glimmer/tracking';
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+// OK - these are already optimized
+
+// But avoid this pattern with utility libraries:
+import * as lodash from 'lodash';
+import * as moment from 'moment';
+
+class My extends Component {
+  someMethod() {
+    return lodash.debounce(this.handler, 300);
+  }
+}
+```
+
+**Correct: direct imports**
+
+```javascript
+import { tracked } from '@glimmer/tracking';
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import debounce from 'lodash/debounce';
+import dayjs from 'dayjs'; // moment alternative, smaller
+
+class My extends Component {
+  someMethod() {
+    return debounce(this.handler, 300);
+  }
+}
+```
+
+**Even better: use Ember utilities when available**
+
+```javascript
+import { tracked } from '@glimmer/tracking';
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { debounce } from '@ember/runloop';
+
+class My extends Component {
+  someMethod() {
+    return debounce(this, this.handler, 300);
+  }
+}
+```
+
+Direct imports and using built-in Ember utilities reduce bundle size by avoiding unused code.
+
+### 2.2 Lazy Load Heavy Dependencies
+
+**Impact: CRITICAL (30-50% initial bundle reduction)**
+
+Use dynamic imports to load heavy libraries only when needed, reducing initial bundle size.
+
+**Incorrect: loaded upfront**
+
+```javascript
+import Component from '@glimmer/component';
+import Chart from 'chart.js/auto'; // 300KB library loaded immediately
+import hljs from 'highlight.js'; // 500KB library loaded immediately
+
+class Dashboard extends Component {
+  get showChart() {
+    return this.args.hasData;
+  }
+}
+```
+
+**Correct: lazy loaded with error/loading state handling**
+
+```glimmer-js
+import Component from '@glimmer/component';
+import { getPromiseState } from 'reactiveweb/promise';
+
+class Dashboard extends Component {
+  // Use getPromiseState to model promise state for error/loading handling
+  chartLoader = getPromiseState(async () => {
+    const { default: Chart } = await import('chart.js/auto');
+    return Chart;
+  });
+
+  highlighterLoader = getPromiseState(async () => {
+    const { default: hljs } = await import('highlight.js');
+    return hljs;
+  });
+
+  loadChart = () => {
+    // Triggers lazy load, handles loading/error states automatically
+    return this.chartLoader.value;
+  };
+
+  highlightCode = (code) => {
+    const hljs = this.highlighterLoader.value;
+    if (hljs) {
+      return hljs.highlightAuto(code);
+    }
+    return code;
+  };
+
+  <template>
+    {{#if this.chartLoader.isLoading}}
+      <p>Loading chart library...</p>
+    {{else if this.chartLoader.isError}}
+      <p>Error loading chart: {{this.chartLoader.error.message}}</p>
+    {{else if this.chartLoader.isResolved}}
+      <canvas {{on "click" this.loadChart}}></canvas>
+    {{/if}}
+  </template>
+}
+```
+
+**Note**: Always model promise state (loading/error/resolved) using `getPromiseState` from `reactiveweb/promise` to handle slow networks and errors properly.
+
+Dynamic imports reduce initial bundle size by 30-50%, improving Time to Interactive.
+
+### 2.3 Use Embroider Build Pipeline
+
+**Impact: CRITICAL (Modern build system with better performance)**
+
+Use Embroider, Ember's modern build pipeline, with Vite for faster builds, better tree-shaking, and smaller bundles.
+
+**Incorrect: classic build pipeline**
+
+```javascript
+// ember-cli-build.js
+const EmberApp = require('ember-cli/lib/broccoli/ember-app');
+
+module.exports = function (defaults) {
+  const app = new EmberApp(defaults, {});
+  return app.toTree();
+};
+```
+
+**Correct: Embroider with Vite**
+
+```javascript
+// ember-cli-build.js
+const EmberApp = require('ember-cli/lib/broccoli/ember-app');
+const { compatBuild } = require('@embroider/compat');
+
+module.exports = async function (defaults) {
+  const { buildOnce } = await import('@embroider/vite');
+
+  let app = new EmberApp(defaults, {
+    // Add options here
+  });
+
+  return compatBuild(app, buildOnce);
+};
+```
+
+**For stricter static analysis: optimized mode**
+
+```javascript
+// ember-cli-build.js
+const EmberApp = require('ember-cli/lib/broccoli/ember-app');
+const { compatBuild } = require('@embroider/compat');
+
+module.exports = async function (defaults) {
+  const { buildOnce } = await import('@embroider/vite');
+
+  let app = new EmberApp(defaults, {
+    // Add options here
+  });
+
+  return compatBuild(app, buildOnce, {
+    // Enable static analysis for better tree-shaking
+    staticAddonTestSupportTrees: true,
+    staticAddonTrees: true,
+    staticHelpers: true,
+    staticModifiers: true,
+    staticComponents: true,
+  });
+};
+```
+
+Embroider provides a modern build pipeline with Vite that offers faster builds and better optimization compared to the classic Ember CLI build system.
+
+Reference: [https://github.com/embroider-build/embroider](https://github.com/embroider-build/embroider)
+
+---
+
+## 3. Component and Reactivity Optimization
+
+**Impact: HIGH**
+
+Proper use of Glimmer components, modern file conventions, tracked properties, and avoiding unnecessary recomputation improves rendering performance.
+
+### 3.1 Avoid Constructors in Components
+
+**Impact: HIGH (Prevents infinite render loops and simplifies code)**
+
+**Strongly discourage constructor usage.** Modern Ember components rarely need constructors. Use class fields, @service decorators, and getPromiseState for initialization instead. Constructors with function calls that set tracked state can cause infinite render loops.
+
+- [Ember Octane Guide](https://guides.emberjs.com/release/upgrading/current-edition/)
+
+- [warp-drive/reactiveweb](https://github.com/emberjs/data/tree/main/packages/reactiveweb)
+
+**Incorrect: using constructor**
+
+```glimmer-js
+// app/components/user-profile.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { service } from '@ember/service';
+
+class UserProfile extends Component {
+  constructor() {
+    super(...arguments);
+
+    // Anti-pattern: Manual service lookup
+    this.store = this.owner.lookup('service:store');
+    this.router = this.owner.lookup('service:router');
+
+    // Anti-pattern: Imperative initialization
+    this.data = null;
+    this.isLoading = false;
+    this.error = null;
+
+    // Anti-pattern: Side effects in constructor
+    this.loadUserData();
+  }
+
+  async loadUserData() {
+    this.isLoading = true;
+    try {
+      this.data = await this.store.request({
+        url: `/users/${this.args.userId}`
+      });
+    } catch (e) {
+      this.error = e;
+    } finally {
+      this.isLoading = false;
+    }
+  }
+
+  <template>
+    {{#if this.isLoading}}
+      <div>Loading...</div>
+    {{else if this.error}}
+      <div>Error: {{this.error.message}}</div>
+    {{else if this.data}}
+      <h1>{{this.data.name}}</h1>
+    {{/if}}
+  </template>
+}
+```
+
+**Correct: use class fields and declarative async state**
+
+```glimmer-js
+// app/components/user-profile.gjs
+import Component from '@glimmer/component';
+import { cached } from '@glimmer/tracking';
+import { service } from '@ember/service';
+import { getRequestState } from '@warp-drive/ember';
+
+class UserProfile extends Component {
+  @service store;
+
+  @cached
+  get userRequest() {
+    return this.store.request({
+      url: `/users/${this.args.userId}`,
+    });
+  }
+
+  <template>
+    {{#let (getRequestState this.userRequest) as |state|}}
+      {{#if state.isPending}}
+        <div>Loading...</div>
+      {{else if state.isError}}
+        <div>Error loading user</div>
+      {{else}}
+        <h1>{{state.value.name}}</h1>
+      {{/if}}
+    {{/let}}
+  </template>
+}
+```
+
+**When You Might Need a Constructor: Very Rare**
+
+```glimmer-js
+// app/components/complex-setup.gjs
+import Component from '@glimmer/component';
+import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+
+class ComplexSetup extends Component {
+  @service store;
+
+  @tracked state = null;
+
+  constructor(owner, args) {
+    super(owner, args);
+
+    // Only if you absolutely must do something that can't be done with class fields
+    // Even then, prefer resources or modifiers
+    if (this.args.legacyInitMode) {
+      this.initializeLegacyMode();
+    }
+  }
+
+  initializeLegacyMode() {
+    // Rare edge case initialization
+  }
+
+  <template>
+    <!-- template -->
+  </template>
+}
+```
+
+Very rarely, you might need a constructor for truly exceptional cases. Even then, use modern patterns:
+
+**Why Strongly Avoid Constructors:**
+
+1. **Infinite Render Loops**: Setting tracked state in constructor that's read during render causes infinite loops
+
+2. **Service Injection**: Use `@service` decorator instead of `owner.lookup()`
+
+3. **Testability**: Class fields are easier to mock and test
+
+4. **Clarity**: Declarative class fields show state at a glance
+
+5. **Side Effects**: getPromiseState and modifiers handle side effects better
+
+6. **Memory Leaks**: getPromiseState auto-cleanup; constructor code doesn't
+
+7. **Reactivity**: Class fields integrate better with tracking
+
+8. **Initialization Order**: No need to worry about super() call timing
+
+9. **Argument Validation**: Constructor validation runs only once; use getters to catch arg changes
+
+**Modern Alternatives:**
+
+| Old Pattern                                                    | Modern Alternative                                       |
+
+| -------------------------------------------------------------- | -------------------------------------------------------- |
+
+| `constructor() { this.store = owner.lookup('service:store') }` | `@service store;`                                        |
+
+| `constructor() { this.data = null; }`                          | `@tracked data = null;`                                  |
+
+| `constructor() { this.loadData(); }`                           | Use `@cached get` with getPromiseState                   |
+
+| `constructor() { this.interval = setInterval(...) }`           | Use modifier with registerDestructor                     |
+
+| `constructor() { this.subscription = ... }`                    | Use modifier or constructor with registerDestructor ONLY |
+
+**Performance Impact:**
+
+- **Before**: Constructor runs on every instantiation, manual cleanup risk, infinite loop danger
+
+- **After**: Class fields initialize efficiently, getPromiseState auto-cleanup, no render loops
+
+**Strongly discourage constructors** - they add complexity and infinite render loop risks. Use declarative class fields and getPromiseState instead.
+
+### 3.2 Avoid CSS Classes in Learning Examples
+
+**Impact: LOW-MEDIUM (Cleaner, more focused learning materials)**
+
+Don't add CSS classes to learning content and examples unless they provide actual value above the surrounding context. Classes add visual noise and distract from the concepts being taught.
+
+**Incorrect: unnecessary classes in learning example**
+
+```glimmer-js
+// app/components/user-card.gjs
+import Component from '@glimmer/component';
+
+export class UserCard extends Component {
+  <template>
+    <div class="user-card">
+      <div class="user-card__header">
+        <h3 class="user-card__name">{{@user.name}}</h3>
+        <p class="user-card__email">{{@user.email}}</p>
+      </div>
+
+      {{#if @user.avatarUrl}}
+        <img class="user-card__avatar" src={{@user.avatarUrl}} alt={{@user.name}} />
+      {{/if}}
+
+      {{#if @onEdit}}
+        <button class="user-card__edit-button" {{on "click" (fn @onEdit @user)}}>
+          Edit
+        </button>
+      {{/if}}
+
+      <div class="user-card__content">
+        {{yield}}
+      </div>
+    </div>
+  </template>
+}
+```
+
+**Why This Is Wrong:**
+
+- Classes add visual clutter that obscures the actual concepts
+
+- Learners focus on naming conventions instead of the pattern being taught
+
+- Makes copy-paste more work (need to remove or change class names)
+
+- Implies these specific class names are required or best practice
+
+- Distracts from structural HTML and component logic
+
+**Correct: focused on concepts**
+
+```glimmer-js
+// app/components/user-card.gjs
+import Component from '@glimmer/component';
+
+export class UserCard extends Component {
+  <template>
+    <div ...attributes>
+      <h3>{{@user.name}}</h3>
+      <p>{{@user.email}}</p>
+
+      {{#if @user.avatarUrl}}
+        <img src={{@user.avatarUrl}} alt={{@user.name}} />
+      {{/if}}
+
+      {{#if @onEdit}}
+        <button {{on "click" (fn @onEdit @user)}}>Edit</button>
+      {{/if}}
+
+      {{yield}}
+    </div>
+  </template>
+}
+```
+
+**Benefits:**
+
+- **Clarity**: Easier to understand the component structure
+
+- **Focus**: Reader attention stays on the concepts being taught
+
+- **Simplicity**: Less code to process mentally
+
+- **Flexibility**: Reader can add their own classes without conflict
+
+- **Reusability**: Examples are easier to adapt to real code
+
+**When Classes ARE Appropriate in Examples:**
+
+```glimmer-js
+// Example: Teaching about ...attributes for styling flexibility
+export class Card extends Component {
+  <template>
+    {{! Caller can add their own classes via ...attributes }}
+    <div ...attributes>
+      {{yield}}
+    </div>
+  </template>
+}
+
+{{! Usage: <Card class="user-card">...</Card> }}
+```
+
+**When to Include Classes:**
+
+1. **Teaching class binding** - Example explicitly about conditional classes or class composition
+
+2. **Demonstrating ...attributes** - Showing how callers add classes
+
+3. **Accessibility** - Using classes for semantic meaning (e.g., `aria-*` helpers)
+
+4. **Critical to example** - Class name is essential to understanding (e.g., `selected`, `active`)
+
+**Examples Where Classes Add Value:**
+
+```glimmer-js
+// Good: Teaching about class composition
+import { cn } from 'ember-cn';
+
+export class Button extends Component {
+  <template>
+    <button class={{cn "btn" (if @primary "btn-primary" "btn-secondary")}}>
+      {{yield}}
+    </button>
+  </template>
+}
+```
+
+**Default Stance:**
+
+When writing learning examples or documentation:
+
+1. **Start without classes** - Add them only if needed
+
+2. **Ask**: Does this class help explain the concept?
+
+3. **Remove** any decorative or structural classes that aren't essential
+
+4. **Use** `...attributes` to show styling flexibility
+
+**Real-World Context:**
+
+In production code, you'll have classes for styling. But in learning materials, strip them away unless they're teaching something specific about classes themselves.
+
+**Common Violations:**
+
+❌ BEM classes in examples (`user-card__header`)
+
+❌ Utility classes unless teaching utilities (`flex`, `mt-4`)
+
+❌ Semantic classes that don't teach anything (`container`, `wrapper`)
+
+❌ Design system classes unless teaching design system integration
+
+**Summary:**
+
+Keep learning examples focused on the concept being taught. CSS classes should appear only when they're essential to understanding the pattern or when demonstrating styling flexibility with `...attributes`.
+
+Reference: [https://guides.emberjs.com/release/components/](https://guides.emberjs.com/release/components/)
+
+### 3.3 Avoid Legacy Lifecycle Hooks (did-insert, will-destroy, did-update)
+
+**Impact: HIGH (Prevents memory leaks and enforces modern patterns)**
+
+**Never use `{{did-insert}}`, `{{will-destroy}}`, or `{{did-update}}` in new code.** These legacy helpers create coupling between templates and component lifecycle, making code harder to test and maintain. Modern Ember provides better alternatives through derived data and custom modifiers.
+
+1. **Memory Leaks**: Easy to forget cleanup, especially with `did-insert`
+
+2. **Tight Coupling**: Mixes template concerns with JavaScript logic
+
+3. **Poor Testability**: Lifecycle hooks are harder to unit test
+
+4. **Not Composable**: Can't be easily shared across components
+
+5. **Deprecated Pattern**: Not recommended in modern Ember
+
+For computed values or reactive transformations, use getters and `@cached`:
+
+- [Ember Modifiers](https://github.com/ember-modifier/ember-modifier)
+
+- [warp-drive/reactiveweb](https://github.com/emberjs/data/tree/main/packages/reactiveweb)
+
+- [Glimmer Tracking](https://guides.emberjs.com/release/in-depth-topics/autotracking-in-depth/)
+
+**❌ Incorrect (did-update):**
+
+```glimmer-js
+// app/components/user-greeting.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+class UserGreeting extends Component {
+  @tracked displayName = '';
+
+  @action
+  updateDisplayName() {
+    // Runs on every render - inefficient and error-prone
+    this.displayName = `${this.args.user.firstName} ${this.args.user.lastName}`;
+  }
+
+  <template>
+    <div {{did-update this.updateDisplayName @user}}>
+      Hello, {{this.displayName}}
+    </div>
+  </template>
+}
+```
+
+**✅ Correct (derived data with getter):**
+
+```glimmer-js
+// app/components/user-greeting.gjs
+import Component from '@glimmer/component';
+
+class UserGreeting extends Component {
+  // Automatically reactive - updates when args change
+  get displayName() {
+    return `${this.args.user.firstName} ${this.args.user.lastName}`;
+  }
+
+  <template>
+    <div>
+      Hello, {{this.displayName}}
+    </div>
+  </template>
+}
+```
+
+**✅ Even better (use @cached for expensive computations):**
+
+```glimmer-js
+// app/components/user-stats.gjs
+import Component from '@glimmer/component';
+import { cached } from '@glimmer/tracking';
+
+class UserStats extends Component {
+  @cached
+  get sortedPosts() {
+    // Expensive computation only runs when @posts changes
+    return [...this.args.posts].sort((a, b) =>
+      b.createdAt - a.createdAt
+    );
+  }
+
+  @cached
+  get statistics() {
+    return {
+      total: this.args.posts.length,
+      published: this.args.posts.filter(p => p.published).length,
+      drafts: this.args.posts.filter(p => !p.published).length
+    };
+  }
+
+  <template>
+    <div>
+      <p>Total: {{this.statistics.total}}</p>
+      <p>Published: {{this.statistics.published}}</p>
+      <p>Drafts: {{this.statistics.drafts}}</p>
+
+      <ul>
+        {{#each this.sortedPosts as |post|}}
+          <li>{{post.title}}</li>
+        {{/each}}
+      </ul>
+    </div>
+  </template>
+}
+```
+
+For DOM side effects, element setup, or cleanup, use custom modifiers:
+
+**❌ Incorrect (did-insert + will-destroy):**
+
+```glimmer-js
+// app/components/chart.gjs
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+class Chart extends Component {
+  chartInstance = null;
+
+  @action
+  setupChart(element) {
+    this.chartInstance = new Chart(element, this.args.config);
+  }
+
+  willDestroy() {
+    super.willDestroy();
+    // Easy to forget cleanup!
+    this.chartInstance?.destroy();
+  }
+
+  <template>
+    <canvas {{did-insert this.setupChart}}></canvas>
+  </template>
+}
+```
+
+**✅ Correct (custom modifier with automatic cleanup):**
+
+```glimmer-js
+// app/components/chart.gjs
+import chart from '../modifiers/chart';
+
+<template>
+  <canvas {{chart @config}}></canvas>
+</template>
+```
+
+For complex state management with automatic cleanup, use `ember-resources`:
+
+**❌ Incorrect (did-insert for data fetching):**
+
+```glimmer-js
+// app/components/user-profile.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+class UserProfile extends Component {
+  @tracked userData = null;
+  @tracked loading = true;
+  controller = new AbortController();
+
+  @action
+  async loadUser() {
+    this.loading = true;
+    try {
+      const response = await fetch(`/api/users/${this.args.userId}`, {
+        signal: this.controller.signal
+      });
+      this.userData = await response.json();
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  willDestroy() {
+    super.willDestroy();
+    this.controller.abort(); // Easy to forget!
+  }
+
+  <template>
+    <div {{did-insert this.loadUser}}>
+      {{#if this.loading}}
+        Loading...
+      {{else}}
+        {{this.userData.name}}
+      {{/if}}
+    </div>
+  </template>
+}
+```
+
+**✅ Correct (Resource with automatic cleanup):**
+
+```glimmer-js
+// app/components/user-profile.gjs
+import Component from '@glimmer/component';
+import UserDataResource from '../resources/user-data';
+
+class UserProfile extends Component {
+  userData = UserDataResource.from(this, () => [this.args.userId]);
+
+  <template>
+    {{#if this.userData.loading}}
+      Loading...
+    {{else}}
+      {{this.userData.data.name}}
+    {{/if}}
+  </template>
+}
+```
+
+| Use Case         | Solution                            | Why                                       |
+
+| ---------------- | ----------------------------------- | ----------------------------------------- |
+
+| Computed values  | Getters + `@cached`                 | Reactive, efficient, no lifecycle needed  |
+
+| DOM manipulation | Custom modifiers                    | Encapsulated, reusable, automatic cleanup |
+
+| Data fetching    | getPromiseState from warp-drive     | Declarative, automatic cleanup            |
+
+| Event listeners  | `{{on}}` modifier                   | Built-in, automatic cleanup               |
+
+| Focus management | Custom modifier or ember-focus-trap | Proper lifecycle, accessibility           |
+
+If you have existing code using these hooks:
+
+1. **Identify the purpose**: What is the hook doing?
+
+2. **Choose the right alternative**:
+
+   - Deriving data? → Use getters/`@cached`
+
+   - DOM setup/teardown? → Use a custom modifier
+
+   - Async data loading? → Use getPromiseState from warp-drive
+
+3. **Test thoroughly**: Ensure cleanup happens correctly
+
+4. **Remove the legacy hook**: Delete `{{did-insert}}`, `{{will-destroy}}`, or `{{did-update}}`
+
+Modern alternatives provide better performance:
+
+- **Getters**: Only compute when dependencies change
+
+- **@cached**: Memoizes expensive computations
+
+- **Modifiers**: Scoped to specific elements, composable
+
+- **getPromiseState**: Declarative data loading, automatic cleanup
+
+❌ **Don't use `willDestroy()` for cleanup when a modifier would work**
+
+❌ **Don't use `@action` + `did-insert` when a getter would suffice**
+
+❌ **Don't manually track changes when `@cached` handles it automatically**
+
+❌ **Don't forget `registerDestructor` in custom modifiers**
+
+Modern Ember provides superior alternatives to legacy lifecycle hooks:
+
+- **Derived Data**: Use getters and `@cached` for reactive computations
+
+- **DOM Side Effects**: Use custom modifiers with `registerDestructor`
+
+- **Async Data Loading**: Use getPromiseState from warp-drive/reactiveweb
+
+- **Better Code**: More testable, composable, and maintainable
+
+**Never use `{{did-insert}}`, `{{will-destroy}}`, or `{{did-update}}` in new code.**
+
+### 3.4 Avoid Unnecessary Tracking
+
+**Impact: HIGH (20-40% fewer invalidations)**
+
+Only mark properties as `@tracked` if they need to trigger re-renders when changed. Overusing `@tracked` causes unnecessary invalidations and re-renders.
+
+**Incorrect: everything tracked**
+
+```javascript
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+class Form extends Component {
+  @tracked firstName = ''; // Used in template ✓
+  @tracked lastName = ''; // Used in template ✓
+  @tracked _formId = Date.now(); // Internal, never rendered ✗
+  @tracked _validationCache = new Map(); // Internal state ✗
+
+  @action
+  validate() {
+    this._validationCache.set('firstName', this.firstName.length > 0);
+    // Unnecessary re-render triggered
+  }
+}
+```
+
+**Correct: selective tracking**
+
+```javascript
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+class Form extends Component {
+  @tracked firstName = ''; // Rendered in template
+  @tracked lastName = ''; // Rendered in template
+  @tracked isValid = false; // Rendered status
+
+  _formId = Date.now(); // Not tracked - internal only
+  _validationCache = new Map(); // Not tracked - internal state
+
+  @action
+  validate() {
+    this._validationCache.set('firstName', this.firstName.length > 0);
+    this.isValid = this._validationCache.get('firstName');
+    // Only re-renders when isValid changes
+  }
+}
+```
+
+Only track properties that directly affect the template or other tracked getters to minimize unnecessary re-renders.
+
+### 3.5 Build Reactive Chains with Dependent Getters
+
+**Impact: HIGH (Clear data flow and automatic reactivity)**
+
+Create reactive chains where getters depend on other getters or tracked properties for clear, maintainable data derivation.
+
+**Incorrect: imperative updates**
+
+```glimmer-js
+// app/components/shopping-cart.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+class ShoppingCart extends Component {
+  @tracked items = [];
+  @tracked subtotal = 0;
+  @tracked tax = 0;
+  @tracked shipping = 0;
+  @tracked total = 0;
+
+  @action
+  addItem(item) {
+    this.items = [...this.items, item];
+    this.recalculate();
+  }
+
+  @action
+  removeItem(index) {
+    this.items = this.items.filter((_, i) => i !== index);
+    this.recalculate();
+  }
+
+  recalculate() {
+    this.subtotal = this.items.reduce((sum, item) => sum + item.price, 0);
+    this.tax = this.subtotal * 0.08;
+    this.shipping = this.subtotal > 50 ? 0 : 5.99;
+    this.total = this.subtotal + this.tax + this.shipping;
+  }
+
+  <template>
+    <div class="cart">
+      <div>Subtotal: ${{this.subtotal}}</div>
+      <div>Tax: ${{this.tax}}</div>
+      <div>Shipping: ${{this.shipping}}</div>
+      <div>Total: ${{this.total}}</div>
+    </div>
+  </template>
+}
+```
+
+**Correct: reactive getter chains**
+
+```glimmer-js
+// app/components/shopping-cart.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { TrackedArray } from 'tracked-built-ins';
+
+class ShoppingCart extends Component {
+  @tracked items = new TrackedArray([]);
+
+  // Base calculation
+  get subtotal() {
+    return this.items.reduce((sum, item) => sum + item.price, 0);
+  }
+
+  // Depends on subtotal
+  get tax() {
+    return this.subtotal * 0.08;
+  }
+
+  // Depends on subtotal
+  get shipping() {
+    return this.subtotal > 50 ? 0 : 5.99;
+  }
+
+  // Depends on subtotal, tax, and shipping
+  get total() {
+    return this.subtotal + this.tax + this.shipping;
+  }
+
+  // Derived from total
+  get formattedTotal() {
+    return `$${this.total.toFixed(2)}`;
+  }
+
+  // Multiple dependencies
+  get discount() {
+    if (this.items.length >= 5) return this.subtotal * 0.1;
+    if (this.subtotal > 100) return this.subtotal * 0.05;
+    return 0;
+  }
+
+  // Depends on total and discount
+  get finalTotal() {
+    return this.total - this.discount;
+  }
+
+  @action
+  addItem(item) {
+    this.items.push(item);
+    // All getters automatically update!
+  }
+
+  @action
+  removeItem(index) {
+    this.items.splice(index, 1);
+    // All getters automatically update!
+  }
+
+  <template>
+    <div class="cart">
+      <div>Items: {{this.items.length}}</div>
+      <div>Subtotal: ${{this.subtotal.toFixed 2}}</div>
+      <div>Tax: ${{this.tax.toFixed 2}}</div>
+      <div>Shipping: ${{this.shipping.toFixed 2}}</div>
+      {{#if this.discount}}
+        <div class="discount">Discount: -${{this.discount.toFixed 2}}</div>
+      {{/if}}
+      <div class="total">Total: {{this.formattedTotal}}</div>
+    </div>
+  </template>
+}
+```
+
+**Complex reactive chains with @cached:**
+
+```glimmer-js
+// app/components/data-analysis.gjs
+import Component from '@glimmer/component';
+import { cached } from '@glimmer/tracking';
+
+class DataAnalysis extends Component {
+  // Base data
+  get rawData() {
+    return this.args.data || [];
+  }
+
+  // Level 1: Filter
+  @cached
+  get validData() {
+    return this.rawData.filter(item => item.value != null);
+  }
+
+  // Level 2: Transform (depends on validData)
+  @cached
+  get normalizedData() {
+    const max = Math.max(...this.validData.map(d => d.value));
+    return this.validData.map(item => ({
+      ...item,
+      normalized: item.value / max
+    }));
+  }
+
+  // Level 2: Statistics (depends on validData)
+  @cached
+  get statistics() {
+    const values = this.validData.map(d => d.value);
+    const sum = values.reduce((a, b) => a + b, 0);
+    const mean = sum / values.length;
+    const variance = values.reduce((a, b) => a + Math.pow(b - mean, 2), 0) / values.length;
+
+    return {
+      count: values.length,
+      sum,
+      mean,
+      stdDev: Math.sqrt(variance),
+      min: Math.min(...values),
+      max: Math.max(...values)
+    };
+  }
+
+  // Level 3: Depends on normalizedData and statistics
+  @cached
+  get outliers() {
+    const threshold = this.statistics.mean + (2 * this.statistics.stdDev);
+    return this.normalizedData.filter(item => item.value > threshold);
+  }
+
+  // Level 3: Depends on statistics
+  get qualityScore() {
+    const validRatio = this.validData.length / this.rawData.length;
+    const outlierRatio = this.outliers.length / this.validData.length;
+    return (validRatio * 0.7) + ((1 - outlierRatio) * 0.3);
+  }
+
+  <template>
+    <div class="analysis">
+      <h3>Data Quality: {{this.qualityScore.toFixed 2}}</h3>
+      <div>Valid: {{this.validData.length}} / {{this.rawData.length}}</div>
+      <div>Mean: {{this.statistics.mean.toFixed 2}}</div>
+      <div>Std Dev: {{this.statistics.stdDev.toFixed 2}}</div>
+      <div>Outliers: {{this.outliers.length}}</div>
+    </div>
+  </template>
+}
+```
+
+**Combining multiple tracked sources:**
+
+```glimmer-js
+// app/components/filtered-list.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { cached } from '@glimmer/tracking';
+
+class FilteredList extends Component {
+  @tracked searchTerm = '';
+  @tracked selectedCategory = 'all';
+  @tracked sortDirection = 'asc';
+
+  // Depends on args.items and searchTerm
+  @cached
+  get searchFiltered() {
+    if (!this.searchTerm) return this.args.items;
+
+    const term = this.searchTerm.toLowerCase();
+    return this.args.items.filter(item =>
+      item.name.toLowerCase().includes(term) ||
+      item.description?.toLowerCase().includes(term)
+    );
+  }
+
+  // Depends on searchFiltered and selectedCategory
+  @cached
+  get categoryFiltered() {
+    if (this.selectedCategory === 'all') return this.searchFiltered;
+
+    return this.searchFiltered.filter(item =>
+      item.category === this.selectedCategory
+    );
+  }
+
+  // Depends on categoryFiltered and sortDirection
+  @cached
+  get sorted() {
+    const items = [...this.categoryFiltered];
+    const direction = this.sortDirection === 'asc' ? 1 : -1;
+
+    return items.sort((a, b) =>
+      direction * a.name.localeCompare(b.name)
+    );
+  }
+
+  // Final result
+  get items() {
+    return this.sorted;
+  }
+
+  // Metadata derived from chain
+  get resultsCount() {
+    return this.items.length;
+  }
+
+  get hasFilters() {
+    return this.searchTerm || this.selectedCategory !== 'all';
+  }
+
+  <template>
+    <div class="filtered-list">
+      <input
+        type="search"
+        value={{this.searchTerm}}
+        {{on "input" (pick "target.value" (set this "searchTerm"))}}
+      />
+
+      <select
+        value={{this.selectedCategory}}
+        {{on "change" (pick "target.value" (set this "selectedCategory"))}}
+      >
+        <option value="all">All Categories</option>
+        {{#each @categories as |cat|}}
+          <option value={{cat}}>{{cat}}</option>
+        {{/each}}
+      </select>
+
+      <p>Showing {{this.resultsCount}} results</p>
+
+      {{#each this.items as |item|}}
+        <div>{{item.name}}</div>
+      {{/each}}
+    </div>
+  </template>
+}
+```
+
+Reactive getter chains provide automatic updates, clear data dependencies, and better performance through intelligent caching with @cached.
+
+Reference: [https://guides.emberjs.com/release/in-depth-topics/autotracking-in-depth/](https://guides.emberjs.com/release/in-depth-topics/autotracking-in-depth/)
+
+### 3.6 Component File Naming and Export Conventions
+
+**Impact: HIGH (Enforces consistent component structure and predictable imports)**
+
+Follow modern Ember component file conventions: use `.gjs`/`.gts` files with `<template>` tags (never `.hbs` files), use kebab-case filenames, match class names to file names (in PascalCase), do not use the `Component` suffix in class names, and avoid `export default` in .gjs/.gts component files.
+
+This export guidance applies to `.gjs`/`.gts` component files only. If your app still uses `.hbs`, keep default exports for resolver-facing invokables used there (or use a named export plus default alias in hybrid codebases).
+
+**Incorrect:**
+
+```glimmer-js
+// app/components/UserProfile.gjs - WRONG: PascalCase filename
+import Component from '@glimmer/component';
+
+export class UserProfile extends Component {
+  <template>
+    <div class="profile">
+      {{@name}}
+    </div>
+  </template>
+}
+```
+
+**Correct:**
+
+```glimmer-js
+// app/components/user-profile.gjs - CORRECT: All conventions followed
+import Component from '@glimmer/component';
+import { service } from '@ember/service';
+
+export class UserProfile extends Component {
+  @service session;
+
+  <template>
+    <div class="profile">
+      <h1>{{@name}}</h1>
+      {{#if this.session.isAuthenticated}}
+        <button>Edit Profile</button>
+      {{/if}}
+    </div>
+  </template>
+}
+```
+
+**Never use .hbs files:**
+
+- `.gjs`/`.gts` files with `<template>` tags are the modern standard
+
+- Co-located templates and logic in a single file improve maintainability
+
+- Better tooling support (type checking, imports, refactoring)
+
+- Enables strict mode and proper scope
+
+- Avoid split between `.js` and `.hbs` files which makes components harder to understand
+
+**Filename conventions:**
+
+- Kebab-case filenames (`user-card.gjs`, not `UserCard.gjs`) follow web component standards and Ember conventions
+
+- Predictable: component name maps directly to filename (UserCard → user-card.gjs)
+
+- Avoids filesystem case-sensitivity issues across platforms
+
+**Class naming:**
+
+- No "Component" suffix - it's redundant (extends Component already declares the type)
+
+- PascalCase class name matches the capitalized component invocation: `<UserCard />`
+
+- Cleaner code: `UserCard` vs `UserCardComponent`
+
+**No default export:**
+
+- Modern .gjs/.gts files don't need `export default`
+
+- The template compiler automatically exports the component
+
+- Simpler syntax, less boilerplate
+
+- Consistent with strict-mode semantics
+
+| Filename              | Class Name             | Template Invocation  |
+
+| --------------------- | ---------------------- | -------------------- |
+
+| `user-card.gjs`       | `class UserCard`       | `<UserCard />`       |
+
+| `loading-spinner.gjs` | `class LoadingSpinner` | `<LoadingSpinner />` |
+
+| `nav-bar.gjs`         | `class NavBar`         | `<NavBar />`         |
+
+| `todo-list.gjs`       | `class TodoList`       | `<TodoList />`       |
+
+| `search-input.gjs`    | `class SearchInput`    | `<SearchInput />`    |
+
+**Conversion rule:**
+
+- Filename: all lowercase, words separated by hyphens
+
+- Class: PascalCase, same words, no hyphens
+
+- `user-card.gjs` → `class UserCard`
+
+**Template-only components:**
+
+```glimmer-js
+// app/components/simple-card.gjs - Template-only, no class needed
+<template>
+  <div class="card">
+    {{yield}}
+  </div>
+</template>
+```
+
+**Components in subdirectories:**
+
+```glimmer-js
+// app/components/ui/button.gjs
+import Component from '@glimmer/component';
+
+export class Button extends Component {
+  <template>
+    <button type="button">
+      {{yield}}
+    </button>
+  </template>
+}
+
+// Usage: <Ui::Button />
+```
+
+**Nested namespaces:**
+
+```glimmer-js
+// app/components/admin/user/profile-card.gjs
+import Component from '@glimmer/component';
+
+export class ProfileCard extends Component {
+  <template>
+    <div class="admin-profile">
+      {{@user.name}}
+    </div>
+  </template>
+}
+
+// Usage: <Admin::User::ProfileCard />
+```
+
+**Positive:**
+
+- ⚡️ Cleaner, more maintainable code
+
+- 🎯 Predictable mapping between files and classes
+
+- 🌐 Follows web standards (kebab-case)
+
+- 📦 Smaller bundle size (less export overhead)
+
+- 🚀 Better alignment with modern Ember/Glimmer
+
+**Negative:**
+
+- None - this is the modern standard
+
+- **Code clarity**: +30% (shorter, clearer names)
+
+- **Bundle size**: -5-10 bytes per component (no export overhead)
+
+- **Developer experience**: Improved (predictable naming)
+
+- [Ember Components Guide](https://guides.emberjs.com/release/components/)
+
+- [Glimmer Components](https://github.com/glimmerjs/glimmer.js)
+
+- [Template Tag Format RFC](https://github.com/emberjs/rfcs/pull/779)
+
+- [Strict Mode Semantics](https://github.com/emberjs/rfcs/blob/master/text/0496-handlebars-strict-mode.md)
+
+- component-use-glimmer.md - Modern Glimmer component patterns
+
+- component-strict-mode.md - Template-only components and strict mode
+
+- route-templates.md - Route file naming conventions
+
+### 3.7 Prefer Named Exports, Fallback to Default for Implicit Template Lookup
+
+**Impact: LOW (Clear export contracts across .hbs and template-tag codebases)**
+
+Use named exports for shared modules imported directly in JS/TS (utilities, constants, pure functions). If a module should be invokable from `.hbs` templates via implicit lookup, provide a default export. In hybrid `.gjs`/`.hbs` projects, a practical pattern is a named export plus a default export alias.
+
+**Incorrect: default export in a shared utility module**
+
+```javascript
+// app/utils/format-date.js
+export default function formatDate(date) {
+  return new Date(date).toLocaleDateString();
+}
+```
+
+**Correct: named export in a shared utility module**
+
+```javascript
+// app/utils/format-date.js
+export function formatDate(date) {
+  return new Date(date).toLocaleDateString();
+}
+```
+
+**Correct: hybrid `.gjs`/`.hbs` named export + default alias**
+
+```javascript
+// app/helpers/format-date.js
+import { helper } from '@ember/component/helper';
+
+export const formatDate = helper(([value]) => {
+  return new Date(value).toLocaleDateString();
+});
+
+export default formatDate;
+```
+
+Use named exports when the module is imported directly by other modules and is not resolved via implicit template lookup.
+
+**Example: utility module with multiple named exports**
+
+```javascript
+// app/utils/validators.js
+export function isEmail(value) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+}
+
+export function isPhoneNumber(value) {
+  return /^\d{3}-\d{3}-\d{4}$/.test(value);
+}
+```
+
+Benefits:
+
+1. Explicit import contracts
+
+2. Better refactor safety (symbol rename tracking)
+
+3. Better tree-shaking for utility modules
+
+4. Easier multi-export module organization
+
+Use default exports for modules consumed through resolver/template lookup.
+
+If your project uses `.hbs`, invokables that should be accessible from templates should provide `export default`.
+
+In hybrid `.gjs`/`.hbs` codebases, use named exports plus a default export alias where you want both explicit imports and template compatibility.
+
+**Service:**
+
+```javascript
+// app/services/auth.js
+import Service from '@ember/service';
+
+export default class AuthService extends Service {
+  // ...
+}
+```
+
+**Route:**
+
+```javascript
+// app/routes/dashboard.js
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class DashboardRoute extends Route {
+  @service store;
+
+  model() {
+    return this.store.findAll('dashboard-item');
+  }
+}
+```
+
+**Modifier: when invoked from `.hbs`**
+
+```javascript
+// app/modifiers/focus.js
+import { modifier } from 'ember-modifier';
+
+export default modifier((element) => {
+  element.focus();
+});
+```
+
+**Template: `.gjs`**
+
+```glimmer-js
+// app/templates/dashboard.gjs
+<template>
+  <h1>Dashboard</h1>
+</template>
+```
+
+**Template: `.gts`**
+
+```glimmer-ts
+// app/templates/dashboard.gts
+import type { TOC } from '@ember/component/template-only';
+
+interface Signature {
+  Args: {
+    model: unknown;
+  };
+}
+
+export default <template>
+  <h1>Dashboard</h1>
+</template> satisfies TOC<Signature>;
+```
+
+Template-tag files must resolve via a module default export in convention-based and `import.meta.glob` flows.
+
+For `app/templates/*.gjs`, the default export is implicit after compilation.
+
+With `ember-strict-application-resolver`, you can register explicit module values in `App.modules`:
+
+**Strict resolver explicit modules registration:**
+
+```ts
+modules = {
+  './services/manual': { default: ManualService },
+  './services/manual-shorthand': ManualService,
+};
+```
+
+In that explicit shorthand case, a direct value works without a default-exported module object.
+
+This is an explicit registration escape hatch and does not replace default-export requirements for `.hbs`-invokable modules.
+
+1. If a module should be invokable from `.hbs`, provide a default export.
+
+2. In hybrid `.gjs`/`.hbs` projects, use named export + default alias for resolver-facing modules.
+
+3. Strict resolver explicit `modules` entries may use direct shorthand values where appropriate.
+
+4. Plain shared modules (`app/utils`, shared constants, reusable pure functions): prefer named exports.
+
+5. Template-tag components (`.gjs`/`.gts`): follow the component file-conventions rule and use named class exports.
+
+- [ES Modules Best Practices](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules)
+
+- [ember-strict-application-resolver](https://github.com/ember-cli/ember-strict-application-resolver)
+
+- [ember-resolver](https://github.com/ember-cli/ember-resolver)
+
+### 3.8 Prevent Memory Leaks in Components
+
+**Impact: HIGH (Avoid memory leaks and resource exhaustion)**
+
+Properly clean up event listeners, timers, and subscriptions to prevent memory leaks.
+
+**Incorrect: no cleanup**
+
+```glimmer-js
+// app/components/live-clock.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+class LiveClock extends Component {
+  @tracked time = new Date();
+
+  constructor() {
+    super(...arguments);
+
+    // Memory leak: interval never cleared
+    setInterval(() => {
+      this.time = new Date();
+    }, 1000);
+  }
+
+  <template>
+    <div>{{this.time}}</div>
+  </template>
+}
+```
+
+**Correct: proper cleanup with registerDestructor**
+
+```glimmer-js
+// app/components/live-clock.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { registerDestructor } from '@ember/destroyable';
+
+class LiveClock extends Component {
+  @tracked time = new Date();
+
+  constructor() {
+    super(...arguments);
+
+    const intervalId = setInterval(() => {
+      this.time = new Date();
+    }, 1000);
+
+    // Proper cleanup
+    registerDestructor(this, () => {
+      clearInterval(intervalId);
+    });
+  }
+
+  <template>
+    <div>{{this.time}}</div>
+  </template>
+}
+```
+
+**Event listener cleanup:**
+
+```glimmer-js
+// app/components/window-size.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { registerDestructor } from '@ember/destroyable';
+
+class WindowSize extends Component {
+  @tracked width = window.innerWidth;
+  @tracked height = window.innerHeight;
+
+  constructor() {
+    super(...arguments);
+
+    const handleResize = () => {
+      this.width = window.innerWidth;
+      this.height = window.innerHeight;
+    };
+
+    window.addEventListener('resize', handleResize);
+
+    registerDestructor(this, () => {
+      window.removeEventListener('resize', handleResize);
+    });
+  }
+
+  <template>
+    <div>Window: {{this.width}} x {{this.height}}</div>
+  </template>
+}
+```
+
+**Using modifiers for automatic cleanup:**
+
+```glimmer-js
+// app/components/resize-aware.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import windowListener from '../modifiers/window-listener';
+
+class ResizeAware extends Component {
+  @tracked size = { width: 0, height: 0 };
+
+  handleResize = () => {
+    this.size = {
+      width: window.innerWidth,
+      height: window.innerHeight
+    };
+  }
+
+  <template>
+    <div {{windowListener "resize" this.handleResize}}>
+      {{this.size.width}} x {{this.size.height}}
+    </div>
+  </template>
+}
+```
+
+**Abort controller for fetch requests:**
+
+```glimmer-js
+// app/components/data-loader.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { registerDestructor } from '@ember/destroyable';
+
+class DataLoader extends Component {
+  @tracked data = null;
+  abortController = new AbortController();
+
+  constructor() {
+    super(...arguments);
+
+    this.loadData();
+
+    registerDestructor(this, () => {
+      this.abortController.abort();
+    });
+  }
+
+  async loadData() {
+    try {
+      const response = await fetch('/api/data', {
+        signal: this.abortController.signal
+      });
+      this.data = await response.json();
+    } catch (error) {
+      if (error.name !== 'AbortError') {
+        console.error('Failed to load data:', error);
+      }
+    }
+  }
+
+  <template>
+    {{#if this.data}}
+      <div>{{this.data.content}}</div>
+    {{/if}}
+  </template>
+}
+```
+
+**Using ember-resources for automatic cleanup:**
+
+```glimmer-js
+// app/components/websocket-data.gjs
+import Component from '@glimmer/component';
+import { resource } from 'ember-resources';
+
+class WebsocketData extends Component {
+  messages = resource(({ on }) => {
+    const messages = [];
+    const ws = new WebSocket('wss://example.com/socket');
+
+    ws.onmessage = (event) => {
+      messages.push(event.data);
+    };
+
+    // Automatic cleanup
+    on.cleanup(() => {
+      ws.close();
+    });
+
+    return messages;
+  });
+
+  <template>
+    {{#each this.messages.value as |message|}}
+      <div>{{message}}</div>
+    {{/each}}
+  </template>
+}
+```
+
+Always clean up timers, event listeners, subscriptions, and pending requests to prevent memory leaks and performance degradation.
+
+Reference: [https://api.emberjs.com/ember/release/modules/@ember%2Fdestroyable](https://api.emberjs.com/ember/release/modules/@ember%2Fdestroyable)
+
+### 3.9 Use {{on}} Modifier for Event Handling
+
+**Impact: MEDIUM (Better memory management and clarity)**
+
+Use the `{{on}}` modifier for event handling instead of traditional action handlers for better memory management and clearer code.
+
+**Incorrect: traditional action attribute**
+
+```glimmer-js
+// app/components/button.gjs
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+class Button extends Component {
+  @action
+  handleClick() {
+    this.args.onClick?.();
+  }
+
+  <template>
+    <button onclick={{this.handleClick}}>
+      {{@label}}
+    </button>
+  </template>
+}
+```
+
+**Correct: using {{on}} modifier**
+
+```glimmer-js
+// app/components/button.gjs
+import Component from '@glimmer/component';
+import { on } from '@ember/modifier';
+
+class Button extends Component {
+  handleClick = () => {
+    this.args.onClick?.();
+  }
+
+  <template>
+    <button {{on "click" this.handleClick}}>
+      {{@label}}
+    </button>
+  </template>
+}
+```
+
+**With event options:**
+
+```glimmer-js
+// app/components/scroll-tracker.gjs
+import Component from '@glimmer/component';
+import { on } from '@ember/modifier';
+
+class ScrollTracker extends Component {
+  handleScroll = (event) => {
+    console.log('Scroll position:', event.target.scrollTop);
+  }
+
+  <template>
+    <div
+      class="scrollable"
+      {{on "scroll" this.handleScroll passive=true}}
+    >
+      {{yield}}
+    </div>
+  </template>
+}
+```
+
+**Multiple event handlers:**
+
+```glimmer-js
+// app/components/input-field.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { on } from '@ember/modifier';
+
+class InputField extends Component {
+  @tracked isFocused = false;
+
+  handleFocus = () => {
+    this.isFocused = true;
+  }
+
+  handleBlur = () => {
+    this.isFocused = false;
+  }
+
+  handleInput = (event) => {
+    this.args.onInput?.(event.target.value);
+  }
+
+  <template>
+    <input
+      type="text"
+      class={{if this.isFocused "focused"}}
+      {{on "focus" this.handleFocus}}
+      {{on "blur" this.handleBlur}}
+      {{on "input" this.handleInput}}
+      value={{@value}}
+    />
+  </template>
+}
+```
+
+**Using fn helper for arguments:**
+
+```glimmer-js
+// app/components/item-list.gjs
+import { fn } from '@ember/helper';
+import { on } from '@ember/modifier';
+
+<template>
+  <ul>
+    {{#each @items as |item|}}
+      <li>
+        {{item.name}}
+        <button {{on "click" (fn @onDelete item.id)}}>
+          Delete
+        </button>
+      </li>
+    {{/each}}
+  </ul>
+</template>
+```
+
+The `{{on}}` modifier properly cleans up event listeners, supports event options (passive, capture, once), and makes event handling more explicit.
+
+Reference: [https://guides.emberjs.com/release/components/template-lifecycle-dom-and-modifiers/#toc_event-handlers](https://guides.emberjs.com/release/components/template-lifecycle-dom-and-modifiers/#toc_event-handlers)
+
+### 3.10 Use @cached for Expensive Getters
+
+**Impact: HIGH (50-90% reduction in recomputation)**
+
+Use `@cached` from `@glimmer/tracking` to memoize expensive computations that depend on tracked properties. The cached value is automatically invalidated when dependencies change.
+
+**Incorrect: recomputes on every access**
+
+```javascript
+import Component from '@glimmer/component';
+
+class DataTable extends Component {
+  get filteredAndSortedData() {
+    // Expensive: runs on every access, even if nothing changed
+    return this.args.data
+      .filter((item) => item.status === this.args.filter)
+      .sort((a, b) => a[this.args.sortBy] - b[this.args.sortBy])
+      .map((item) => this.transformItem(item));
+  }
+}
+```
+
+**Correct: cached computation**
+
+```javascript
+import Component from '@glimmer/component';
+import { cached } from '@glimmer/tracking';
+
+class DataTable extends Component {
+  @cached
+  get filteredAndSortedData() {
+    // Computed once per unique combination of dependencies
+    return this.args.data
+      .filter((item) => item.status === this.args.filter)
+      .sort((a, b) => a[this.args.sortBy] - b[this.args.sortBy])
+      .map((item) => this.transformItem(item));
+  }
+
+  transformItem(item) {
+    // Expensive transformation
+    return { ...item, computed: this.expensiveCalculation(item) };
+  }
+}
+```
+
+`@cached` memoizes the getter result and only recomputes when tracked dependencies change, providing 50-90% reduction in unnecessary work.
+
+Reference: [https://guides.emberjs.com/release/in-depth-topics/autotracking-in-depth/#toc_caching](https://guides.emberjs.com/release/in-depth-topics/autotracking-in-depth/#toc_caching)
+
+### 3.11 Use Class Fields for Component Composition
+
+**Impact: MEDIUM-HIGH (Better composition and initialization patterns)**
+
+Use class fields for clean component composition, initialization, and dependency injection patterns. Tracked class fields should be **roots of state** - representing the minimal independent state that your component owns. In most apps, you should have very few tracked fields.
+
+**Incorrect: imperative initialization, scattered state**
+
+```glimmer-js
+// app/components/data-manager.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { service } from '@ember/service';
+
+class DataManager extends Component {
+  @service store;
+  @service router;
+
+  // Scattered state management - hard to track relationships
+  @tracked currentUser = null;
+  @tracked isLoading = false;
+  @tracked error = null;
+
+  loadData = async () => {
+    this.isLoading = true;
+    try {
+      this.currentUser = await this.store.request({ url: '/users/me' });
+    } catch (e) {
+      this.error = e;
+    } finally {
+      this.isLoading = false;
+    }
+  };
+
+  <template>
+    <div>{{this.currentUser.name}}</div>
+  </template>
+}
+```
+
+**Correct: class fields with proper patterns**
+
+```glimmer-js
+// app/components/data-manager.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { service } from '@ember/service';
+import { cached } from '@glimmer/tracking';
+import { getPromiseState } from '@warp-drive/reactiveweb';
+
+class DataManager extends Component {
+  // Service injection as class fields
+  @service store;
+  @service router;
+
+  // Tracked state as class fields - this is a "root of state"
+  // Most components should have very few of these
+  @tracked selectedFilter = 'all';
+
+  // Data loading with getPromiseState
+  @cached
+  get currentUser() {
+    const promise = this.store.request({
+      url: '/users/me'
+    });
+    return getPromiseState(promise);
+  }
+
+  <template>
+    {{#if this.currentUser.isFulfilled}}
+      <div>{{this.currentUser.value.name}}</div>
+    {{else if this.currentUser.isRejected}}
+      <div>Error: {{this.currentUser.error.message}}</div>
+    {{/if}}
+  </template>
+}
+```
+
+**Understanding "roots of state":**
+
+Tracked fields should represent **independent state** that your component owns - not derived data or loaded data. Examples of good tracked fields:
+
+- User selections (selected tab, filter option)
+
+- UI state (is modal open, is expanded)
+
+- Form input values (not yet persisted)
+
+In most apps, you'll have very few tracked fields because most data comes from arguments, services, or computed getters.
+
+**Composition through class field assignment:**
+
+```glimmer-js
+// app/components/form-container.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { TrackedObject } from 'tracked-built-ins';
+
+class FormContainer extends Component {
+  // Compose form state
+  @tracked formData = new TrackedObject({
+    firstName: '',
+    lastName: '',
+    email: '',
+    preferences: {
+      newsletter: false,
+      notifications: true
+    }
+  });
+
+  // Compose validation state
+  @tracked errors = new TrackedObject({});
+
+  // Compose UI state
+  @tracked ui = new TrackedObject({
+    isSubmitting: false,
+    isDirty: false,
+    showErrors: false
+  });
+
+  // Computed field based on composed state
+  get isValid() {
+    return Object.keys(this.errors).length === 0 &&
+           this.formData.email &&
+           this.formData.firstName;
+  }
+
+  get canSubmit() {
+    return this.isValid && !this.ui.isSubmitting && this.ui.isDirty;
+  }
+
+  updateField = (field, value) => {
+    this.formData[field] = value;
+    this.ui.isDirty = true;
+    this.validate(field, value);
+  };
+
+  validate(field, value) {
+    if (field === 'email' && !value.includes('@')) {
+      this.errors.email = 'Invalid email';
+    } else {
+      delete this.errors[field];
+    }
+  }
+
+  <template>
+    <form>
+      <input
+        value={{this.formData.firstName}}
+        {{on "input" (pick "target.value" (fn this.updateField "firstName"))}}
+      />
+
+      <button disabled={{not this.canSubmit}}>
+        Submit
+      </button>
+    </form>
+  </template>
+}
+```
+
+**Mixin-like composition with class fields:**
+
+```glimmer-js
+// app/components/paginated-list.gjs
+import Component from '@glimmer/component';
+import { cached } from '@glimmer/tracking';
+import { PaginationState } from '../utils/pagination-mixin';
+
+class PaginatedList extends Component {
+  // Compose pagination functionality
+  pagination = new PaginationState();
+
+  @cached
+  get paginatedItems() {
+    const start = this.pagination.offset;
+    const end = start + this.pagination.perPage;
+    return this.args.items.slice(start, end);
+  }
+
+  get totalPages() {
+    return Math.ceil(this.args.items.length / this.pagination.perPage);
+  }
+
+  <template>
+    <div class="list">
+      {{#each this.paginatedItems as |item|}}
+        <div>{{item.name}}</div>
+      {{/each}}
+
+      <div class="pagination">
+        <button
+          {{on "click" this.pagination.prevPage}}
+          disabled={{eq this.pagination.page 1}}
+        >
+          Previous
+        </button>
+
+        <span>Page {{this.pagination.page}} of {{this.totalPages}}</span>
+
+        <button
+          {{on "click" this.pagination.nextPage}}
+          disabled={{eq this.pagination.page this.totalPages}}
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  </template>
+}
+```
+
+**Shareable state objects:**
+
+```glimmer-js
+// app/components/selectable-list.gjs
+import Component from '@glimmer/component';
+import { SelectionState } from '../utils/selection-state';
+
+class SelectableList extends Component {
+  // Compose selection behavior
+  selection = new SelectionState();
+
+  get selectedItems() {
+    return this.args.items.filter(item =>
+      this.selection.isSelected(item.id)
+    );
+  }
+
+  <template>
+    <div class="toolbar">
+      <button {{on "click" (fn this.selection.selectAll @items)}}>
+        Select All
+      </button>
+      <button {{on "click" this.selection.clear}}>
+        Clear
+      </button>
+      <span>{{this.selection.count}} selected</span>
+    </div>
+
+    <ul>
+      {{#each @items as |item|}}
+        <li class={{if (this.selection.isSelected item.id) "selected"}}>
+          <input
+            type="checkbox"
+            checked={{this.selection.isSelected item.id}}
+            {{on "change" (fn this.selection.toggle item.id)}}
+          />
+          {{item.name}}
+        </li>
+      {{/each}}
+    </ul>
+
+    {{#if this.selection.hasSelection}}
+      <div class="actions">
+        <button>Delete {{this.selection.count}} items</button>
+      </div>
+    {{/if}}
+  </template>
+}
+```
+
+Class fields provide clean composition patterns, better initialization, and shareable state objects that can be tested independently.
+
+Reference: [https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields)
+
+### 3.12 Use Component Composition Patterns
+
+**Impact: HIGH (Better code reuse and maintainability)**
+
+Use component composition with yield blocks, named blocks, and contextual components for flexible, reusable UI patterns.
+
+**Named blocks** are for invocation consistency in design systems where you **don't want the caller to have full markup control**. They provide structured extension points while maintaining design system constraints - the same concept as named slots in other frameworks.
+
+**Incorrect: monolithic component**
+
+```glimmer-js
+// app/components/user-card.gjs
+import Component from '@glimmer/component';
+
+class UserCard extends Component {
+  <template>
+    <div class="user-card">
+      <div class="header">
+        <img src={{@user.avatar}} alt={{@user.name}} />
+        <h3>{{@user.name}}</h3>
+        <p>{{@user.email}}</p>
+      </div>
+
+      {{#if @showActions}}
+        <div class="actions">
+          <button {{on "click" @onEdit}}>Edit</button>
+          <button {{on "click" @onDelete}}>Delete</button>
+        </div>
+      {{/if}}
+
+      {{#if @showStats}}
+        <div class="stats">
+          <span>Posts: {{@user.postCount}}</span>
+          <span>Followers: {{@user.followers}}</span>
+        </div>
+      {{/if}}
+    </div>
+  </template>
+}
+```
+
+**Correct: composable with named blocks**
+
+```glimmer-js
+// app/components/user-card.gjs
+import Component from '@glimmer/component';
+
+class UserCard extends Component {
+  <template>
+    <div class="user-card" ...attributes>
+      {{#if (has-block "header")}}
+        {{yield to="header"}}
+      {{else}}
+        <div class="header">
+          <img src={{@user.avatar}} alt={{@user.name}} />
+          <h3>{{@user.name}}</h3>
+        </div>
+      {{/if}}
+
+      {{yield @user to="default"}}
+
+      {{#if (has-block "actions")}}
+        <div class="actions">
+          {{yield @user to="actions"}}
+        </div>
+      {{/if}}
+
+      {{#if (has-block "footer")}}
+        <div class="footer">
+          {{yield @user to="footer"}}
+        </div>
+      {{/if}}
+    </div>
+  </template>
+}
+```
+
+**Usage with flexible composition:**
+
+```glimmer-js
+// app/components/user-list.gjs
+import UserCard from './user-card';
+
+<template>
+  {{#each @users as |user|}}
+    <UserCard @user={{user}}>
+      <:header>
+        <div class="custom-header">
+          <span class="badge">{{user.role}}</span>
+          <h3>{{user.name}}</h3>
+        </div>
+      </:header>
+
+      <:default as |u|>
+        <p class="bio">{{u.bio}}</p>
+        <p class="email">{{u.email}}</p>
+      </:default>
+
+      <:actions as |u|>
+        <button {{on "click" (fn @onEdit u)}}>Edit</button>
+        <button {{on "click" (fn @onDelete u)}}>Delete</button>
+      </:actions>
+
+      <:footer as |u|>
+        <div class="stats">
+          Posts: {{u.postCount}} | Followers: {{u.followers}}
+        </div>
+      </:footer>
+    </UserCard>
+  {{/each}}
+</template>
+```
+
+**Contextual components pattern:**
+
+```glimmer-js
+// app/components/data-table.gjs
+import Component from '@glimmer/component';
+import { hash } from '@ember/helper';
+
+class HeaderCell extends Component {
+  <template>
+    <th class="sortable" {{on "click" @onSort}}>
+      {{yield}}
+      {{#if @sorted}}
+        <span class="sort-icon">{{if @ascending "↑" "↓"}}</span>
+      {{/if}}
+    </th>
+  </template>
+}
+
+class Row extends Component {
+  <template>
+    <tr class={{if @selected "selected"}}>
+      {{yield}}
+    </tr>
+  </template>
+}
+
+class Cell extends Component {
+  <template>
+    <td>{{yield}}</td>
+  </template>
+}
+
+class DataTable extends Component {
+  <template>
+    <table class="data-table">
+      {{yield (hash
+        Header=HeaderCell
+        Row=Row
+        Cell=Cell
+      )}}
+    </table>
+  </template>
+}
+```
+
+**Using contextual components:**
+
+```glimmer-js
+// app/components/users-table.gjs
+import DataTable from './data-table';
+
+<template>
+  <DataTable as |Table|>
+    <thead>
+      <tr>
+        <Table.Header @onSort={{fn @onSort "name"}}>Name</Table.Header>
+        <Table.Header @onSort={{fn @onSort "email"}}>Email</Table.Header>
+        <Table.Header @onSort={{fn @onSort "role"}}>Role</Table.Header>
+      </tr>
+    </thead>
+    <tbody>
+      {{#each @users as |user|}}
+        <Table.Row @selected={{eq @selectedId user.id}}>
+          <Table.Cell>{{user.name}}</Table.Cell>
+          <Table.Cell>{{user.email}}</Table.Cell>
+          <Table.Cell>{{user.role}}</Table.Cell>
+        </Table.Row>
+      {{/each}}
+    </tbody>
+  </DataTable>
+</template>
+```
+
+**Renderless component pattern:**
+
+```glimmer-js
+// Usage
+import Dropdown from './dropdown';
+
+<template>
+  <Dropdown as |dd|>
+    <button {{on "click" dd.toggle}}>
+      Menu {{if dd.isOpen "▲" "▼"}}
+    </button>
+
+    {{#if dd.isOpen}}
+      <ul class="dropdown-menu">
+        <li><a href="#" {{on "click" dd.close}}>Profile</a></li>
+        <li><a href="#" {{on "click" dd.close}}>Settings</a></li>
+        <li><a href="#" {{on "click" dd.close}}>Logout</a></li>
+      </ul>
+    {{/if}}
+  </Dropdown>
+</template>
+```
+
+Component composition provides flexibility, reusability, and clean separation of concerns while maintaining type safety and clarity.
+
+Reference: [https://guides.emberjs.com/release/components/block-content/](https://guides.emberjs.com/release/components/block-content/)
+
+### 3.13 Use Glimmer Components Over Classic Components
+
+**Impact: HIGH (30-50% faster rendering)**
+
+Glimmer components are lighter, faster, and have a simpler lifecycle than classic Ember components. They don't have two-way bindings or element lifecycle hooks, making them more predictable and performant.
+
+**Incorrect: classic component**
+
+```javascript
+// app/components/user-card.js
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+
+export default Component.extend({
+  tagName: 'div',
+  classNames: ['user-card'],
+
+  fullName: computed('user.{firstName,lastName}', function () {
+    return `${this.user.firstName} ${this.user.lastName}`;
+  }),
+
+  didInsertElement() {
+    this._super(...arguments);
+    // Complex lifecycle management
+  },
+});
+```
+
+**Correct: Glimmer component**
+
+```glimmer-js
+// app/components/user-card.gjs
+import Component from '@glimmer/component';
+
+class UserCard extends Component {
+  get fullName() {
+    return `${this.args.user.firstName} ${this.args.user.lastName}`;
+  }
+
+  <template>
+    <div class="user-card">
+      <h3>{{this.fullName}}</h3>
+      <p>{{@user.email}}</p>
+    </div>
+  </template>
+}
+```
+
+Glimmer components are 30-50% faster, have cleaner APIs, and integrate better with tracked properties.
+
+Reference: [https://guides.emberjs.com/release/components/component-state-and-actions/](https://guides.emberjs.com/release/components/component-state-and-actions/)
+
+### 3.14 Use Native Forms with Platform Validation
+
+**Impact: HIGH (Reduces JavaScript form complexity and improves built-in a11y)**
+
+Rely on native `<form>` elements and the browser's Constraint Validation API instead of reinventing form handling with JavaScript. The platform is really good at forms.
+
+Over-engineering forms with JavaScript when native browser features provide validation, accessibility, and UX patterns for free.
+
+**Incorrect: Too much JavaScript**
+
+```glimmer-js
+// app/components/signup-form.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+class SignupForm extends Component {
+  @tracked email = '';
+  @tracked emailError = '';
+
+  validateEmail = () => {
+    // ❌ Reinventing email validation
+    if (!this.email.includes('@')) {
+      this.emailError = 'Invalid email';
+    }
+  };
+
+  handleSubmit = (event) => {
+    event.preventDefault();
+    if (this.emailError) return;
+    // Submit logic
+  };
+
+  <template>
+    <div>
+      <input
+        type="text"
+        value={{this.email}}
+        {{on "input" this.updateEmail}}
+        {{on "blur" this.validateEmail}}
+      />
+      {{#if this.emailError}}
+        <span class="error">{{this.emailError}}</span>
+      {{/if}}
+      <button type="button" {{on "click" this.handleSubmit}}>Submit</button>
+    </div>
+  </template>
+}
+```
+
+Use native `<form>` with proper input types and browser validation:
+
+**Correct: Native form with platform validation**
+
+```glimmer-js
+// app/components/live-search.gjs - Controlled state needed for instant search
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { on } from '@ember/modifier';
+
+class LiveSearch extends Component {
+  @tracked query = '';
+
+  updateQuery = (event) => {
+    this.query = event.target.value;
+    // Instant search as user types
+    this.args.onSearch?.(this.query);
+  };
+
+  <template>
+    {{! Controlled state justified - need instant feedback }}
+    <input
+      type="search"
+      value={{this.query}}
+      {{on "input" this.updateQuery}}
+      placeholder="Search..."
+    />
+    {{#if this.query}}
+      <p>Searching for: {{this.query}}</p>
+    {{/if}}
+  </template>
+}
+```
+
+**Performance: -15KB** (no validation libraries needed)
+
+**Accessibility: +100%** (native form semantics and error announcements)
+
+**Code: -50%** (let the platform handle it)
+
+Access and display native validation state in your component:
+
+The browser provides rich validation state via `input.validity`:
+
+For business logic validation beyond HTML5 constraints:
+
+Use controlled patterns when you need real-time interactivity that isn't form submission:
+
+**Use controlled state when you need:**
+
+- Real-time validation display as user types
+
+- Character counters
+
+- Live search/filtering
+
+- Multi-step forms where state drives UI
+
+- Form state that affects other components
+
+**Use native forms when:**
+
+- Simple submit-and-validate workflows
+
+- Standard HTML5 validation is sufficient
+
+- You want browser-native UX and accessibility
+
+- Simpler code and less JavaScript is better
+
+- [MDN: Constraint Validation API](https://developer.mozilla.org/en-US/docs/Web/API/Constraint_validation)
+
+- [MDN: FormData](https://developer.mozilla.org/en-US/docs/Web/API/FormData)
+
+- [MDN: Form Validation](https://developer.mozilla.org/en-US/docs/Learn/Forms/Form_validation)
+
+- [Ember Guides: Event Handling](https://guides.emberjs.com/release/components/component-state-and-actions/)
+
+### 3.15 Use Strict Mode and Template-Only Components
+
+**Impact: HIGH (Better type safety and simpler components)**
+
+Use strict mode and template-only components for simpler, safer code with better tooling support.
+
+**Incorrect: JavaScript component for simple templates**
+
+```glimmer-js
+// app/components/user-card.gjs
+import Component from '@glimmer/component';
+
+class UserCard extends Component {
+  <template>
+    <div class="user-card">
+      <h3>{{@user.name}}</h3>
+      <p>{{@user.email}}</p>
+    </div>
+  </template>
+}
+```
+
+**Correct: template-only component**
+
+```glimmer-js
+// app/components/user-card.gjs
+<template>
+  <div class="user-card">
+    <h3>{{@user.name}}</h3>
+    <p>{{@user.email}}</p>
+  </div>
+</template>
+```
+
+**With TypeScript for better type safety:**
+
+```glimmer-ts
+// app/components/user-card.gts
+import type { TOC } from '@ember/component/template-only';
+
+interface UserCardSignature {
+  Args: {
+    user: {
+      name: string;
+      email: string;
+    };
+  };
+}
+
+const UserCard: TOC<UserCardSignature> = <template>
+  <div class="user-card">
+    <h3>{{@user.name}}</h3>
+    <p>{{@user.email}}</p>
+  </div>
+</template>;
+
+export default UserCard;
+```
+
+**Enable strict mode in your app:**
+
+```javascript
+// ember-cli-build.js
+'use strict';
+
+const EmberApp = require('ember-cli/lib/broccoli/ember-app');
+
+module.exports = function (defaults) {
+  const app = new EmberApp(defaults, {
+    'ember-cli-babel': {
+      enableTypeScriptTransform: true,
+    },
+  });
+
+  return app.toTree();
+};
+```
+
+Template-only components are lighter, more performant, and easier to understand. Strict mode provides better error messages and prevents common mistakes.
+
+Reference: [https://guides.emberjs.com/release/upgrading/current-edition/templates/](https://guides.emberjs.com/release/upgrading/current-edition/templates/)
+
+### 3.16 Use Tracked Toolbox for Complex State
+
+**Impact: HIGH (Cleaner state management)**
+
+For complex state patterns like maps, sets, and arrays that need fine-grained reactivity, use tracked-toolbox utilities instead of marking entire structures as @tracked.
+
+**Incorrect: tracking entire structures**
+
+```javascript
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+class TodoList extends Component {
+  @tracked items = []; // Entire array replaced on every change
+
+  addItem = (item) => {
+    // Creates new array, invalidates all consumers
+    this.items = [...this.items, item];
+  };
+
+  removeItem = (index) => {
+    // Creates new array again
+    this.items = this.items.filter((_, i) => i !== index);
+  };
+}
+```
+
+**Correct: using tracked-toolbox**
+
+```javascript
+import Component from '@glimmer/component';
+import { TrackedArray } from 'tracked-built-ins';
+
+class TodoList extends Component {
+  items = new TrackedArray([]);
+
+  // Use arrow functions for methods used in templates (no @action needed)
+  addItem = (item) => {
+    // Efficiently adds to tracked array
+    this.items.push(item);
+  };
+
+  removeItem = (index) => {
+    // Efficiently removes from tracked array
+    this.items.splice(index, 1);
+  };
+}
+```
+
+**Also useful for Maps and Sets:**
+
+```javascript
+import { TrackedMap, TrackedSet } from 'tracked-built-ins';
+
+class Cache extends Component {
+  cache = new TrackedMap(); // Fine-grained reactivity per key
+  selected = new TrackedSet(); // Fine-grained reactivity per item
+}
+```
+
+tracked-built-ins provides fine-grained reactivity and better performance than replacing entire structures.
+
+Reference: [https://github.com/tracked-tools/tracked-built-ins](https://github.com/tracked-tools/tracked-built-ins)
+
+### 3.17 Validate Component Arguments
+
+**Impact: MEDIUM (Better error messages and type safety)**
+
+Validate component arguments for better error messages, documentation, and type safety.
+
+**Incorrect: no argument validation**
+
+```glimmer-js
+// app/components/user-card.gjs
+import Component from '@glimmer/component';
+
+class UserCard extends Component {
+  <template>
+    <div>
+      <h3>{{@user.name}}</h3>
+      <p>{{@user.email}}</p>
+    </div>
+  </template>
+}
+```
+
+**Correct: with TypeScript signature**
+
+```glimmer-ts
+// app/components/user-card.gts
+import Component from '@glimmer/component';
+
+interface UserCardSignature {
+  Args: {
+    user: {
+      name: string;
+      email: string;
+      avatarUrl?: string;
+    };
+    onEdit?: (user: UserCardSignature['Args']['user']) => void;
+  };
+  Blocks: {
+    default: [];
+  };
+  Element: HTMLDivElement;
+}
+
+class UserCard extends Component<UserCardSignature> {
+  <template>
+    <div ...attributes>
+      <h3>{{@user.name}}</h3>
+      <p>{{@user.email}}</p>
+
+      {{#if @user.avatarUrl}}
+        <img src={{@user.avatarUrl}} alt={{@user.name}} />
+      {{/if}}
+
+      {{#if @onEdit}}
+        <button {{on "click" (fn @onEdit @user)}}>Edit</button>
+      {{/if}}
+
+      {{yield}}
+    </div>
+  </template>
+}
+```
+
+**Runtime validation with assertions: using getters**
+
+```glimmer-js
+// app/components/data-table.gjs
+import Component from '@glimmer/component';
+import { assert } from '@ember/debug';
+
+class DataTable extends Component {
+  // Use getters so validation runs on each access and catches arg changes
+  get columns() {
+    assert(
+      'DataTable requires @columns argument',
+      this.args.columns && Array.isArray(this.args.columns)
+    );
+
+    assert(
+      '@columns must be an array of objects with "key" and "label" properties',
+      this.args.columns.every(col => col.key && col.label)
+    );
+
+    return this.args.columns;
+  }
+
+  get rows() {
+    assert(
+      'DataTable requires @rows argument',
+      this.args.rows && Array.isArray(this.args.rows)
+    );
+
+    return this.args.rows;
+  }
+
+  <template>
+    <table>
+      <thead>
+        <tr>
+          {{#each this.columns as |column|}}
+            <th>{{column.label}}</th>
+          {{/each}}
+        </tr>
+      </thead>
+      <tbody>
+        {{#each this.rows as |row|}}
+          <tr>
+            {{#each this.columns as |column|}}
+              <td>{{get row column.key}}</td>
+            {{/each}}
+          </tr>
+        {{/each}}
+      </tbody>
+    </table>
+  </template>
+}
+```
+
+**Template-only component with TypeScript:**
+
+```glimmer-ts
+// app/components/icon.gts
+import type { TOC } from '@ember/component/template-only';
+
+interface IconSignature {
+  Args: {
+    name: string;
+    size?: 'small' | 'medium' | 'large';
+  };
+  Element: HTMLSpanElement;
+}
+
+const Icon: TOC<IconSignature> = <template>
+  <span ...attributes></span>
+</template>;
+
+export default Icon;
+```
+
+**Documentation with JSDoc:**
+
+```glimmer-js
+// app/components/modal.gjs
+import Component from '@glimmer/component';
+
+/**
+ * Modal dialog component
+ *
+ * @param {Object} args
+ * @param {boolean} args.isOpen - Controls modal visibility
+ * @param {() => void} args.onClose - Called when modal should close
+ * @param {string} [args.title] - Optional modal title
+ * @param {string} [args.size='medium'] - Modal size: 'small', 'medium', 'large'
+ */
+class Modal extends Component {
+  <template>
+    {{#if @isOpen}}
+      <div>
+        {{#if @title}}
+          <h2>{{@title}}</h2>
+        {{/if}}
+        {{yield}}
+        <button {{on "click" @onClose}}>Close</button>
+      </div>
+    {{/if}}
+  </template>
+}
+```
+
+Argument validation provides better error messages during development, serves as documentation, and enables better IDE support.
+
+Reference: [https://guides.emberjs.com/release/typescript/](https://guides.emberjs.com/release/typescript/)
+
+---
+
+## 4. Accessibility Best Practices
+
+**Impact: HIGH**
+
+Making applications accessible is critical. Use ember-a11y-testing, semantic HTML, proper ARIA attributes, and keyboard navigation support.
+
+### 4.1 Announce Route Transitions to Screen Readers
+
+**Impact: HIGH (Critical for screen reader navigation)**
+
+Announce page title changes and route transitions to screen readers so users know when navigation has occurred.
+
+**Incorrect: no announcements**
+
+```javascript
+// app/router.js
+export default class Router extends EmberRouter {
+  location = config.locationType;
+  rootURL = config.rootURL;
+}
+```
+
+**Correct: using a11y-announcer library - recommended**
+
+```glimmer-js
+// app/routes/dashboard.gjs
+import { pageTitle } from 'ember-page-title';
+
+<template>
+  {{pageTitle "Dashboard"}}
+
+  <div class="dashboard">
+    {{outlet}}
+  </div>
+</template>
+```
+
+Use the [a11y-announcer](https://github.com/ember-a11y/a11y-announcer) library for robust route announcements:
+
+The a11y-announcer library automatically handles route announcements. For custom announcements in your routes:
+
+**Alternative: DIY approach with ARIA live regions:**
+
+If you prefer not to use a library, you can implement route announcements yourself:
+
+**Alternative: Use ember-page-title with announcements:**
+
+Route announcements ensure screen reader users know when navigation occurs, improving the overall accessibility experience.
+
+Reference: [https://guides.emberjs.com/release/accessibility/page-template-considerations/](https://guides.emberjs.com/release/accessibility/page-template-considerations/)
+
+### 4.2 Form Labels and Error Announcements
+
+**Impact: HIGH (Essential for screen reader users)**
+
+All form inputs must have associated labels, and validation errors should be announced to screen readers using ARIA live regions.
+
+**Incorrect: missing labels and announcements**
+
+```glimmer-js
+// app/components/form.gjs
+<template>
+  <form {{on "submit" this.handleSubmit}}>
+    <input
+      type="email"
+      value={{this.email}}
+      {{on "input" this.updateEmail}}
+      placeholder="Email"
+    />
+
+    {{#if this.emailError}}
+      <span>{{this.emailError}}</span>
+    {{/if}}
+
+    <button type="submit">Submit</button>
+  </form>
+</template>
+```
+
+**Correct: with labels and announcements**
+
+```glimmer-js
+// app/components/form.gjs
+<template>
+  <form {{on "submit" this.handleSubmit}}>
+    <div>
+      <label for="email-input">
+        Email Address
+        {{#if this.isEmailRequired}}
+          <span aria-label="required">*</span>
+        {{/if}}
+      </label>
+
+      <input
+        id="email-input"
+        type="email"
+        value={{this.email}}
+        {{on "input" this.updateEmail}}
+        aria-describedby={{if this.emailError "email-error"}}
+        aria-invalid={{if this.emailError "true"}}
+        required={{this.isEmailRequired}}
+      />
+
+      {{#if this.emailError}}
+        <span
+          id="email-error"
+          role="alert"
+          aria-live="polite"
+        >
+          {{this.emailError}}
+        </span>
+      {{/if}}
+    </div>
+
+    <button type="submit" disabled={{this.isSubmitting}}>
+      {{#if this.isSubmitting}}
+        <span aria-live="polite">Submitting...</span>
+      {{else}}
+        Submit
+      {{/if}}
+    </button>
+  </form>
+</template>
+```
+
+**For complex forms, use platform-native validation with custom logic:**
+
+```glimmer-js
+// app/components/user-form.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { on } from '@ember/modifier';
+
+class UserForm extends Component {
+  @tracked errorMessages = {};
+
+  validateEmail = (event) => {
+    // Custom business logic validation
+    const input = event.target;
+    const value = input.value;
+
+    if (!value) {
+      input.setCustomValidity('Email is required');
+      return false;
+    }
+
+    if (!input.validity.valid) {
+      input.setCustomValidity('Must be a valid email');
+      return false;
+    }
+
+    // Additional custom validation (e.g., check if email is already taken)
+    if (value === 'taken@example.com') {
+      input.setCustomValidity('This email is already registered');
+      return false;
+    }
+
+    input.setCustomValidity('');
+    return true;
+  };
+
+  handleSubmit = async (event) => {
+    event.preventDefault();
+    const form = event.target;
+
+    // Run custom validations
+    const emailInput = form.querySelector('[name="email"]');
+    const fakeEvent = { target: emailInput };
+    this.validateEmail(fakeEvent);
+
+    // Use native validation check
+    if (!form.checkValidity()) {
+      form.reportValidity();
+      return;
+    }
+
+    const formData = new FormData(form);
+    await this.args.onSubmit(formData);
+  };
+
+  <template>
+    <form {{on "submit" this.handleSubmit}}>
+      <label for="user-email">
+        Email
+        <input
+          id="user-email"
+          type="email"
+          name="email"
+          required
+          value={{@user.email}}
+          {{on "blur" this.validateEmail}}
+        />
+      </label>
+      <button type="submit">Save</button>
+    </form>
+  </template>
+}
+```
+
+Always associate labels with inputs and announce dynamic changes to screen readers using aria-live regions.
+
+Reference: [https://guides.emberjs.com/release/accessibility/application-considerations/](https://guides.emberjs.com/release/accessibility/application-considerations/)
+
+### 4.3 Keyboard Navigation Support
+
+**Impact: HIGH (Critical for keyboard-only users)**
+
+Ensure all interactive elements are keyboard accessible and focus management is handled properly, especially in modals and dynamic content.
+
+**Incorrect: no keyboard support**
+
+```glimmer-js
+// app/components/dropdown.gjs
+<template>
+  <div class="dropdown" {{on "click" this.toggleMenu}}>
+    Menu
+    {{#if this.isOpen}}
+      <div class="dropdown-menu">
+        <div {{on "click" this.selectOption}}>Option 1</div>
+        <div {{on "click" this.selectOption}}>Option 2</div>
+      </div>
+    {{/if}}
+  </div>
+</template>
+```
+
+**Correct: full keyboard support with custom modifier**
+
+```glimmer-js
+// app/components/dropdown.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { fn } from '@ember/helper';
+import focusFirst from '../modifiers/focus-first';
+
+class Dropdown extends Component {
+  @tracked isOpen = false;
+
+  @action
+  toggleMenu() {
+    this.isOpen = !this.isOpen;
+  }
+
+  @action
+  handleButtonKeyDown(event) {
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      this.isOpen = true;
+    }
+  }
+
+  @action
+  handleMenuKeyDown(event) {
+    if (event.key === 'Escape') {
+      this.isOpen = false;
+      // Return focus to button
+      event.target.closest('.dropdown').querySelector('button').focus();
+    }
+    // Handle arrow key navigation between menu items
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault();
+      this.moveFocus(event.key === 'ArrowDown' ? 1 : -1);
+    }
+  }
+
+  moveFocus(direction) {
+    const items = Array.from(
+      document.querySelectorAll('[role="menuitem"] button')
+    );
+    const currentIndex = items.indexOf(document.activeElement);
+    const nextIndex = (currentIndex + direction + items.length) % items.length;
+    items[nextIndex]?.focus();
+  }
+
+  @action
+  selectOption(value) {
+    this.args.onSelect?.(value);
+    this.isOpen = false;
+  }
+
+  <template>
+    <div class="dropdown">
+      <button
+        type="button"
+        {{on "click" this.toggleMenu}}
+        {{on "keydown" this.handleButtonKeyDown}}
+        aria-haspopup="true"
+        aria-expanded="{{this.isOpen}}"
+      >
+        Menu
+      </button>
+
+      {{#if this.isOpen}}
+        <ul
+          class="dropdown-menu"
+          role="menu"
+          {{focusFirst '[role="menuitem"] button'}}
+          {{on "keydown" this.handleMenuKeyDown}}
+        >
+          <li role="menuitem">
+            <button type="button" {{on "click" (fn this.selectOption "1")}}>
+              Option 1
+            </button>
+          </li>
+          <li role="menuitem">
+            <button type="button" {{on "click" (fn this.selectOption "2")}}>
+              Option 2
+            </button>
+          </li>
+        </ul>
+      {{/if}}
+    </div>
+  </template>
+}
+```
+
+**For focus trapping in modals, use ember-focus-trap:**
+
+```bash
+npm install @fluentui/keyboard-keys
+```
+
+**Alternative: Use libraries for keyboard support:**
+
+For complex keyboard interactions, consider using libraries that abstract keyboard support patterns:
+
+Or use [tabster](https://tabster.io/) for comprehensive keyboard navigation management including focus trapping, arrow key navigation, and modalizers.
+
+Proper keyboard navigation ensures all users can interact with your application effectively.
+
+Reference: [https://guides.emberjs.com/release/accessibility/keyboard/](https://guides.emberjs.com/release/accessibility/keyboard/)
+
+### 4.4 Semantic HTML and ARIA Attributes
+
+**Impact: HIGH (Essential for screen reader users)**
+
+Use semantic HTML elements and proper ARIA attributes to make your application accessible to screen reader users. **The first rule of ARIA is to not use ARIA** - prefer native semantic HTML elements whenever possible.
+
+**Key principle:** Native HTML elements have built-in keyboard support, roles, and behaviors. Only add ARIA when semantic HTML can't provide the needed functionality.
+
+**Incorrect: divs with insufficient semantics**
+
+```glimmer-js
+// app/components/example.gjs
+<template>
+  <div class="button" {{on "click" this.submit}}>
+    Submit
+  </div>
+
+  <div class="nav">
+    <div class="nav-item">Home</div>
+    <div class="nav-item">About</div>
+  </div>
+
+  <div class="alert">
+    {{this.message}}
+  </div>
+</template>
+```
+
+**Correct: semantic HTML with proper ARIA**
+
+```glimmer-js
+// app/components/example.gjs
+import { LinkTo } from '@ember/routing';
+
+<template>
+  <button type="submit" {{on "click" this.submit}}>
+    Submit
+  </button>
+
+  <nav aria-label="Main navigation">
+    <ul>
+      <li><LinkTo @route="index">Home</LinkTo></li>
+      <li><LinkTo @route="about">About</LinkTo></li>
+    </ul>
+  </nav>
+
+  <div role="alert" aria-live="polite" aria-atomic="true">
+    {{this.message}}
+  </div>
+</template>
+```
+
+**For interactive custom elements:**
+
+```glimmer-js
+// app/components/custom-button.gjs
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import XIcon from './x-icon';
+
+class CustomButton extends Component {
+  @action
+  handleKeyDown(event) {
+    // Support Enter and Space keys for keyboard users
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      this.handleClick();
+    }
+  }
+
+  @action
+  handleClick() {
+    this.args.onClick?.();
+  }
+
+  <template>
+    <div
+      role="button"
+      tabindex="0"
+      {{on "click" this.handleClick}}
+      {{on "keydown" this.handleKeyDown}}
+      aria-label="Close dialog"
+    >
+      <XIcon />
+    </div>
+  </template>
+}
+```
+
+Always use native semantic elements when possible. When creating custom interactive elements, ensure they're keyboard accessible and have proper ARIA attributes.
+
+**References:**
+
+- [ARIA Authoring Practices Guide (W3C)](https://www.w3.org/WAI/ARIA/apg/)
+
+- [Using ARIA (W3C)](https://www.w3.org/TR/using-aria/)
+
+- [ARIA in HTML (WHATWG)](https://html.spec.whatwg.org/multipage/aria.html#aria)
+
+- [Ember Accessibility Guide](https://guides.emberjs.com/release/accessibility/)
+
+### 4.5 Use ember-a11y-testing for Automated Checks
+
+**Impact: HIGH (Catch 30-50% of a11y issues automatically)**
+
+Integrate ember-a11y-testing into your test suite to automatically catch common accessibility violations during development. This addon uses axe-core to identify issues before they reach production.
+
+**Incorrect: no accessibility testing**
+
+```glimmer-js
+// tests/integration/components/user-form-test.js
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, fillIn, click } from '@ember/test-helpers';
+import UserForm from 'my-app/components/user-form';
+
+module('Integration | Component | user-form', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it submits the form', async function(assert) {
+    await render(<template><UserForm /></template>);
+    await fillIn('input', 'John');
+    await click('button');
+    assert.ok(true);
+  });
+});
+```
+
+**Correct: with a11y testing**
+
+```glimmer-js
+// tests/integration/components/user-form-test.js
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, fillIn, click } from '@ember/test-helpers';
+import a11yAudit from 'ember-a11y-testing/test-support/audit';
+import UserForm from 'my-app/components/user-form';
+
+module('Integration | Component | user-form', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it submits the form', async function(assert) {
+    await render(<template><UserForm /></template>);
+
+    // Automatically checks for a11y violations
+    await a11yAudit();
+
+    await fillIn('input', 'John');
+    await click('button');
+    assert.ok(true);
+  });
+});
+```
+
+**Setup: install and configure**
+
+```javascript
+// tests/test-helper.js
+import { setupGlobalA11yHooks } from 'ember-a11y-testing/test-support';
+
+setupGlobalA11yHooks(); // Runs on every test automatically
+```
+
+ember-a11y-testing catches issues like missing labels, insufficient color contrast, invalid ARIA, and keyboard navigation problems automatically.
+
+Reference: [https://github.com/ember-a11y/ember-a11y-testing](https://github.com/ember-a11y/ember-a11y-testing)
+
+---
+
+## 5. Service and State Management
+
+**Impact: MEDIUM-HIGH**
+
+Efficient service patterns, proper dependency injection, and state management reduce redundant computations and API calls.
+
+### 5.1 Cache API Responses in Services
+
+**Impact: MEDIUM-HIGH (50-90% reduction in duplicate requests)**
+
+Cache API responses in services to avoid duplicate network requests. Use tracked properties to make the cache reactive.
+
+**Incorrect: no caching**
+
+```javascript
+// app/services/user.js
+import Service from '@ember/service';
+import { service } from '@ember/service';
+
+export default class UserService extends Service {
+  @service store;
+
+  async getCurrentUser() {
+    // Fetches from API every time
+    return this.store.request({ url: '/users/me' });
+  }
+}
+```
+
+**Correct: with caching**
+
+```javascript
+// app/services/user.js
+import Service from '@ember/service';
+import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { TrackedMap } from 'tracked-built-ins';
+
+export default class UserService extends Service {
+  @service store;
+
+  @tracked currentUser = null;
+  cache = new TrackedMap();
+
+  async getCurrentUser() {
+    if (!this.currentUser) {
+      const response = await this.store.request({ url: '/users/me' });
+      this.currentUser = response.content.data;
+    }
+    return this.currentUser;
+  }
+
+  async getUser(id) {
+    if (!this.cache.has(id)) {
+      const response = await this.store.request({ url: `/users/${id}` });
+      this.cache.set(id, response.content.data);
+    }
+    return this.cache.get(id);
+  }
+
+  clearCache() {
+    this.currentUser = null;
+    this.cache.clear();
+  }
+}
+```
+
+**For time-based cache invalidation:**
+
+```javascript
+import Service from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+
+export default class DataService extends Service {
+  @tracked _cache = null;
+  _cacheTimestamp = null;
+  _cacheDuration = 5 * 60 * 1000; // 5 minutes
+
+  async getData() {
+    const now = Date.now();
+    const isCacheValid =
+      this._cache && this._cacheTimestamp && now - this._cacheTimestamp < this._cacheDuration;
+
+    if (!isCacheValid) {
+      this._cache = await this.fetchData();
+      this._cacheTimestamp = now;
+    }
+
+    return this._cache;
+  }
+
+  async fetchData() {
+    const response = await fetch('/api/data');
+    return response.json();
+  }
+}
+```
+
+Caching in services prevents duplicate API requests and improves performance significantly.
+
+### 5.2 Implement Robust Data Requesting Patterns
+
+**Impact: HIGH (Prevents request waterfalls and race conditions in data flows)**
+
+Use proper patterns for data fetching including parallel requests, error handling, request cancellation, and retry logic.
+
+`export default` in route/service snippets below is intentional because these modules are commonly resolved by convention and referenced from templates. In hybrid `.gjs`/`.hbs` codebases, you can pair named exports with a default alias where needed.
+
+Naive data fetching creates waterfall requests, doesn't handle errors properly, and can cause race conditions or memory leaks from uncanceled requests.
+
+**Incorrect:**
+
+```javascript
+// app/routes/dashboard.js
+import Route from '@ember/routing/route';
+
+export default class DashboardRoute extends Route {
+  async model() {
+    // Sequential waterfall - slow!
+    const user = await this.store.request({ url: '/users/me' });
+    const posts = await this.store.request({ url: '/posts' });
+    const notifications = await this.store.request({ url: '/notifications' });
+
+    // No error handling
+    // No cancellation
+    return { user, posts, notifications };
+  }
+}
+```
+
+Use `RSVP.hash` or `Promise.all` for parallel loading:
+
+**Correct: parallelized model loading**
+
+```javascript
+// app/services/batch-loader.js
+import Service, { service } from '@ember/service';
+
+export default class BatchLoaderService extends Service {
+  @service store;
+
+  pendingIds = new Set();
+  batchTimeout = null;
+
+  async loadUser(id) {
+    this.pendingIds.add(id);
+
+    if (!this.batchTimeout) {
+      this.batchTimeout = setTimeout(() => this.executeBatch(), 50);
+    }
+
+    // Return a promise that resolves when batch completes
+    return new Promise((resolve) => {
+      this.registerCallback(id, resolve);
+    });
+  }
+
+  async executeBatch() {
+    const ids = Array.from(this.pendingIds);
+    this.pendingIds.clear();
+    this.batchTimeout = null;
+
+    const response = await this.store.request({
+      url: `/users?ids=${ids.join(',')}`,
+    });
+
+    // Resolve all pending promises
+    response.content.forEach((user) => {
+      this.resolveCallback(user.id, user);
+    });
+  }
+}
+```
+
+Handle errors gracefully with fallbacks:
+
+Prevent race conditions by canceling stale requests:
+
+For non-ember-concurrency scenarios:
+
+When requests depend on previous results:
+
+For real-time data updates:
+
+Optimize multiple similar requests:
+
+- **Parallel requests (RSVP.hash)**: 60-80% faster than sequential
+
+- **Request cancellation**: Prevents memory leaks and race conditions
+
+- **Retry logic**: Improves reliability with < 5% overhead
+
+- **Batch loading**: 40-70% reduction in requests
+
+- **RSVP.hash**: Independent data that can load in parallel
+
+- **ember-concurrency**: Search, autocomplete, or user-driven requests
+
+- **AbortController**: Long-running requests that may become stale
+
+- **Retry logic**: Critical data with transient network issues
+
+- **Batch loading**: Loading many similar items (N+1 scenarios)
+
+- [WarpDrive Documentation](https://warp-drive.io/)
+
+- [ember-concurrency](https://ember-concurrency.com/)
+
+- [RSVP.js](https://github.com/tildeio/rsvp.js)
+
+- [AbortController MDN](https://developer.mozilla.org/en-US/docs/Web/API/AbortController)
+
+### 5.3 Manage Service Owner and Linkage Patterns
+
+**Impact: MEDIUM-HIGH (Better service organization and dependency management)**
+
+Understand how to manage service linkage, owner passing, and alternative service organization patterns beyond the traditional app/services directory.
+
+**Incorrect: manual service instantiation**
+
+```glimmer-js
+// app/components/user-profile.gjs
+import Component from '@glimmer/component';
+import ApiService from '../services/api';
+
+class UserProfile extends Component {
+  // ❌ Creates orphaned instance without owner
+  api = new ApiService();
+
+  async loadUser() {
+    // Won't have access to other services or owner features
+    return this.api.fetch('/user/me');
+  }
+
+  <template>
+    <div>{{@user.name}}</div>
+  </template>
+}
+```
+
+**Correct: proper service injection with owner**
+
+```glimmer-js
+// app/components/user-profile.gjs
+import Component from '@glimmer/component';
+import { service } from '@ember/service';
+
+class UserProfile extends Component {
+  // ✅ Proper injection with owner linkage
+  @service api;
+
+  async loadUser() {
+    // Has full owner context and can inject other services
+    return this.api.fetch('/user/me');
+  }
+
+  <template>
+    <div>{{@user.name}}</div>
+  </template>
+}
+```
+
+**Creating instances with owner:**
+
+```glimmer-js
+// app/components/data-processor.gjs
+import Component from '@glimmer/component';
+import { getOwner, setOwner } from '@ember/application';
+import { service } from '@ember/service';
+
+class DataTransformer {
+  @service store;
+
+  transform(data) {
+    // Can use injected services because it has an owner
+    return this.store.request({ url: '/transform', data });
+  }
+}
+
+class DataProcessor extends Component {
+  @service('store') storeService;
+
+  constructor(owner, args) {
+    super(owner, args);
+
+    // Manual instantiation with owner linkage
+    this.transformer = new DataTransformer();
+    setOwner(this.transformer, getOwner(this));
+  }
+
+  processData(data) {
+    // transformer can now access services
+    return this.transformer.transform(data);
+  }
+
+  <template>
+    <div>Processing...</div>
+  </template>
+}
+```
+
+**Factory pattern with owner:**
+
+```glimmer-js
+// Usage in component
+import Component from '@glimmer/component';
+import { getOwner } from '@ember/application';
+import { createLogger } from '../utils/logger-factory';
+
+class My extends Component {
+  logger = createLogger(getOwner(this), 'MyComponent');
+
+  performAction() {
+    this.logger.log('Action performed');
+  }
+
+  <template>
+    <button {{on "click" this.performAction}}>Do Something</button>
+  </template>
+}
+```
+
+**Using reactiveweb's link() for ownership and destruction:**
+
+```glimmer-js
+// app/components/advanced-form.gjs
+import Component from '@glimmer/component';
+import { link } from 'reactiveweb/link';
+
+class ValidationService {
+  validate(data) {
+    // Validation logic
+    return data.email && data.email.includes('@');
+  }
+}
+
+class FormStateManager {
+  data = { email: '' };
+
+  updateEmail(value) {
+    this.data.email = value;
+  }
+}
+
+export class AdvancedForm extends Component {
+  // link() handles both owner and destruction automatically
+  validation = link(this, () => new ValidationService());
+  formState = link(this, () => new FormStateManager());
+
+  get isValid() {
+    return this.validation.validate(this.formState.data);
+  }
+
+  <template>
+    <form>
+      <input value={{this.formState.data.email}} />
+      {{#if (not this.isValid)}}
+        <span>Invalid form</span>
+      {{/if}}
+    </form>
+  </template>
+}
+```
+
+The `link()` function from `reactiveweb` provides both ownership transfer and automatic destruction linkage.
+
+**Why use link():**
+
+- Automatically transfers owner from parent to child instance
+
+- Registers destructor so child is cleaned up when parent is destroyed
+
+- No manual `setOwner` or `registerDestructor` calls needed
+
+- See [RFC #1067](https://github.com/emberjs/rfcs/pull/1067) for the proposal and reasoning
+
+- Documentation: https://reactive.nullvoxpopuli.com/functions/link.link.html
+
+**Using createService from ember-primitives:**
+
+```glimmer-js
+// app/components/analytics-tracker.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { createService } from 'ember-primitives/utils';
+
+// Define service logic as a plain function
+function AnalyticsService() {
+  let events = [];
+
+  return {
+    get events() {
+      return events;
+    },
+
+    track(event) {
+      events.push({ ...event, timestamp: Date.now() });
+
+      // Send to analytics endpoint
+      fetch('/analytics', {
+        method: 'POST',
+        body: JSON.stringify(event)
+      });
+    }
+  };
+}
+
+export class AnalyticsTracker extends Component {
+  // createService handles owner linkage and cleanup automatically
+  analytics = createService(this, AnalyticsService);
+
+  <template>
+    <div>Tracking {{this.analytics.events.length}} events</div>
+  </template>
+}
+```
+
+**Why createService:**
+
+- No need to extend Service class
+
+- Automatic owner linkage and cleanup
+
+- Simpler than manual setOwner/registerDestructor
+
+- Documentation: https://ce1d7e18.ember-primitives.pages.dev/6-utils/createService.md
+
+**Co-located services with components:**
+
+```glimmer-js
+// app/components/shopping-cart/index.gjs
+import Component from '@glimmer/component';
+import { getOwner, setOwner } from '@ember/application';
+import { CartService } from './service';
+
+class ShoppingCart extends Component {
+  cart = (() => {
+    const instance = new CartService();
+    setOwner(instance, getOwner(this));
+    return instance;
+  })();
+
+  <template>
+    <div class="cart">
+      <h3>Cart ({{this.cart.items.length}} items)</h3>
+      <div>Total: ${{this.cart.total}}</div>
+
+      {{#each this.cart.items as |item|}}
+        <div class="cart-item">
+          {{item.name}} - ${{item.price}}
+          <button {{on "click" (fn this.cart.removeItem item.id)}}>
+            Remove
+          </button>
+        </div>
+      {{/each}}
+
+      <button {{on "click" this.cart.clear}}>Clear Cart</button>
+    </div>
+  </template>
+}
+```
+
+**Service-like utilities in utils/ directory:**
+
+```glimmer-js
+// app/components/notification-container.gjs
+import Component from '@glimmer/component';
+import { getOwner } from '@ember/application';
+import { NotificationManager } from '../utils/notification-manager';
+
+class NotificationContainer extends Component {
+  notifications = new NotificationManager(getOwner(this));
+
+  <template>
+    <div class="notifications">
+      {{#each this.notifications.notifications as |notif|}}
+        <div class="notification notification-{{notif.type}}">
+          {{notif.message}}
+          <button {{on "click" (fn this.notifications.dismiss notif.id)}}>
+            ×
+          </button>
+        </div>
+      {{/each}}
+    </div>
+
+    {{! Example usage }}
+    <button {{on "click" (fn this.notifications.add "Success!" "success")}}>
+      Show Notification
+    </button>
+  </template>
+}
+```
+
+**Runtime service registration:**
+
+```javascript
+// app/instance-initializers/dynamic-services.js
+export function initialize(appInstance) {
+  // Register service dynamically without app/services file
+  appInstance.register(
+    'service:feature-flags',
+    class FeatureFlagsService {
+      flags = {
+        newDashboard: true,
+        betaFeatures: false,
+      };
+
+      isEnabled(flag) {
+        return this.flags[flag] || false;
+      }
+    },
+  );
+
+  // Make it a singleton
+  appInstance.inject('route', 'featureFlags', 'service:feature-flags');
+  appInstance.inject('component', 'featureFlags', 'service:feature-flags');
+}
+
+export default {
+  initialize,
+};
+```
+
+**Using registered services:**
+
+```glimmer-js
+// app/components/feature-gated.gjs
+import Component from '@glimmer/component';
+import { service } from '@ember/service';
+
+class FeatureGated extends Component {
+  @service featureFlags;
+
+  get shouldShow() {
+    return this.featureFlags.isEnabled(this.args.feature);
+  }
+
+  <template>
+    {{#if this.shouldShow}}
+      {{yield}}
+    {{else}}
+      <div class="feature-disabled">This feature is not available</div>
+    {{/if}}
+  </template>
+}
+```
+
+1. **Use @service decorator** for app/services - cleanest and most maintainable
+
+2. **Use link() from reactiveweb** for ownership and destruction linkage
+
+3. **Use createService from ember-primitives** for component-scoped services without extending Service class
+
+4. **Manual owner passing** for utilities that need occasional service access
+
+5. **Co-located services** for component-specific state that doesn't need global access
+
+6. **Runtime registration** for dynamic services or testing scenarios
+
+7. **Always use setOwner** when manually instantiating classes that need services
+
+- **app/services**: Global singletons needed across the app
+
+- **link() from reactiveweb**: When you need both owner and destruction linkage
+
+- **createService from ember-primitives**: Component-scoped services without Service class
+
+- **Co-located services**: Component-specific state, not needed elsewhere
+
+- **Utils with owner**: Stateless utilities that occasionally need config/services
+
+- **Runtime registration**: Dynamic configuration, feature flags, testing
+
+Reference: [https://api.emberjs.com/ember/release/functions/@ember%2Fapplication/getOwner](https://api.emberjs.com/ember/release/functions/@ember%2Fapplication/getOwner), [https://guides.emberjs.com/release/applications/dependency-injection/](https://guides.emberjs.com/release/applications/dependency-injection/), [https://reactive.nullvoxpopuli.com/functions/link.link.html](https://reactive.nullvoxpopuli.com/functions/link.link.html), [https://ce1d7e18.ember-primitives.pages.dev/6-utils/createService.md](https://ce1d7e18.ember-primitives.pages.dev/6-utils/createService.md)
+
+### 5.4 Optimize WarpDrive Queries
+
+**Impact: MEDIUM-HIGH (40-70% reduction in API calls)**
+
+Use WarpDrive's request features effectively to reduce API calls and load only the data you need.
+
+**Incorrect: multiple queries, overfetching**
+
+```javascript
+// app/routes/posts.js
+export default class PostsRoute extends Route {
+  @service store;
+
+  async model() {
+    // Loads all posts (could be thousands)
+    const response = await this.store.request({ url: '/posts' });
+    const posts = response.content.data;
+
+    // Then filters in memory
+    return posts.filter((post) => post.attributes.status === 'published');
+  }
+}
+```
+
+**Correct: filtered query with pagination**
+
+```javascript
+// app/routes/posts.js
+export default class PostsRoute extends Route {
+  @service store;
+
+  queryParams = {
+    page: { refreshModel: true },
+    filter: { refreshModel: true },
+  };
+
+  model(params) {
+    // Server-side filtering and pagination
+    return this.store.request({
+      url: '/posts',
+      data: {
+        filter: {
+          status: 'published',
+        },
+        page: {
+          number: params.page || 1,
+          size: 20,
+        },
+        include: 'author', // Sideload related data
+        fields: {
+          // Sparse fieldsets
+          posts: 'title,excerpt,publishedAt,author',
+          users: 'name,avatar',
+        },
+      },
+    });
+  }
+}
+```
+
+**Use request with includes for single records:**
+
+```javascript
+// app/routes/post.js
+export default class PostRoute extends Route {
+  @service store;
+
+  model(params) {
+    return this.store.request({
+      url: `/posts/${params.post_id}`,
+      data: {
+        include: 'author,comments.user', // Nested relationships
+      },
+    });
+  }
+}
+```
+
+**For frequently accessed data, use cache lookups:**
+
+```javascript
+// app/components/user-badge.js
+class UserBadge extends Component {
+  @service store;
+
+  get user() {
+    // Check cache first, avoiding API call if already loaded
+    const cached = this.store.cache.peek({
+      type: 'user',
+      id: this.args.userId,
+    });
+
+    if (cached) {
+      return cached;
+    }
+
+    // Only fetch if not in cache
+    return this.store.request({
+      url: `/users/${this.args.userId}`,
+    });
+  }
+}
+```
+
+**Use request options for custom queries:**
+
+```javascript
+model() {
+  return this.store.request({
+    url: '/posts',
+    data: {
+      include: 'author,tags',
+      customParam: 'value'
+    },
+    options: {
+      reload: true // Bypass cache
+    }
+  });
+}
+```
+
+Efficient WarpDrive usage reduces network overhead and improves application performance significantly.
+
+Reference: [https://warp-drive.io/](https://warp-drive.io/)
+
+### 5.5 Use Services for Shared State
+
+**Impact: MEDIUM-HIGH (Better state management and reusability)**
+
+Use services to manage shared state across components and routes instead of passing data through multiple layers or duplicating state.
+
+**Incorrect: prop drilling**
+
+```glimmer-js
+// app/routes/dashboard.gjs
+export default class DashboardRoute extends Route {
+  model() {
+    return { currentTheme: 'dark' };
+  }
+
+  <template>
+    <Header @theme={{@model.currentTheme}} />
+    <Sidebar @theme={{@model.currentTheme}} />
+    <MainContent @theme={{@model.currentTheme}} />
+  </template>
+}
+```
+
+**Correct: using service**
+
+```javascript
+// app/components/sidebar.js
+import Component from '@glimmer/component';
+import { service } from '@ember/service';
+
+class Sidebar extends Component {
+  @service theme;
+
+  // Access theme.currentTheme directly
+}
+```
+
+Services provide centralized state management with automatic reactivity through tracked properties.
+
+**For complex state, consider using Ember Data or ember-orbit:**
+
+```javascript
+// app/services/cart.js
+import Service from '@ember/service';
+import { service } from '@ember/service';
+import { TrackedArray } from 'tracked-built-ins';
+import { cached } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class CartService extends Service {
+  @service store;
+
+  items = new TrackedArray([]);
+
+  @cached
+  get total() {
+    return this.items.reduce((sum, item) => sum + item.price, 0);
+  }
+
+  @cached
+  get itemCount() {
+    return this.items.length;
+  }
+
+  @action
+  addItem(item) {
+    this.items.push(item);
+  }
+
+  @action
+  removeItem(item) {
+    const index = this.items.indexOf(item);
+    if (index > -1) {
+      this.items.splice(index, 1);
+    }
+  }
+}
+```
+
+Reference: [https://guides.emberjs.com/release/services/](https://guides.emberjs.com/release/services/)
+
+---
+
+## 6. Template Optimization
+
+**Impact: MEDIUM**
+
+Optimizing templates with proper helpers, avoiding expensive computations in templates, and using {{#each}} efficiently improves rendering speed.
+
+### 6.1 Avoid Heavy Computation in Templates
+
+**Impact: MEDIUM (40-60% reduction in render time)**
+
+Move expensive computations from templates to cached getters in the component class or in-scope functions for template-only components. Templates should only display data, not compute it. Keep templates easy for humans to read by minimizing nested function invocations.
+
+**Why this matters:**
+
+- Templates should be easy to read and understand
+
+- Nested function calls create cognitive overhead
+
+- Computations should be cached and reused, not recalculated on every render
+
+- Template-only components (without `this`) need alternative patterns
+
+**Incorrect: heavy computation in template**
+
+```glimmer-js
+// app/components/stats.gjs
+import { sum, map, div, max, multiply, sortBy } from '../helpers/math';
+
+<template>
+  <div>
+    <p>Total: {{sum (map @items "price")}}</p>
+    <p>Average: {{div (sum (map @items "price")) @items.length}}</p>
+    <p>Max: {{max (map @items "price")}}</p>
+
+    {{#each (sortBy "name" @items) as |item|}}
+      <div>{{item.name}}: {{multiply item.price item.quantity}}</div>
+    {{/each}}
+  </div>
+</template>
+```
+
+**Correct: computation in component with cached getters**
+
+```glimmer-js
+// app/components/stats.gjs
+import Component from '@glimmer/component';
+import { cached } from '@glimmer/tracking';
+
+export class Stats extends Component {
+  // @cached is useful when getters are accessed multiple times
+  // For single access, regular getters are sufficient
+
+  @cached
+  get total() {
+    return this.args.items.reduce((sum, item) => sum + item.price, 0);
+  }
+
+  get average() {
+    // No @cached needed if only accessed once in template
+    return this.args.items.length > 0
+      ? this.total / this.args.items.length
+      : 0;
+  }
+
+  get maxPrice() {
+    return Math.max(...this.args.items.map(item => item.price));
+  }
+
+  @cached
+  get sortedItems() {
+    // @cached useful here as it's used by itemsWithTotal
+    return [...this.args.items].sort((a, b) =>
+      a.name.localeCompare(b.name)
+    );
+  }
+
+  @cached
+  get itemsWithTotal() {
+    // @cached useful as accessed multiple times in {{#each}}
+    return this.sortedItems.map(item => ({
+      ...item,
+      total: item.price * item.quantity
+    }));
+  }
+
+  <template>
+    <div>
+      <p>Total: {{this.total}}</p>
+      <p>Average: {{this.average}}</p>
+      <p>Max: {{this.maxPrice}}</p>
+
+      {{#each this.itemsWithTotal key="id" as |item|}}
+        <div>{{item.name}}: {{item.total}}</div>
+      {{/each}}
+    </div>
+  </template>
+}
+```
+
+**Note on @cached**: Use `@cached` when a getter is accessed multiple times (like in `{{#each}}` loops or by other getters). For getters accessed only once, regular getters are sufficient and avoid unnecessary memoization overhead.
+
+Moving computations to getters ensures they run only when dependencies change, not on every render. Templates remain clean and readable.
+
+### 6.2 Compose Helpers for Reusable Logic
+
+**Impact: MEDIUM-HIGH (Better code reuse and testability)**
+
+Compose helpers to create reusable, testable logic that can be combined in templates and components.
+
+**Incorrect: logic duplicated in templates**
+
+```glimmer-js
+// app/components/user-profile.gjs
+<template>
+  <div class="profile">
+    <h1>{{uppercase (truncate @user.name 20)}}</h1>
+
+    {{#if (and @user.isActive (not @user.isDeleted))}}
+      <span class="status">Active</span>
+    {{/if}}
+
+    <p>{{lowercase @user.email}}</p>
+
+    {{#if (gt @user.posts.length 0)}}
+      <span>Posts: {{@user.posts.length}}</span>
+    {{/if}}
+  </div>
+</template>
+```
+
+**Correct: composed helpers**
+
+```glimmer-js
+// app/components/user-profile.gjs
+import { displayName } from '../helpers/display-name';
+import { isVisibleUser } from '../helpers/is-visible-user';
+import { formatEmail } from '../helpers/format-email';
+
+<template>
+  <div class="profile">
+    <h1>{{displayName @user.name}}</h1>
+
+    {{#if (isVisibleUser @user)}}
+      <span class="status">Active</span>
+    {{/if}}
+
+    <p>{{formatEmail @user.email}}</p>
+
+    {{#if (gt @user.posts.length 0)}}
+      <span>Posts: {{@user.posts.length}}</span>
+    {{/if}}
+  </div>
+</template>
+```
+
+**Functional composition with pipe helper:**
+
+```javascript
+// app/helpers/pipe.js
+export function pipe(...fns) {
+  return (value) => fns.reduce((acc, fn) => fn(acc), value);
+}
+```
+
+**Or use a compose helper:**
+
+```javascript
+// app/helpers/compose.js
+export function compose(...helperFns) {
+  return (value) => helperFns.reduceRight((acc, fn) => fn(acc), value);
+}
+```
+
+**Usage:**
+
+```glimmer-js
+// app/components/text-processor.gjs
+import { fn } from '@ember/helper';
+
+// Individual helpers
+const uppercase = (str) => str?.toUpperCase() || '';
+const trim = (str) => str?.trim() || '';
+const truncate = (str, length = 20) => str?.slice(0, length) || '';
+
+<template>
+  {{! Compose multiple transformations }}
+  <div>
+    {{pipe @text (fn trim) (fn uppercase) (fn truncate 50)}}
+  </div>
+</template>
+```
+
+**Higher-order helpers:**
+
+```glimmer-js
+// Usage in template
+import { mapBy } from '../helpers/map-by';
+import { partialApply } from '../helpers/partial-apply';
+
+<template>
+  {{! Extract property from array }}
+  <ul>
+    {{#each (mapBy @users "name") as |name|}}
+      <li>{{name}}</li>
+    {{/each}}
+  </ul>
+
+  {{! Partial application }}
+  {{#let (partialApply @formatNumber 2) as |formatTwoDecimals|}}
+    <span>Price: {{formatTwoDecimals @price}}</span>
+  {{/let}}
+</template>
+```
+
+**Chainable transformation helpers:**
+
+```glimmer-js
+// Usage
+import { transform } from '../helpers/transform';
+
+<template>
+  {{#let (transform @items) as |t|}}
+    {{#each t.filter((i) => i.active).sort((a, b) => a.name.localeCompare(b.name)).take(10).result as |item|}}
+      <div>{{item.name}}</div>
+    {{/each}}
+  {{/let}}
+</template>
+```
+
+**Conditional composition:**
+
+```javascript
+// app/helpers/unless.js
+export function unless(condition, falseFn, trueFn) {
+  return !condition ? falseFn() : trueFn ? trueFn() : null;
+}
+```
+
+**Testing composed helpers:**
+
+```javascript
+// tests/helpers/display-name-test.js
+import { module, test } from 'qunit';
+import { displayName } from 'my-app/helpers/display-name';
+
+module('Unit | Helper | display-name', function () {
+  test('it formats name correctly', function (assert) {
+    assert.strictEqual(displayName('John Doe'), 'JOHN DOE');
+  });
+
+  test('it truncates long names', function (assert) {
+    assert.strictEqual(
+      displayName('A Very Long Name That Should Be Truncated', { maxLength: 10 }),
+      'A VERY LON...',
+    );
+  });
+
+  test('it handles null', function (assert) {
+    assert.strictEqual(displayName(null), '');
+  });
+});
+```
+
+Composed helpers provide testable, reusable logic that keeps templates clean and components focused on behavior rather than data transformation.
+
+Reference: [https://guides.emberjs.com/release/components/helper-functions/](https://guides.emberjs.com/release/components/helper-functions/)
+
+### 6.3 Import Helpers Directly in Templates
+
+**Impact: MEDIUM (Better tree-shaking and clarity)**
+
+Import helpers directly in gjs/gts files for better tree-shaking, clearer dependencies, and improved type safety.
+
+**Incorrect: global helper resolution**
+
+```glimmer-js
+// app/components/user-profile.gjs
+<template>
+  <div class="profile">
+    <h1>{{capitalize @user.name}}</h1>
+    <p>Joined: {{format-date @user.createdAt}}</p>
+    <p>Posts: {{pluralize @user.postCount "post"}}</p>
+  </div>
+</template>
+```
+
+**Correct: explicit helper imports**
+
+```glimmer-js
+// app/components/user-profile.gjs
+import { capitalize } from 'ember-string-helpers';
+import { formatDate } from 'ember-intl';
+import { pluralize } from 'ember-inflector';
+
+<template>
+  <div class="profile">
+    <h1>{{capitalize @user.name}}</h1>
+    <p>Joined: {{formatDate @user.createdAt}}</p>
+    <p>Posts: {{pluralize @user.postCount "post"}}</p>
+  </div>
+</template>
+```
+
+**Built-in and library helpers:**
+
+```glimmer-js
+// app/components/conditional-content.gjs
+import { fn, hash } from '@ember/helper'; // Actually built-in to Ember
+import { eq, not } from 'ember-truth-helpers'; // From ember-truth-helpers addon
+
+<template>
+  <div class="content">
+    {{#if (eq @status "active")}}
+      <span class="badge">Active</span>
+    {{/if}}
+
+    {{#if (not @isLoading)}}
+      <button {{on "click" (fn @onSave (hash id=@id data=@data))}}>
+        Save
+      </button>
+    {{/if}}
+  </div>
+</template>
+```
+
+**Custom helper with imports:**
+
+```glimmer-js
+// app/components/price-display.gjs
+import { formatCurrency } from '../utils/format-currency';
+
+<template>
+  <div class="price">
+    {{formatCurrency @amount currency="EUR"}}
+  </div>
+</template>
+```
+
+**Type-safe helpers with TypeScript:**
+
+```glimmer-ts
+// app/components/typed-component.gts
+import { fn } from '@ember/helper';
+import type { TOC } from '@ember/component/template-only';
+
+interface Signature {
+  Args: {
+    items: Array<{ id: string; name: string }>;
+    onSelect: (id: string) => void;
+  };
+}
+
+const TypedComponent: TOC<Signature> = <template>
+  <ul>
+    {{#each @items as |item|}}
+      <li {{on "click" (fn @onSelect item.id)}}>
+        {{item.name}}
+      </li>
+    {{/each}}
+  </ul>
+</template>;
+
+export default TypedComponent;
+```
+
+Explicit helper imports enable better tree-shaking, make dependencies clear, and improve IDE support with proper type checking.
+
+Reference: [https://github.com/ember-template-imports/ember-template-imports](https://github.com/ember-template-imports/ember-template-imports)
+
+### 6.4 No helper() Wrapper for Plain Functions
+
+**Impact: LOW-MEDIUM (Simpler code, better performance)**
+
+In modern Ember, plain functions can be used directly as helpers without wrapping them with `helper()`. The `helper()` wrapper is legacy and adds unnecessary complexity.
+
+**Incorrect (using helper() wrapper):**
+
+```javascript
+// app/utils/format-date.js
+import { helper } from '@ember/component/helper';
+
+function formatDate([date]) {
+  return new Date(date).toLocaleDateString();
+}
+
+export default helper(formatDate);
+```
+
+**Correct: plain function**
+
+```javascript
+// app/utils/format-date.js
+export function formatDate(date) {
+  return new Date(date).toLocaleDateString();
+}
+```
+
+**Usage in templates:**
+
+```glimmer-js
+// app/components/post-card.gjs
+import { formatDate } from '../utils/format-date';
+
+<template>
+  <article>
+    <h2>{{@post.title}}</h2>
+    <time>{{formatDate @post.publishedAt}}</time>
+  </article>
+</template>
+```
+
+**With Multiple Arguments:**
+
+```glimmer-js
+// app/components/price.gjs
+import { formatCurrency } from '../utils/format-currency';
+
+<template>
+  <span class="price">
+    {{formatCurrency @amount @currency}}
+  </span>
+</template>
+```
+
+**For Helpers that Need Services: use class-based**
+
+```javascript
+// app/utils/format-relative-time.js
+export class FormatRelativeTime {
+  constructor(owner) {
+    this.intl = owner.lookup('service:intl');
+  }
+
+  compute(date) {
+    return this.intl.formatRelative(date);
+  }
+}
+```
+
+When you need dependency injection, use a class instead of `helper()`:
+
+**Why Avoid helper():**
+
+1. **Simpler**: Plain functions are easier to understand
+
+2. **Standard JavaScript**: No Ember-specific wrapper needed
+
+3. **Better Testing**: Plain functions are easier to test
+
+4. **Performance**: No wrapper overhead
+
+5. **Modern Pattern**: Aligns with modern Ember conventions
+
+**Migration from helper():**
+
+```javascript
+// Before
+import { helper } from '@ember/component/helper';
+
+function capitalize([text]) {
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}
+
+export default helper(capitalize);
+
+// After
+export function capitalize(text) {
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}
+```
+
+**Common Helper Patterns:**
+
+```glimmer-js
+// Usage
+import { capitalize, truncate, pluralize } from '../utils/string-helpers';
+
+<template>
+  <h1>{{capitalize @title}}</h1>
+  <p>{{truncate @description 100}}</p>
+  <span>{{@count}} {{pluralize @count "item" "items"}}</span>
+</template>
+```
+
+Plain functions are the modern way to create helpers in Ember. Only use classes when you need dependency injection.
+
+Reference: [https://guides.emberjs.com/release/components/helper-functions/](https://guides.emberjs.com/release/components/helper-functions/)
+
+### 6.5 Optimize Conditional Rendering
+
+**Impact: HIGH (Reduces unnecessary rerenders in dynamic template branches)**
+
+Use efficient conditional rendering patterns to minimize unnecessary DOM updates and improve rendering performance.
+
+Inefficient conditional logic causes excessive re-renders, creates complex template code, and can lead to poor performance in lists and dynamic UIs.
+
+**Incorrect:**
+
+```glimmer-js
+// app/components/user-list.gjs
+import Component from '@glimmer/component';
+
+class UserList extends Component {
+  <template>
+    {{#each @users as |user|}}
+      <div class="user">
+        {{! Recomputes every time}}
+        {{#if (eq user.role "admin")}}
+          <span class="badge admin">{{user.name}} (Admin)</span>
+        {{/if}}
+        {{#if (eq user.role "moderator")}}
+          <span class="badge mod">{{user.name}} (Mod)</span>
+        {{/if}}
+        {{#if (eq user.role "user")}}
+          <span>{{user.name}}</span>
+        {{/if}}
+      </div>
+    {{/each}}
+  </template>
+}
+```
+
+Use `{{#if}}` / `{{#else if}}` / `{{#else}}` chains and extract computed logic to getters for better performance and readability.
+
+**Correct:**
+
+```glimmer-js
+// app/components/task-list.gjs
+import Component from '@glimmer/component';
+
+class TaskList extends Component {
+  get hasTasks() {
+    return this.args.tasks?.length > 0;
+  }
+
+  <template>
+    {{#if this.hasTasks}}
+      <ul class="task-list">
+        {{#each @tasks as |task|}}
+          <li>
+            {{task.title}}
+            {{#if task.completed}}
+              <span class="done">✓</span>
+            {{/if}}
+          </li>
+        {{/each}}
+      </ul>
+    {{else}}
+      <p class="empty-state">No tasks yet</p>
+    {{/if}}
+  </template>
+}
+```
+
+For complex conditions, use getters:
+
+Use `{{#if}}` to guard `{{#each}}` and avoid rendering empty states:
+
+**Bad:**
+
+```glimmer-js
+{{#if @user}}
+  {{#if @user.isPremium}}
+    {{#if @user.hasAccess}}
+      <PremiumContent />
+    {{/if}}
+  {{/if}}
+{{/if}}
+```
+
+**Good:**
+
+```glimmer-js
+// app/components/data-display.gjs
+import Component from '@glimmer/component';
+import { Resource } from 'ember-resources';
+import { resource } from 'ember-resources';
+
+class DataResource extends Resource {
+  @tracked data = null;
+  @tracked isLoading = true;
+  @tracked error = null;
+
+  modify(positional, named) {
+    this.fetchData(named.url);
+  }
+
+  async fetchData(url) {
+    this.isLoading = true;
+    this.error = null;
+    try {
+      const response = await fetch(url);
+      this.data = await response.json();
+    } catch (e) {
+      this.error = e.message;
+    } finally {
+      this.isLoading = false;
+    }
+  }
+}
+
+class DataDisplay extends Component {
+  @resource data = DataResource.from(() => ({
+    url: this.args.url
+  }));
+
+  <template>
+    {{#if this.data.isLoading}}
+      <div class="loading">Loading...</div>
+    {{else if this.data.error}}
+      <div class="error">Error: {{this.data.error}}</div>
+    {{else}}
+      <div class="content">
+        {{this.data.data}}
+      </div>
+    {{/if}}
+  </template>
+}
+```
+
+Use conditional rendering for component selection:
+
+Pattern for async data with loading/error states:
+
+- **Chained if/else**: 40-60% faster than multiple independent {{#if}} blocks
+
+- **Extracted getters**: ~20% faster for complex conditions (cached)
+
+- **Component switching**: Same performance as {{#if}} but better code organization
+
+- **{{#if}}/{{#else}}**: For simple true/false conditions
+
+- **Extracted getters**: For complex or reused conditions
+
+- **Component switching**: For different component types based on state
+
+- **Guard clauses**: To avoid rendering large subtrees when not needed
+
+- [Ember Guides - Conditionals](https://guides.emberjs.com/release/components/conditional-content/)
+
+- [Glimmer VM Performance](https://github.com/glimmerjs/glimmer-vm)
+
+- [@cached decorator](https://api.emberjs.com/ember/release/functions/@glimmer%2Ftracking/cached)
+
+### 6.6 Template-Only Components with In-Scope Functions
+
+**Impact: MEDIUM (Clean, performant patterns for template-only components)**
+
+For template-only components (components without a class and `this`), use in-scope functions to keep logic close to the template while avoiding unnecessary caching overhead.
+
+**Incorrect: using class-based component for simple logic**
+
+```glimmer-js
+// app/components/product-card.gjs
+import Component from '@glimmer/component';
+
+export class ProductCard extends Component {
+  // Unnecessary class and overhead for simple formatting
+  formatPrice(price) {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD'
+    }).format(price);
+  }
+
+  <template>
+    <div class="product-card">
+      <h3>{{@product.name}}</h3>
+      <div class="price">{{this.formatPrice @product.price}}</div>
+    </div>
+  </template>
+}
+```
+
+**Correct: template-only component with in-scope functions**
+
+```glimmer-js
+// app/components/product-card.gjs
+function formatPrice(price) {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD'
+  }).format(price);
+}
+
+function calculateDiscount(price, discountPercent) {
+  return price * (1 - discountPercent / 100);
+}
+
+function isOnSale(product) {
+  return product.discountPercent > 0;
+}
+
+<template>
+  <div class="product-card">
+    <h3>{{@product.name}}</h3>
+
+    {{#if (isOnSale @product)}}
+      <div class="price">
+        <span class="original">{{formatPrice @product.price}}</span>
+        <span class="sale">
+          {{formatPrice (calculateDiscount @product.price @product.discountPercent)}}
+        </span>
+      </div>
+    {{else}}
+      <div class="price">{{formatPrice @product.price}}</div>
+    {{/if}}
+
+    <p>{{@product.description}}</p>
+  </div>
+</template>
+```
+
+**When to use class-based vs template-only:**
+
+```glimmer-js
+// Use template-only when:
+// - Simple transformations
+// - Functions accessed once
+// - No state or services needed
+
+function formatDate(date) {
+  return new Date(date).toLocaleDateString();
+}
+
+<template>
+  <div class="timestamp">
+    Last updated: {{formatDate @lastUpdate}}
+  </div>
+</template>
+```
+
+**Combining in-scope functions for readability:**
+
+```glimmer-js
+// app/components/user-badge.gjs
+function getInitials(name) {
+  return name
+    .split(' ')
+    .map(part => part[0])
+    .join('')
+    .toUpperCase();
+}
+
+function getBadgeColor(status) {
+  const colors = {
+    active: 'green',
+    pending: 'yellow',
+    inactive: 'gray'
+  };
+  return colors[status] || 'gray';
+}
+
+<template>
+  <div class="user-badge" style="background-color: {{getBadgeColor @user.status}}">
+    <span class="initials">{{getInitials @user.name}}</span>
+    <span class="name">{{@user.name}}</span>
+  </div>
+</template>
+```
+
+**Anti-pattern - Complex nested calls:**
+
+```glimmer-js
+// ❌ Hard to read, lots of nesting
+<template>
+  <div>
+    {{formatCurrency (multiply (add @basePrice @taxAmount) @quantity)}}
+  </div>
+</template>
+
+// ✅ Better - use intermediate function
+function calculateTotal(basePrice, taxAmount, quantity) {
+  return (basePrice + taxAmount) * quantity;
+}
+
+function formatCurrency(amount) {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD'
+  }).format(amount);
+}
+
+<template>
+  <div>
+    {{formatCurrency (calculateTotal @basePrice @taxAmount @quantity)}}
+  </div>
+</template>
+```
+
+**Key differences from class-based components:**
+
+| Aspect           | Template-Only            | Class-Based              |
+
+| ---------------- | ------------------------ | ------------------------ |
+
+| `this` context   | ❌ No `this`             | ✅ Has `this`            |
+
+| Function caching | ❌ Recreated each render | ✅ `@cached` available   |
+
+| Services         | ❌ Cannot inject         | ✅ `@service` decorator  |
+
+| Tracked state    | ❌ No instance state     | ✅ `@tracked` properties |
+
+| Best for         | Simple, stateless        | Complex, stateful        |
+
+**Best practices:**
+
+```glimmer-js
+// app/components/stats-display.gjs
+export function average(numbers) {
+  if (numbers.length === 0) return 0;
+  return numbers.reduce((sum, n) => sum + n, 0) / numbers.length;
+}
+
+export function round(number, decimals = 2) {
+  return Math.round(number * Math.pow(10, decimals)) / Math.pow(10, decimals);
+}
+
+<template>
+  <div class="stats">
+    Average: {{round (average @scores)}}
+  </div>
+</template>
+```
+
+1. **Keep functions simple** - If computation is complex, consider a class with `@cached`
+
+2. **One responsibility per function** - Makes them reusable and testable
+
+3. **Minimize nesting** - Use intermediate functions for readability
+
+4. **No side effects** - Functions should be pure transformations
+
+5. **Export for testing** - Export functions so they can be tested independently
+
+Reference: [https://guides.emberjs.com/release/components/component-types/](https://guides.emberjs.com/release/components/component-types/), [https://guides.emberjs.com/release/components/conditional-content/](https://guides.emberjs.com/release/components/conditional-content/)
+
+### 6.7 Use {{#each}} with @key for Lists
+
+**Impact: MEDIUM (50-100% faster list updates)**
+
+Use the `key=` parameter with `{{#each}}` when objects are recreated between renders (e.g., via `.map()` or fresh API data). The default behavior uses object identity (`@identity`), which works when object references are stable.
+
+**Incorrect: no key**
+
+```glimmer-js
+// app/components/user-list.gjs
+import UserCard from './user-card';
+
+<template>
+  <ul>
+    {{#each this.users as |user|}}
+      <li>
+        <UserCard @user={{user}} />
+      </li>
+    {{/each}}
+  </ul>
+</template>
+```
+
+**Correct: with key**
+
+```glimmer-js
+// app/components/user-list.gjs
+import UserCard from './user-card';
+
+<template>
+  <ul>
+    {{#each this.users key="id" as |user|}}
+      <li>
+        <UserCard @user={{user}} />
+      </li>
+    {{/each}}
+  </ul>
+</template>
+```
+
+**For arrays of primitives: strings, numbers**
+
+```glimmer-js
+// app/components/tag-list.gjs
+<template>
+  {{! @identity is implicit, no need to write it }}
+  {{#each this.tags as |tag|}}
+    <span class="tag">{{tag}}</span>
+  {{/each}}
+</template>
+```
+
+`@identity` is the default, so you rarely need to specify it explicitly. It compares items by value for primitives.
+
+**For complex scenarios with @index:**
+
+```glimmer-js
+// app/components/item-list.gjs
+<template>
+  {{#each this.items key="@index" as |item index|}}
+    <div data-index={{index}}>
+      {{item.name}}
+    </div>
+  {{/each}}
+</template>
+```
+
+Using proper keys allows Ember's rendering engine to efficiently update, reorder, and remove items without re-rendering the entire list.
+
+**When to use `key=`:**
+
+- Objects recreated between renders (`.map()`, generators, fresh API responses) → use `key="id"` or similar
+
+- High-frequency updates (animations, real-time data) → always specify a key
+
+- Stable object references (Apollo cache, Ember Data) → default `@identity` is fine
+
+- Items never reorder → `key="@index"` is acceptable
+
+**Performance comparison: dbmon benchmark, 40 rows at 60fps**
+
+- Without key (objects recreated): Destroys/recreates DOM every frame
+
+- With `key="data.db.id"`: DOM reuse, **2x FPS improvement**
+
+- [Ember API: each helper](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/each)
+
+- [Ember template lint: equire-each-key](https://github.com/ember-template-lint/ember-template-lint/blob/main/docs/rule/require-each-key.md)
+
+- [Example PR showing the fps improvement on updated lists](https://github.com/universal-ember/table/pull/68)
+
+### 6.8 Use {{#let}} to Avoid Recomputation
+
+**Impact: MEDIUM (30-50% reduction in duplicate work)**
+
+Use `{{#let}}` to compute expensive values once and reuse them in the template instead of calling getters or helpers multiple times.
+
+**Incorrect: recomputes on every reference**
+
+```glimmer-js
+// app/components/user-card.gjs
+<template>
+  <div class="user-card">
+    {{#if (and this.user.isActive (not this.user.isDeleted))}}
+      <h3>{{this.user.fullName}}</h3>
+      <p>Status: Active</p>
+    {{/if}}
+
+    {{#if (and this.user.isActive (not this.user.isDeleted))}}
+      <button {{on "click" this.editUser}}>Edit</button>
+    {{/if}}
+
+    {{#if (and this.user.isActive (not this.user.isDeleted))}}
+      <button {{on "click" this.deleteUser}}>Delete</button>
+    {{/if}}
+  </div>
+</template>
+```
+
+**Correct: compute once, reuse**
+
+```glimmer-js
+// app/components/user-card.gjs
+<template>
+  {{#let (and this.user.isActive (not this.user.isDeleted)) as |isEditable|}}
+    <div class="user-card">
+      {{#if isEditable}}
+        <h3>{{this.user.fullName}}</h3>
+        <p>Status: Active</p>
+      {{/if}}
+
+      {{#if isEditable}}
+        <button {{on "click" this.editUser}}>Edit</button>
+      {{/if}}
+
+      {{#if isEditable}}
+        <button {{on "click" this.deleteUser}}>Delete</button>
+      {{/if}}
+    </div>
+  {{/let}}
+</template>
+```
+
+**Multiple values:**
+
+```glimmer-js
+// app/components/checkout.gjs
+<template>
+  {{#let
+    (this.calculateTotal this.items)
+    (this.formatCurrency this.total)
+    (this.hasDiscount this.user)
+    as |total formattedTotal showDiscount|
+  }}
+    <div class="checkout">
+      <p>Total: {{formattedTotal}}</p>
+
+      {{#if showDiscount}}
+        <p>Original: {{total}}</p>
+        <p>Discount Applied!</p>
+      {{/if}}
+    </div>
+  {{/let}}
+</template>
+```
+
+`{{#let}}` computes values once and caches them for the block scope, reducing redundant calculations.
+
+### 6.9 Use {{fn}} for Partial Application Only
+
+**Impact: LOW-MEDIUM (Clearer code, avoid unnecessary wrapping)**
+
+The `{{fn}}` helper is used for partial application (binding arguments), similar to JavaScript's `.bind()`. Only use it when you need to pre-bind arguments to a function. Don't use it to simply pass a function reference.
+
+**Incorrect: unnecessary use of {{fn}}**
+
+```glimmer-js
+// app/components/search.gjs
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+class Search extends Component {
+  @action
+  handleSearch(event) {
+    console.log('Searching:', event.target.value);
+  }
+
+  <template>
+    {{! Wrong - no arguments being bound}}
+    <input {{on "input" (fn this.handleSearch)}} />
+  </template>
+}
+```
+
+**Correct: direct function reference**
+
+```glimmer-js
+// app/components/search.gjs
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+class Search extends Component {
+  @action
+  handleSearch(event) {
+    console.log('Searching:', event.target.value);
+  }
+
+  <template>
+    {{! Correct - pass function directly}}
+    <input {{on "input" this.handleSearch}} />
+  </template>
+}
+```
+
+**When to Use {{fn}} - Partial Application:**
+
+```glimmer-js
+// app/components/user-list.gjs
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+class UserList extends Component {
+  @action
+  deleteUser(userId, event) {
+    console.log('Deleting user:', userId);
+    this.args.onDelete(userId);
+  }
+
+  <template>
+    <ul>
+      {{#each @users as |user|}}
+        <li>
+          {{user.name}}
+          {{! Correct - binding user.id as first argument}}
+          <button {{on "click" (fn this.deleteUser user.id)}}>
+            Delete
+          </button>
+        </li>
+      {{/each}}
+    </ul>
+  </template>
+}
+```
+
+Use `{{fn}}` when you need to pre-bind arguments to a function, similar to JavaScript's `.bind()`:
+
+**Multiple Arguments:**
+
+```glimmer-js
+// app/components/data-grid.gjs
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+class DataGrid extends Component {
+  @action
+  updateCell(rowId, columnKey, event) {
+    const newValue = event.target.value;
+    this.args.onUpdate(rowId, columnKey, newValue);
+  }
+
+  <template>
+    {{#each @rows as |row|}}
+      {{#each @columns as |column|}}
+        <input
+          value={{get row column.key}}
+          {{! Pre-binding rowId and columnKey}}
+          {{on "input" (fn this.updateCell row.id column.key)}}
+        />
+      {{/each}}
+    {{/each}}
+  </template>
+}
+```
+
+**Think of {{fn}} like .bind():**
+
+```javascript
+// JavaScript comparison
+const boundFn = this.deleteUser.bind(this, userId); // .bind() pre-binds args
+// Template equivalent: {{fn this.deleteUser userId}}
+
+// Direct reference
+const directFn = this.handleSearch; // No pre-binding
+// Template equivalent: {{this.handleSearch}}
+```
+
+**Common Patterns:**
+
+```javascript
+// ❌ Wrong - no partial application
+<button {{on "click" (fn this.save)}}>Save</button>
+
+// ✅ Correct - direct reference
+<button {{on "click" this.save}}>Save</button>
+
+// ✅ Correct - partial application with argument
+<button {{on "click" (fn this.save "draft")}}>Save Draft</button>
+
+// ❌ Wrong - no partial application
+<input {{on "input" (fn this.handleInput)}} />
+
+// ✅ Correct - direct reference
+<input {{on "input" this.handleInput}} />
+
+// ✅ Correct - partial application with field name
+<input {{on "input" (fn this.updateField "email")}} />
+```
+
+Only use `{{fn}}` when you're binding arguments. For simple function references, pass them directly.
+
+Reference: [https://guides.emberjs.com/release/components/template-lifecycle-dom-and-modifiers/#toc_passing-arguments-to-functions](https://guides.emberjs.com/release/components/template-lifecycle-dom-and-modifiers/#toc_passing-arguments-to-functions)
+
+### 6.10 Use Helper Libraries Effectively
+
+**Impact: MEDIUM (Reduces custom helper maintenance and keeps templates concise)**
+
+Leverage community helper libraries to write cleaner templates and avoid creating unnecessary custom helpers for common operations.
+
+Reinventing common functionality with custom helpers adds maintenance burden and bundle size when well-maintained helper libraries already provide the needed functionality.
+
+**Incorrect:**
+
+```glimmer-js
+// app/utils/is-equal.js - Unnecessary custom helper
+export function isEqual(a, b) {
+  return a === b;
+}
+
+// app/components/user-badge.gjs
+import { isEqual } from '../utils/is-equal';
+
+class UserBadge extends Component {
+  <template>
+    {{#if (isEqual @user.role "admin")}}
+      <span class="badge">Admin</span>
+    {{/if}}
+  </template>
+}
+```
+
+**Note:** These helpers will be built into Ember 7 core, but currently require installing the respective addon packages.
+
+**Installation:**
+
+```bash
+npm install ember-truth-helpers ember-composable-helpers
+```
+
+Use helper libraries like `ember-truth-helpers` and `ember-composable-helpers`:
+
+**Correct:**
+
+```glimmer-js
+// app/components/conditional-inline.gjs
+import Component from '@glimmer/component';
+import { if as ifHelper } from '@ember/helper'; // Built-in to Ember
+
+class ConditionalInline extends Component {
+  <template>
+    {{! Ternary-like behavior }}
+    <span class={{ifHelper @isActive "active" "inactive"}}>
+      {{@user.name}}
+    </span>
+
+    {{! Conditional attribute }}
+    <button disabled={{ifHelper @isProcessing true}}>
+      {{ifHelper @isProcessing "Processing..." "Submit"}}
+    </button>
+
+    {{! With default value }}
+    <p>{{ifHelper @description @description "No description provided"}}</p>
+  </template>
+}
+```
+
+**Installation:** `npm install ember-truth-helpers`
+
+**Installation:** `npm install ember-composable-helpers`
+
+**Dynamic Classes:**
+
+```glimmer-js
+// app/components/dynamic-classes.gjs
+import Component from '@glimmer/component';
+import { concat, if as ifHelper } from '@ember/helper'; // Built-in to Ember
+import { and, not } from 'ember-truth-helpers';
+
+class DynamicClasses extends Component {
+  <template>
+    <div class={{concat
+      "card "
+      (ifHelper @isPremium "premium ")
+      (ifHelper (and @isNew (not @isRead)) "unread ")
+      @customClass
+    }}>
+      <h3>{{@title}}</h3>
+    </div>
+  </template>
+}
+```
+
+**List Filtering:**
+
+```glimmer-js
+// app/components/user-profile-card.gjs
+import Component from '@glimmer/component';
+import { concat, if as ifHelper, fn } from '@ember/helper'; // Built-in to Ember
+import { eq, not, and, or } from 'ember-truth-helpers';
+import { hash, array, get } from 'ember-composable-helpers/helpers';
+import { on } from '@ember/modifier';
+
+class UserProfileCard extends Component {
+  updateField = (field, value) => {
+    this.args.onUpdate(field, value);
+  };
+
+  <template>
+    <div class={{concat
+      "profile-card "
+      (ifHelper @user.isPremium "premium ")
+      (ifHelper (and @user.isOnline (not @user.isAway)) "online ")
+    }}>
+      <h2>{{concat @user.firstName " " @user.lastName}}</h2>
+
+      {{#if (or (eq @user.role "admin") (eq @user.role "moderator"))}}
+        <span class="badge">
+          {{get (hash
+            admin="Administrator"
+            moderator="Moderator"
+          ) @user.role}}
+        </span>
+      {{/if}}
+
+      {{#if (and @canEdit (not @user.locked))}}
+        <div class="actions">
+          {{#each (array "profile" "settings" "privacy") as |section|}}
+            <button {{on "click" (fn this.updateField "activeSection" section)}}>
+              Edit {{section}}
+            </button>
+          {{/each}}
+        </div>
+      {{/if}}
+
+      <p class={{ifHelper @user.verified "verified" "unverified"}}>
+        {{ifHelper @user.bio @user.bio "No bio provided"}}
+      </p>
+    </div>
+  </template>
+}
+```
+
+- **Library helpers**: ~0% overhead (compiled into efficient bytecode)
+
+- **Custom helpers**: 5-15% overhead per helper call
+
+- **Inline logic**: Cleaner templates, better tree-shaking
+
+- **Library helpers**: For all common operations (equality, logic, arrays, strings)
+
+- **Custom helpers**: Only for domain-specific logic not covered by library helpers
+
+- **Component logic**: For complex operations that need @cached or multiple dependencies
+
+**Note:** These helpers will be built into Ember 7 core. Until then:
+
+**Actually Built-in to Ember (from `@ember/helper`):**
+
+- `concat` - Concatenate strings
+
+- `fn` - Partial application / bind arguments
+
+- `if` - Ternary-like conditional value
+
+- `mut` - Create settable binding (use sparingly)
+
+**From `ember-truth-helpers` package:**
+
+- `eq` - Equality (===)
+
+- `not` - Negation (!)
+
+- `and` - Logical AND
+
+- `or` - Logical OR
+
+- `lt`, `lte`, `gt`, `gte` - Numeric comparisons
+
+**From `ember-composable-helpers` package:**
+
+- `array` - Create array inline
+
+- `hash` - Create object inline
+
+- `get` - Dynamic property access
+
+- [Ember Built-in Helpers](https://guides.emberjs.com/release/templates/built-in-helpers/)
+
+- [Template Helpers API](https://api.emberjs.com/ember/release/modules/@ember%2Fhelper)
+
+- [fn Helper Guide](https://guides.emberjs.com/release/components/helper-functions/)
+
+- [ember-truth-helpers](https://github.com/jmurphyau/ember-truth-helpers)
+
+- [ember-composable-helpers](https://github.com/DockYard/ember-composable-helpers)
+
+---
+
+## 7. Performance Optimization
+
+**Impact: MEDIUM**
+
+Performance-focused rendering and event handling patterns help reduce unnecessary work in hot UI paths.
+
+### 7.1 Use {{on}} Modifier Instead of Event Handler Properties
+
+**Impact: MEDIUM (Better performance and clearer event handling)**
+
+Always use the `{{on}}` modifier for event handling instead of HTML event handler properties. The `{{on}}` modifier provides better memory management, automatic cleanup, and clearer intent.
+
+**Why {{on}} is Better:**
+
+- Automatic cleanup when element is removed (prevents memory leaks)
+
+- Supports event options (`capture`, `passive`, `once`)
+
+- More explicit and searchable in templates
+
+**Incorrect: HTML event properties**
+
+```glimmer-js
+// app/components/button.gjs
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+export default class Button extends Component {
+  @action
+  handleClick() {
+    console.log('clicked');
+  }
+
+  <template>
+    <button onclick={{this.handleClick}}>
+      Click Me
+    </button>
+  </template>
+}
+```
+
+**Correct: {{on}} modifier**
+
+```glimmer-js
+// app/components/scrollable.gjs
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { on } from '@ember/modifier';
+
+export default class Scrollable extends Component {
+  @action
+  handleScroll(event) {
+    console.log('scrolled', event.target.scrollTop);
+  }
+
+  <template>
+    {{! passive: true improves scroll performance }}
+    <div {{on "scroll" this.handleScroll passive=true}}>
+      {{yield}}
+    </div>
+  </template>
+}
+```
+
+The `{{on}}` modifier supports standard event listener options:
+
+**Available options:**
+
+```glimmer-js
+// app/components/todo-list.gjs
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { on } from '@ember/modifier';
+
+export default class TodoList extends Component {
+  @action
+  handleClick(event) {
+    // Find which todo was clicked
+    const todoId = event.target.closest('[data-todo-id]')?.dataset.todoId;
+    if (todoId) {
+      this.args.onTodoClick?.(todoId);
+    }
+  }
+
+  <template>
+    {{! Single listener for all todos - better than one per item }}
+    <ul {{on "click" this.handleClick}}>
+      {{#each @todos as |todo|}}
+        <li data-todo-id={{todo.id}}>
+          {{todo.title}}
+        </li>
+      {{/each}}
+    </ul>
+  </template>
+}
+```
+
+- `capture` - Use capture phase instead of bubble phase
+
+- `once` - Remove listener after first invocation
+
+- `passive` - Indicates handler won't call `preventDefault()` (better scroll performance)
+
+Handle these in your action, not in the template:
+
+For lists with many items, use event delegation on the parent:
+
+**❌ Don't bind directly without @action:**
+
+```glimmer-js
+// This won't work - loses 'this' context
+<button {{on "click" this.myMethod}}>Bad</button>
+```
+
+**✅ Use @action decorator:**
+
+```glimmer-js
+@action
+myMethod() {
+  // 'this' is correctly bound
+}
+
+<button {{on "click" this.myMethod}}>Good</button>
+```
+
+**❌ Don't use string event handlers:**
+
+```glimmer-js
+{{! Security risk and doesn't work in strict mode }}
+<button onclick="handleClick()">Bad</button>
+```
+
+Always use the `{{on}}` modifier for cleaner, safer, and more performant event handling in Ember applications.
+
+**References:**
+
+- [Ember Modifiers Guide](https://guides.emberjs.com/release/components/template-lifecycle-dom-and-modifiers/)
+
+- [{{on}} Modifier RFC](https://github.com/emberjs/rfcs/blob/master/text/0471-on-modifier.md)
+
+- [Event Listener Options](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#parameters)
+
+---
+
+## 8. Testing Best Practices
+
+**Impact: MEDIUM**
+
+Modern testing patterns, waiters, and abstraction utilities improve test reliability and maintainability.
+
+### 8.1 MSW (Mock Service Worker) Setup for Testing
+
+**Impact: HIGH (Proper API mocking without ORM complexity)**
+
+Use MSW (Mock Service Worker) for API mocking in tests. MSW provides a cleaner approach than Mirage by intercepting requests at the network level without introducing unnecessary ORM patterns or abstractions.
+
+Create a test helper to set up MSW in your tests:
+
+MSW works in integration tests too:
+
+1. **Define handlers per test** - Use `server.use()` in individual tests rather than global handlers
+
+2. **Reset between tests** - The helper automatically resets handlers after each test
+
+3. **Use JSON:API format** - Keep responses consistent with your API format
+
+4. **Test error states** - Mock various HTTP error codes (400, 401, 403, 404, 500)
+
+5. **Capture requests** - Use the request object to verify what your app sent
+
+6. **Use fixtures** - Create reusable test data to keep tests DRY
+
+7. **Simulate delays** - Test loading states with artificial delays
+
+8. **Type-safe responses** - In TypeScript, type your response payloads
+
+**Incorrect: using Mirage with ORM complexity**
+
+```javascript
+// mirage/config.js
+export default function () {
+  this.namespace = '/api';
+
+  // Complex schema and factories
+  this.get('/users', (schema) => {
+    return schema.users.all();
+  });
+
+  // Need to maintain schema, factories, serializers
+  this.post('/users', (schema, request) => {
+    let attrs = JSON.parse(request.requestBody);
+    return schema.users.create(attrs);
+  });
+}
+```
+
+**Correct: using MSW with simple network mocking**
+
+```javascript
+// tests/helpers/msw.js
+import { http, HttpResponse } from 'msw';
+
+// Simple request/response mocking
+export const handlers = [
+  http.get('/api/users', () => {
+    return HttpResponse.json([
+      { id: 1, name: 'Alice' },
+      { id: 2, name: 'Bob' },
+    ]);
+  }),
+
+  http.post('/api/users', async ({ request }) => {
+    const user = await request.json();
+    return HttpResponse.json({ id: 3, ...user }, { status: 201 });
+  }),
+];
+```
+
+**Why MSW over Mirage:**
+
+- **Better conventions** - Mock at the network level, not with an ORM
+
+- **Simpler mental model** - Define request handlers, return responses
+
+- **Doesn't lead developers astray** - No schema migrations or factories to maintain
+
+- **Works everywhere** - Same mocks work in tests, Storybook, and development
+
+- **More realistic** - Actually intercepts fetch/XMLHttpRequest
+
+**Default handlers for all tests:**
+
+```javascript
+// tests/helpers/msw.js
+const defaultHandlers = [
+  // Always return current user
+  http.get('/api/current-user', () => {
+    return HttpResponse.json({
+      data: {
+        id: '1',
+        type: 'user',
+        attributes: { name: 'Test User', role: 'admin' },
+      },
+    });
+  }),
+];
+```
+
+**One-time handlers (don't persist):**
+
+```javascript
+// MSW handlers persist until resetHandlers() is called
+// The test helper automatically resets after each test
+// For a one-time handler within a test, manually reset:
+test('one-time response', async function (assert) {
+  server.use(
+    http.get('/api/special', () => {
+      return HttpResponse.json({ data: 'special' });
+    }),
+  );
+
+  // First request gets mocked response
+  await visit('/special');
+  assert.dom('[data-test-data]').hasText('special');
+
+  // Reset to remove this handler
+  server.resetHandlers();
+
+  // Subsequent requests will use default handlers or be unhandled
+});
+```
+
+**Conditional responses:**
+
+```javascript
+http.post('/api/login', async ({ request }) => {
+  const { email, password } = await request.json();
+
+  if (email === 'test@example.com' && password === 'password') {
+    return HttpResponse.json({
+      data: { token: 'abc123' },
+    });
+  }
+
+  return HttpResponse.json({ errors: [{ title: 'Invalid credentials' }] }, { status: 401 });
+});
+```
+
+If migrating from Mirage:
+
+1. Remove `ember-cli-mirage` dependency
+
+2. Delete `mirage/` directory (models, factories, scenarios)
+
+3. Install MSW: `npm install --save-dev msw`
+
+4. Create the MSW test helper (see above)
+
+5. Replace `setupMirage(hooks)` with `setupMSW(hooks)`
+
+6. Convert Mirage handlers:
+
+   - `this.server.get()` → `http.get()`
+
+   - `this.server.create()` → Return inline JSON
+
+   - `this.server.createList()` → Return array of JSON objects
+
+**Before: Mirage**
+
+```javascript
+test('lists posts', async function (assert) {
+  this.server.createList('post', 3);
+  await visit('/posts');
+  assert.dom('[data-test-post]').exists({ count: 3 });
+});
+```
+
+**After: MSW**
+
+```javascript
+test('lists posts', async function (assert) {
+  server.use(
+    http.get('/api/posts', () => {
+      return HttpResponse.json({
+        data: [
+          { id: '1', type: 'post', attributes: { title: 'Post 1' } },
+          { id: '2', type: 'post', attributes: { title: 'Post 2' } },
+          { id: '3', type: 'post', attributes: { title: 'Post 3' } },
+        ],
+      });
+    }),
+  );
+  await visit('/posts');
+  assert.dom('[data-test-post]').exists({ count: 3 });
+});
+```
+
+Reference: [https://discuss.emberjs.com/t/my-cookbook-for-various-emberjs-things/19679](https://discuss.emberjs.com/t/my-cookbook-for-various-emberjs-things/19679), [https://mswjs.io/docs/](https://mswjs.io/docs/)
+
+### 8.2 Provide DOM-Abstracted Test Utilities for Library Components
+
+**Impact: MEDIUM (Stabilizes consumer tests against internal DOM refactors)**
+
+When building reusable components or libraries, consumers should not need to know implementation details or interact directly with the component's DOM. DOM structure should be considered **private** unless the author of the tests is the **owner** of the code being tested.
+
+Without abstracted test utilities:
+
+- Component refactoring breaks consumer tests
+
+- Tests are tightly coupled to implementation details
+
+- Teams waste time updating tests when internals change
+
+- Testing becomes fragile and maintenance-heavy
+
+**Library authors should provide test utilities that fully abstract the DOM.** These utilities expose a public API for testing that remains stable even when internal implementation changes.
+
+**Incorrect: exposing DOM to consumers**
+
+```glimmer-js
+// Consumer's test - tightly coupled to DOM
+import { render, click } from '@ember/test-helpers';
+import { DataGrid } from 'my-library';
+
+test('sorting works', async function(assert) {
+  await render(<template>
+    <DataGrid @rows={{this.rows}} />
+  </template>);
+
+  // Fragile: breaks if class names or structure change
+  await click('.data-grid__header .sort-button[data-column="name"]');
+
+  assert.dom('.data-grid__row:first-child').hasText('Alice');
+});
+```
+
+**Problems:**
+
+- Consumer knows about `.data-grid__header`, `.sort-button`, `[data-column]`
+
+- Refactoring component structure breaks consumer tests
+
+- No clear public API for testing
+
+**Correct: providing DOM-abstracted test utilities**
+
+```glimmer-js
+// Consumer's test - abstracted from DOM
+import { render } from '@ember/test-helpers';
+import { DataGrid } from 'my-library';
+import { getDataGrid } from 'my-library/test-support';
+
+test('sorting works', async function(assert) {
+  await render(<template>
+    <DataGrid @rows={{this.rows}} @columns={{this.columns}} />
+  </template>);
+
+  const grid = getDataGrid();
+
+  // Clean API: no DOM knowledge required
+  await grid.sortBy('name');
+
+  assert.strictEqual(grid.getRow(0), 'Alice');
+  assert.deepEqual(grid.getRows(), ['Alice', 'Bob', 'Charlie']);
+});
+```
+
+**Benefits:**
+
+```javascript
+// addon/test-support/modal.js
+import { click, find, waitUntil } from '@ember/test-helpers';
+
+export class ModalTestHelper {
+  constructor(container = document) {
+    this.container = container;
+  }
+
+  get element() {
+    return find('[data-test-modal]', this.container);
+  }
+
+  isOpen() {
+    return this.element !== null;
+  }
+
+  async waitForOpen() {
+    await waitUntil(() => this.isOpen(), { timeout: 1000 });
+  }
+
+  async waitForClose() {
+    await waitUntil(() => !this.isOpen(), { timeout: 1000 });
+  }
+
+  getTitle() {
+    const titleEl = find('[data-test-modal-title]', this.element);
+    return titleEl ? titleEl.textContent.trim() : null;
+  }
+
+  getBody() {
+    const bodyEl = find('[data-test-modal-body]', this.element);
+    return bodyEl ? bodyEl.textContent.trim() : null;
+  }
+
+  async close() {
+    if (!this.isOpen()) {
+      throw new Error('Cannot close modal: modal is not open');
+    }
+    await click('[data-test-modal-close]', this.element);
+  }
+
+  async clickButton(buttonText) {
+    const buttons = findAll('[data-test-modal-button]', this.element);
+    const button = buttons.find((btn) => btn.textContent.trim() === buttonText);
+    if (!button) {
+      const available = buttons.map((b) => b.textContent.trim()).join(', ');
+      throw new Error(`Button "${buttonText}" not found. Available: ${available}`);
+    }
+    await click(button);
+  }
+}
+
+export function getModal(container) {
+  return new ModalTestHelper(container);
+}
+```
+
+- Component internals can change without breaking consumer tests
+
+- Clear, documented testing API
+
+- Consumer tests are declarative and readable
+
+- Library maintains API stability contract
+
+On projects with teams, DOM abstraction prevents:
+
+- Merge conflicts from test changes
+
+- Cross-team coordination overhead
+
+- Broken tests from uncoordinated refactoring
+
+- Knowledge silos about component internals
+
+For solo projects, the benefit is smaller but still valuable:
+
+- Easier refactoring without test maintenance
+
+- Better separation of concerns
+
+- Professional API design practice
+
+**Before:** ~30-50% of test maintenance time spent updating selectors
+
+**After:** Minimal test maintenance when refactoring components
+
+- **component-avoid-classes-in-examples.md** - Avoid exposing implementation details
+
+- **testing-modern-patterns.md** - Modern testing approaches
+
+- **testing-render-patterns.md** - Component testing patterns
+
+- [Testing Best Practices - ember-learn](https://guides.emberjs.com/release/testing/)
+
+- [ember-test-selectors](https://github.com/mainmatter/ember-test-selectors) - Addon for stripping test selectors from production
+
+- [Page Objects Pattern](https://martinfowler.com/bliki/PageObject.html) - Related testing abstraction pattern
+
+### 8.3 Use Appropriate Render Patterns in Tests
+
+**Impact: MEDIUM (Simpler test code and better readability)**
+
+Choose the right rendering pattern based on whether your component needs arguments, blocks, or attributes in the test.
+
+**Incorrect: using template tag unnecessarily**
+
+```javascript
+// tests/integration/components/loading-spinner-test.js
+import { render } from '@ember/test-helpers';
+import LoadingSpinner from 'my-app/components/loading-spinner';
+
+test('it renders', async function (assert) {
+  // ❌ Unnecessary template wrapper for component with no args
+  await render(
+    <template>
+      <LoadingSpinner />
+    </template>,
+  );
+
+  assert.dom('[data-test-spinner]').exists();
+});
+```
+
+**Correct: direct component render when no args needed**
+
+```glimmer-js
+// tests/integration/components/user-card-test.js
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import UserCard from 'my-app/components/user-card';
+
+module('Integration | Component | user-card', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders with arguments', async function(assert) {
+    const user = { name: 'John Doe', email: 'john@example.com' };
+
+    // ✅ Use template tag when passing arguments
+    await render(<template>
+      <UserCard @user={{user}} />
+    </template>);
+
+    assert.dom('[data-test-user-name]').hasText('John Doe');
+  });
+
+  test('it renders with block content', async function(assert) {
+    // ✅ Use template tag when providing blocks
+    await render(<template>
+      <UserCard>
+        <:header>Custom Header</:header>
+        <:body>Custom Content</:body>
+      </UserCard>
+    </template>);
+
+    assert.dom('[data-test-header]').hasText('Custom Header');
+    assert.dom('[data-test-body]').hasText('Custom Content');
+  });
+
+  test('it renders with HTML attributes', async function(assert) {
+    // ✅ Use template tag when passing HTML attributes
+    await render(<template>
+      <UserCard class="featured" data-test-featured />
+    </template>);
+
+    assert.dom('[data-test-featured]').exists();
+    assert.dom('[data-test-featured]').hasClass('featured');
+  });
+});
+```
+
+**Pattern 1: Direct component render (no args/blocks/attributes):**
+
+**Pattern 2: Template tag render (with args/blocks/attributes):**
+
+**Complete example showing both patterns:**
+
+```glimmer-js
+// tests/integration/components/button-test.js
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click } from '@ember/test-helpers';
+import Button from 'my-app/components/button';
+
+module('Integration | Component | button', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders default button', async function(assert) {
+    // ✅ No args needed - use direct render
+    await render(Button);
+
+    assert.dom('button').exists();
+    assert.dom('button').hasText('Click me');
+  });
+
+  test('it renders with custom text', async function(assert) {
+    // ✅ Needs block content - use template tag
+    await render(<template>
+      <Button>Submit Form</Button>
+    </template>);
+
+    assert.dom('button').hasText('Submit Form');
+  });
+
+  test('it handles click action', async function(assert) {
+    assert.expect(1);
+
+    const handleClick = () => {
+      assert.ok(true, 'Click handler called');
+    };
+
+    // ✅ Needs argument - use template tag
+    await render(<template>
+      <Button @onClick={{handleClick}}>Click me</Button>
+    </template>);
+
+    await click('button');
+  });
+
+  test('it applies variant styling', async function(assert) {
+    // ✅ Needs argument - use template tag
+    await render(<template>
+      <Button @variant="primary">Primary Button</Button>
+    </template>);
+
+    assert.dom('button').hasClass('btn-primary');
+  });
+});
+```
+
+**Testing template-only components:**
+
+```glimmer-js
+// tests/integration/components/icon-test.js
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import Icon from 'my-app/components/icon';
+
+module('Integration | Component | icon', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders default icon', async function(assert) {
+    // ✅ Template-only component with no args - use direct render
+    await render(Icon);
+
+    assert.dom('[data-test-icon]').exists();
+  });
+
+  test('it renders specific icon', async function(assert) {
+    // ✅ Needs @name argument - use template tag
+    await render(<template>
+      <Icon @name="check" @size="large" />
+    </template>);
+
+    assert.dom('[data-test-icon]').hasAttribute('data-icon', 'check');
+    assert.dom('[data-test-icon]').hasClass('icon-large');
+  });
+});
+```
+
+**Decision guide:**
+
+| Scenario                            | Pattern                            | Example                                                     |
+
+| ----------------------------------- | ---------------------------------- | ----------------------------------------------------------- |
+
+| No arguments, blocks, or attributes | `render(Component)`                | `render(LoadingSpinner)`                                    |
+
+| Component needs arguments           | `render(<template>...</template>)` | `render(<template><Card @title="Hello" /></template>)`      |
+
+| Component receives block content    | `render(<template>...</template>)` | `render(<template><Card>Content</Card></template>)`         |
+
+| Component needs HTML attributes     | `render(<template>...</template>)` | `render(<template><Card class="featured" /></template>)`    |
+
+| Multiple test context properties    | `render(<template>...</template>)` | `render(<template><Card @data={{this.data}} /></template>)` |
+
+**Why this matters:**
+
+- **Simplicity**: Direct render reduces boilerplate for simple cases
+
+- **Clarity**: Template syntax makes data flow explicit when needed
+
+- **Consistency**: Clear pattern helps teams write maintainable tests
+
+- **Type Safety**: Both patterns work with TypeScript for component types
+
+**Common patterns:**
+
+```glimmer-js
+// ✅ Simple component, no setup needed
+await render(LoadingSpinner);
+await render(Divider);
+await render(Logo);
+
+// ✅ Component with arguments from test context
+await render(<template>
+  <UserList @users={{this.users}} @onSelect={{this.handleSelect}} />
+</template>);
+
+// ✅ Component with named blocks
+await render(<template>
+  <Modal>
+    <:header>Title</:header>
+    <:body>Content</:body>
+    <:footer><button>Close</button></:footer>
+  </Modal>
+</template>);
+
+// ✅ Component with splattributes
+await render(<template>
+  <Card class="highlighted" data-test-card role="article">
+    Card content
+  </Card>
+</template>);
+```
+
+Using the appropriate render pattern keeps tests clean and expressive.
+
+Reference: [https://guides.emberjs.com/release/testing/](https://guides.emberjs.com/release/testing/)
+
+### 8.4 Use Modern Testing Patterns
+
+**Impact: HIGH (Better test coverage and maintainability)**
+
+Use modern Ember testing patterns with `@ember/test-helpers` and `qunit-dom` for better test coverage and maintainability.
+
+**Incorrect: old testing patterns**
+
+```glimmer-js
+// tests/integration/components/user-card-test.js
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, find, click } from '@ember/test-helpers';
+import UserCard from 'my-app/components/user-card';
+
+module('Integration | Component | user-card', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    await render(<template><UserCard /></template>);
+
+    // Using find() instead of qunit-dom
+    assert.ok(find('.user-card'));
+  });
+});
+```
+
+**Correct: modern testing patterns**
+
+```glimmer-js
+// tests/integration/components/user-card-test.js
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click } from '@ember/test-helpers';
+import { setupIntl } from 'ember-intl/test-support';
+import UserCard from 'my-app/components/user-card';
+
+module('Integration | Component | user-card', function(hooks) {
+  setupRenderingTest(hooks);
+  setupIntl(hooks);
+
+  test('it renders user information', async function(assert) {
+    const user = {
+      name: 'John Doe',
+      email: 'john@example.com',
+      avatarUrl: '/avatar.jpg'
+    };
+
+    await render(<template>
+      <UserCard @user={{user}} />
+    </template>);
+
+    // qunit-dom assertions
+    assert.dom('[data-test-user-name]').hasText('John Doe');
+    assert.dom('[data-test-user-email]').hasText('john@example.com');
+    assert.dom('[data-test-user-avatar]')
+      .hasAttribute('src', '/avatar.jpg')
+      .hasAttribute('alt', 'John Doe');
+  });
+
+  test('it handles edit action', async function(assert) {
+    assert.expect(1);
+
+    const user = { name: 'John Doe', email: 'john@example.com' };
+    const handleEdit = (editedUser) => {
+      assert.deepEqual(editedUser, user, 'Edit handler called with user');
+    };
+
+    await render(<template>
+      <UserCard @user={{user}} @onEdit={{handleEdit}} />
+    </template>);
+
+    await click('[data-test-edit-button]');
+  });
+});
+```
+
+**Component testing with reactive state:**
+
+```glimmer-ts
+// tests/integration/components/search-box-test.ts
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, fillIn } from '@ember/test-helpers';
+import { trackedObject } from '@ember/reactive/collections';
+import SearchBox from 'my-app/components/search-box';
+
+module('Integration | Component | search-box', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it performs search', async function(assert) {
+    // Use trackedObject for reactive state in tests
+    const state = trackedObject({
+      results: [] as string[]
+    });
+
+    const handleSearch = (query: string) => {
+      state.results = [`Result for ${query}`];
+    };
+
+    await render(<template>
+      <SearchBox @onSearch={{handleSearch}} />
+      <ul data-test-results>
+        {{#each state.results as |result|}}
+          <li>{{result}}</li>
+        {{/each}}
+      </ul>
+    </template>);
+
+    await fillIn('[data-test-search-input]', 'ember');
+
+    // State updates reactively - no waitFor needed when using test-waiters
+    assert.dom('[data-test-results] li').hasText('Result for ember');
+  });
+});
+```
+
+**Testing with ember-concurrency tasks:**
+
+```glimmer-js
+// tests/integration/components/async-button-test.js
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click } from '@ember/test-helpers';
+import AsyncButton from 'my-app/components/async-button';
+
+module('Integration | Component | async-button', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it shows loading state during task execution', async function(assert) {
+    let resolveTask;
+    const onSave = () => {
+      return new Promise(resolve => { resolveTask = resolve; });
+    };
+
+    await render(<template>
+      <AsyncButton @onSave={{onSave}}>
+        Save
+      </AsyncButton>
+    </template>);
+
+    // Trigger the task
+    await click('[data-test-button]');
+
+    // ember-concurrency automatically registers test waiters
+    // The button will be disabled while the task runs
+    assert.dom('[data-test-button]').hasAttribute('disabled');
+    assert.dom('[data-test-loading-spinner]').hasText('Saving...');
+
+    // Resolve the task
+    resolveTask();
+    // No need to call settled() - ember-concurrency's test waiters handle this
+
+    assert.dom('[data-test-button]').doesNotHaveAttribute('disabled');
+    assert.dom('[data-test-loading-spinner]').doesNotExist();
+    assert.dom('[data-test-button]').hasText('Save');
+  });
+});
+```
+
+**When to use test-waiters with ember-concurrency:**
+
+- **ember-concurrency auto-registers test waiters** - You don't need to manually register test waiters for ember-concurrency tasks. The library automatically waits for tasks to complete before test helpers like `click()`, `fillIn()`, etc. resolve.
+
+- **You still need test-waiters when:**
+
+  - Using raw Promises outside of ember-concurrency tasks
+
+  - Working with third-party async operations that don't integrate with Ember's test waiter system
+
+  - Creating custom async behavior that needs to pause test execution
+
+- **You DON'T need additional test-waiters when:**
+
+  - Using ember-concurrency tasks (already handled)
+
+  - Using Ember Data operations (already handled)
+
+  - Using `settled()` from `@ember/test-helpers` (already coordinates with test waiters)
+
+  - **Note**: `waitFor()` and `waitUntil()` from `@ember/test-helpers` are code smells - if you need them, it indicates missing test-waiters in your code. Instrument your async operations with test-waiters instead.
+
+**Route testing with MSW: Mock Service Worker**
+
+```javascript
+// tests/acceptance/posts-test.js
+import { module, test } from 'qunit';
+import { visit, currentURL, click } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { http, HttpResponse } from 'msw';
+import { setupMSW } from 'my-app/tests/helpers/msw';
+
+module('Acceptance | posts', function (hooks) {
+  setupApplicationTest(hooks);
+  const { server } = setupMSW(hooks);
+
+  test('visiting /posts', async function (assert) {
+    server.use(
+      http.get('/api/posts', () => {
+        return HttpResponse.json({
+          data: [
+            { id: '1', type: 'post', attributes: { title: 'Post 1' } },
+            { id: '2', type: 'post', attributes: { title: 'Post 2' } },
+            { id: '3', type: 'post', attributes: { title: 'Post 3' } },
+          ],
+        });
+      }),
+    );
+
+    await visit('/posts');
+
+    assert.strictEqual(currentURL(), '/posts');
+    assert.dom('[data-test-post-item]').exists({ count: 3 });
+  });
+
+  test('clicking a post navigates to detail', async function (assert) {
+    server.use(
+      http.get('/api/posts', () => {
+        return HttpResponse.json({
+          data: [{ id: '1', type: 'post', attributes: { title: 'Test Post', slug: 'test-post' } }],
+        });
+      }),
+      http.get('/api/posts/test-post', () => {
+        return HttpResponse.json({
+          data: { id: '1', type: 'post', attributes: { title: 'Test Post', slug: 'test-post' } },
+        });
+      }),
+    );
+
+    await visit('/posts');
+    await click('[data-test-post-item]:first-child');
+
+    assert.strictEqual(currentURL(), '/posts/test-post');
+    assert.dom('[data-test-post-title]').hasText('Test Post');
+  });
+});
+```
+
+**Note:** Use MSW (Mock Service Worker) for API mocking instead of Mirage. MSW provides better conventions and doesn't lead developers astray. See `testing-msw-setup.md` for detailed setup instructions.
+
+**Accessibility testing:**
+
+```glimmer-js
+// tests/integration/components/modal-test.js
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click } from '@ember/test-helpers';
+import a11yAudit from 'ember-a11y-testing/test-support/audit';
+import Modal from 'my-app/components/modal';
+
+module('Integration | Component | modal', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it passes accessibility audit', async function(assert) {
+    await render(<template>
+      <Modal @isOpen={{true}} @title="Test Modal">
+        <p>Modal content</p>
+      </Modal>
+    </template>);
+
+    await a11yAudit();
+    assert.ok(true, 'no a11y violations');
+  });
+
+  test('it traps focus', async function(assert) {
+    await render(<template>
+      <Modal @isOpen={{true}}>
+        <button data-test-first>First</button>
+        <button data-test-last>Last</button>
+      </Modal>
+    </template>);
+
+    assert.dom('[data-test-first]').isFocused();
+
+    // Tab should stay within modal
+    await click('[data-test-last]');
+    assert.dom('[data-test-last]').isFocused();
+  });
+});
+```
+
+**Testing with data-test attributes:**
+
+```glimmer-js
+// app/components/user-profile.gjs
+import Component from '@glimmer/component';
+
+class UserProfile extends Component {
+  <template>
+    <div class="user-profile" data-test-user-profile>
+      <img
+        src={{@user.avatar}}
+        alt={{@user.name}}
+        data-test-avatar
+      />
+      <h2 data-test-name>{{@user.name}}</h2>
+      <p data-test-email>{{@user.email}}</p>
+
+      {{#if @onEdit}}
+        <button
+          {{on "click" (fn @onEdit @user)}}
+          data-test-edit-button
+        >
+          Edit
+        </button>
+      {{/if}}
+    </div>
+  </template>
+}
+```
+
+Modern testing patterns with `@ember/test-helpers`, `qunit-dom`, and data-test attributes provide better test reliability, readability, and maintainability.
+
+Reference: [https://guides.emberjs.com/release/testing/](https://guides.emberjs.com/release/testing/)
+
+### 8.5 Use qunit-dom for Better Test Assertions
+
+**Impact: MEDIUM (More readable and maintainable tests)**
+
+Use `qunit-dom` for DOM assertions in tests. It provides expressive, chainable assertions that make tests more readable and provide better error messages than raw QUnit assertions.
+
+**Why qunit-dom:**
+
+- More expressive and readable test assertions
+
+- Better error messages when tests fail
+
+- Type-safe with TypeScript
+
+- Reduces boilerplate in DOM testing
+
+**Incorrect: verbose QUnit assertions**
+
+```javascript
+// tests/integration/components/greeting-test.js
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+
+
+module('Integration | Component | greeting', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    await render(<template><Greeting @name="World" /></template>);
+
+    const element = this.element.querySelector('.greeting');
+    assert.ok(element, 'greeting element exists');
+    assert.equal(element.textContent.trim(), 'Hello, World!', 'shows greeting');
+    assert.ok(element.classList.contains('greeting'), 'has greeting class');
+  });
+});
+```
+
+**Correct: expressive qunit-dom**
+
+```javascript
+// tests/integration/components/greeting-test.js
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+
+
+module('Integration | Component | greeting', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    await render(<template><Greeting @name="World" /></template>);
+
+    assert.dom('.greeting').exists('greeting element exists');
+    assert.dom('.greeting').hasText('Hello, World!', 'shows greeting');
+  });
+});
+```
+
+**Existence and Visibility:**
+
+```javascript
+test('element visibility', async function (assert) {
+  await render(
+    <template>
+      <MyComponent />
+    </template>,
+  );
+
+  // Element exists in DOM
+  assert.dom('[data-test-output]').exists();
+
+  // Element doesn't exist
+  assert.dom('[data-test-deleted]').doesNotExist();
+
+  // Element is visible (not display: none or visibility: hidden)
+  assert.dom('[data-test-visible]').isVisible();
+
+  // Element is not visible
+  assert.dom('[data-test-hidden]').isNotVisible();
+
+  // Count elements
+  assert.dom('[data-test-item]').exists({ count: 3 });
+});
+```
+
+**Text Content:**
+
+```javascript
+test('text assertions', async function (assert) {
+  await render(<template><Article @title="Hello World" /></template>);
+
+  // Exact text match
+  assert.dom('h1').hasText('Hello World');
+
+  // Contains text (partial match)
+  assert.dom('p').containsText('Hello');
+
+  // Any text exists
+  assert.dom('h1').hasAnyText();
+
+  // No text
+  assert.dom('.empty').hasNoText();
+});
+```
+
+**Attributes:**
+
+```javascript
+test('attribute assertions', async function (assert) {
+  await render(<template><Button @disabled={{true}} /></template>);
+
+  // Has attribute (any value)
+  assert.dom('button').hasAttribute('disabled');
+
+  // Has specific attribute value
+  assert.dom('button').hasAttribute('type', 'submit');
+
+  // Attribute value matches regex
+  assert.dom('a').hasAttribute('href', /^https:\/\//);
+
+  // Doesn't have attribute
+  assert.dom('button').doesNotHaveAttribute('aria-hidden');
+
+  // Has ARIA attributes
+  assert.dom('[role="button"]').hasAttribute('aria-label', 'Close dialog');
+});
+```
+
+**Classes:**
+
+```javascript
+test('class assertions', async function (assert) {
+  await render(<template><Card @status="active" /></template>);
+
+  // Has single class
+  assert.dom('.card').hasClass('active');
+
+  // Doesn't have class
+  assert.dom('.card').doesNotHaveClass('disabled');
+
+  // Has no classes at all
+  assert.dom('.plain').hasNoClass();
+});
+```
+
+**Form Elements:**
+
+```javascript
+test('accessibility', async function (assert) {
+  await render(<template><Modal @onClose={{this.close}} /></template>);
+
+  // ARIA roles
+  assert.dom('[role="dialog"]').exists();
+  assert.dom('[role="dialog"]').hasAttribute('aria-modal', 'true');
+
+  // Labels
+  assert.dom('[aria-label="Close modal"]').exists();
+
+  // Focus management
+  assert.dom('[data-test-close-button]').isFocused();
+
+  // Required fields
+  assert.dom('input[name="email"]').hasAttribute('aria-required', 'true');
+});
+```
+
+You can chain multiple assertions on the same element:
+
+Add custom messages to make failures clearer:
+
+Use qunit-dom for basic accessibility checks:
+
+1. **Use data-test attributes** for test selectors instead of classes:
+
+   ```javascript
+
+   // Good
+
+   assert.dom('[data-test-submit-button]').exists();
+
+   // Avoid - classes can change
+
+   assert.dom('.btn.btn-primary').exists();
+
+   ```
+
+2. **Make assertions specific**:
+
+   ```javascript
+
+   // Better - exact match
+
+   assert.dom('h1').hasText('Welcome');
+
+   // Less specific - could miss issues
+
+   assert.dom('h1').containsText('Welc');
+
+   ```
+
+3. **Use meaningful custom messages**:
+
+   ```javascript
+
+   assert.dom('[data-test-error]').hasText('Invalid email', 'shows correct validation error');
+
+   ```
+
+4. **Combine with @ember/test-helpers**:
+
+   ```javascript
+
+   import { click, fillIn } from '@ember/test-helpers';
+
+   await fillIn('[data-test-email]', 'user@example.com');
+
+   await click('[data-test-submit]');
+
+   assert.dom('[data-test-success]').exists();
+
+   ```
+
+5. **Test user-visible behavior**, not implementation:
+
+   ```javascript
+
+   // Good - tests what user sees
+
+   assert.dom('[data-test-greeting]').hasText('Hello, Alice');
+
+   // Avoid - tests implementation details
+
+   assert.ok(this.component.internalState === 'ready');
+
+   ```
+
+qunit-dom makes your tests more maintainable and easier to understand. It comes pre-installed with `ember-qunit`, so you can start using it immediately.
+
+**References:**
+
+- [qunit-dom Documentation](https://github.com/mainmatter/qunit-dom)
+
+- [qunit-dom API](https://github.com/mainmatter/qunit-dom/blob/master/API.md)
+
+- [Ember Testing Guide](https://guides.emberjs.com/release/testing/)
+
+### 8.6 Use Test Waiters for Async Operations
+
+**Impact: HIGH (Reliable tests that don't depend on implementation details)**
+
+Instrument async code with test waiters instead of using `waitFor()` or `waitUntil()` in tests. Test waiters abstract async implementation details so tests focus on user behavior rather than timing.
+
+**Why Test Waiters Matter:**
+
+Test waiters allow `settled()` and other test helpers to automatically wait for your async operations. This means:
+
+- Tests don't need to know about implementation details (timeouts, polling intervals, etc.)
+
+- Tests are written from a user's perspective ("click button, see result")
+
+- Code refactoring doesn't break tests
+
+- Tests are more reliable and less flaky
+
+**Incorrect: testing implementation details**
+
+```glimmer-js
+// tests/integration/components/data-loader-test.js
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click, waitFor } from '@ember/test-helpers';
+import DataLoader from 'my-app/components/data-loader';
+
+module('Integration | Component | data-loader', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it loads data', async function(assert) {
+    await render(<template><DataLoader /></template>);
+
+    await click('[data-test-load-button]');
+
+    // BAD: Test knows about implementation details
+    // If the component changes from polling every 100ms to 200ms, test breaks
+    await waitFor('[data-test-data]', { timeout: 5000 });
+
+    assert.dom('[data-test-data]').hasText('Loaded data');
+  });
+});
+```
+
+**Correct: using test waiters**
+
+```glimmer-js
+// tests/integration/components/data-loader-test.js
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click, settled } from '@ember/test-helpers';
+import DataLoader from 'my-app/components/data-loader';
+
+module('Integration | Component | data-loader', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it loads data', async function(assert) {
+    await render(<template><DataLoader /></template>);
+
+    await click('[data-test-load-button]');
+
+    // GOOD: settled() automatically waits for test waiters
+    // No knowledge of timing needed - tests from user's perspective
+    await settled();
+
+    assert.dom('[data-test-data]').hasText('Loaded data');
+  });
+});
+```
+
+**Test waiter with cleanup:**
+
+```glimmer-js
+// app/components/polling-widget.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { registerDestructor } from '@ember/destroyable';
+import { buildWaiter } from '@ember/test-waiters';
+
+const waiter = buildWaiter('polling-widget');
+
+export class PollingWidget extends Component {
+  @tracked status = 'idle';
+  intervalId = null;
+  token = null;
+
+  constructor(owner, args) {
+    super(owner, args);
+
+    registerDestructor(this, () => {
+      this.stopPolling();
+    });
+  }
+
+  startPolling = () => {
+    // Register async operation
+    this.token = waiter.beginAsync();
+
+    this.intervalId = setInterval(() => {
+      this.checkStatus();
+    }, 1000);
+  };
+
+  stopPolling = () => {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
+
+    // End async operation on cleanup
+    if (this.token) {
+      waiter.endAsync(this.token);
+      this.token = null;
+    }
+  };
+
+  checkStatus = async () => {
+    const response = await fetch('/api/status');
+    this.status = await response.text();
+
+    if (this.status === 'complete') {
+      this.stopPolling();
+    }
+  };
+
+  <template>
+    <div>
+      <button {{on "click" this.startPolling}} data-test-start>
+        Start Polling
+      </button>
+      <div data-test-status>{{this.status}}</div>
+    </div>
+  </template>
+}
+```
+
+**Test waiter with Services:**
+
+```glimmer-js
+// tests/unit/services/data-sync-test.js
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { settled } from '@ember/test-helpers';
+
+module('Unit | Service | data-sync', function(hooks) {
+  setupTest(hooks);
+
+  test('it syncs data', async function(assert) {
+    const service = this.owner.lookup('service:data-sync');
+
+    // Start async operation
+    const syncPromise = service.sync();
+
+    // No need for manual waiting - settled() handles it
+    await settled();
+
+    const result = await syncPromise;
+    assert.ok(result, 'Sync completed successfully');
+  });
+});
+```
+
+**Multiple concurrent operations:**
+
+```glimmer-js
+// app/components/parallel-loader.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { buildWaiter } from '@ember/test-waiters';
+
+const waiter = buildWaiter('parallel-loader');
+
+export class ParallelLoader extends Component {
+  @tracked results = [];
+
+  loadAll = async () => {
+    const urls = ['/api/data1', '/api/data2', '/api/data3'];
+
+    // Each request gets its own token
+    const requests = urls.map(async (url) => {
+      const token = waiter.beginAsync();
+
+      try {
+        const response = await fetch(url);
+        return await response.json();
+      } finally {
+        waiter.endAsync(token);
+      }
+    });
+
+    this.results = await Promise.all(requests);
+  };
+
+  <template>
+    <button {{on "click" this.loadAll}} data-test-load-all>
+      Load All
+    </button>
+
+    {{#each this.results as |result|}}
+      <div data-test-result>{{result}}</div>
+    {{/each}}
+  </template>
+}
+```
+
+**Benefits:**
+
+1. **User-focused tests**: Tests describe user actions, not implementation
+
+2. **Resilient to refactoring**: Change timing/polling without breaking tests
+
+3. **No arbitrary timeouts**: Tests complete as soon as operations finish
+
+4. **Automatic waiting**: `settled()`, `click()`, etc. wait for all registered operations
+
+5. **Better debugging**: Test waiters show pending operations when tests hang
+
+**When to use test waiters:**
+
+- Network requests (fetch, XHR)
+
+- Timers and intervals (setTimeout, setInterval)
+
+- Animations and transitions
+
+- Polling operations
+
+- Any async operation that affects rendered output
+
+**When NOT needed:**
+
+- ember-concurrency already registers test waiters automatically
+
+- Promises that complete before render (data preparation in constructors)
+
+- Operations that don't affect the DOM or component state
+
+**Key principle:** If your code does something async that users care about, register it with a test waiter. Tests should never use `waitFor()` or `waitUntil()` - those are code smells indicating missing test waiters.
+
+Reference: [https://github.com/emberjs/ember-test-waiters](https://github.com/emberjs/ember-test-waiters)
+
+---
+
+## 9. Tooling and Configuration
+
+**Impact: MEDIUM**
+
+Consistent editor setup and tooling recommendations improve team productivity and reduce environment drift.
+
+### 9.1 VSCode Extensions and MCP Configuration for Ember Projects
+
+**Impact: HIGH (Improves editor consistency and AI-assisted debugging setup)**
+
+Set up recommended VSCode extensions and Model Context Protocol (MCP) servers for optimal Ember development experience.
+
+**Incorrect: no extension recommendations**
+
+```json
+{
+  "recommendations": []
+}
+```
+
+**Correct: recommended extensions for Ember**
+
+```json
+{
+  "recommendations": [
+    "emberjs.vscode-ember",
+    "vunguyentuan.vscode-glint",
+    "esbenp.prettier-vscode",
+    "dbaeumer.vscode-eslint"
+  ]
+}
+```
+
+Create a `.vscode/extensions.json` file in your project root to recommend extensions to all team members:
+
+**ember-extension-pack** (or individual extensions):**
+
+- `emberjs.vscode-ember` - Ember.js language support
+
+- Syntax highlighting for `.hbs`, `.gjs`, `.gts` files
+
+- IntelliSense for Ember-specific patterns
+
+- Code snippets for common Ember patterns
+
+**Glint 2 Extension** (for TypeScript projects):**
+
+```json
+{
+  "github.copilot.enable": {
+    "*": true,
+    "yaml": false,
+    "plaintext": false,
+    "markdown": false
+  },
+  "mcp.servers": {
+    "ember-mcp": {
+      "command": "npx",
+      "args": ["@ember/mcp-server"],
+      "description": "Ember.js MCP Server - Provides Ember-specific context"
+    },
+    "chrome-devtools": {
+      "command": "npx",
+      "args": ["@modelcontextprotocol/server-chrome-devtools"],
+      "description": "Chrome DevTools MCP Server - Browser debugging integration"
+    },
+    "playwright": {
+      "command": "npx",
+      "args": ["@playwright/mcp-server"],
+      "description": "Playwright MCP Server - Browser automation and testing"
+    }
+  }
+}
+```
+
+- `vunguyentuan.vscode-glint` - Type checking for Glimmer templates
+
+- Real-time type errors in `.gts`/`.gjs` files
+
+- Template-aware autocomplete
+
+- Hover information for template helpers and components
+
+Install instructions:
+
+Configure MCP servers in `.vscode/settings.json` to integrate AI coding assistants with Ember-specific context:
+
+**Ember MCP Server** (`@ember/mcp-server`):**
+
+- Ember API documentation lookup
+
+- Component and helper discovery
+
+- Addon documentation integration
+
+- Routing and data layer context
+
+**Chrome DevTools MCP** (`@modelcontextprotocol/server-chrome-devtools`):**
+
+- Live browser inspection
+
+- Console debugging assistance
+
+- Network request analysis
+
+- Performance profiling integration
+
+**Playwright MCP** (optional, `@playwright/mcp-server`):**
+
+```json
+{
+  "compilerOptions": {
+    // ... standard TS options
+  },
+  "glint": {
+    "environment": ["ember-loose", "ember-template-imports"]
+  }
+}
+```
+
+- Test generation assistance
+
+- Browser automation context
+
+- E2E testing patterns
+
+- Debugging test failures
+
+Ensure your `tsconfig.json` has Glint configuration:
+
+1. **Install extensions** (prompted automatically when opening project with `.vscode/extensions.json`)
+
+2. **Install Glint** (if using TypeScript):
+
+   ```bash
+
+   npm install --save-dev @glint/core @glint/environment-ember-loose @glint/environment-ember-template-imports
+
+   ```
+
+3. **Configure MCP servers** in `.vscode/settings.json`
+
+4. **Reload VSCode** to activate all extensions and MCP integrations
+
+- **Consistent team setup**: All developers get same extensions
+
+- **Type safety**: Glint provides template type checking
+
+- **AI assistance**: MCP servers give AI tools Ember-specific context
+
+- **Better DX**: Autocomplete, debugging, and testing integration
+
+- **Reduced onboarding**: New team members get productive faster
+
+- [VSCode Ember Extension](https://marketplace.visualstudio.com/items?itemName=emberjs.vscode-ember)
+
+- [Glint Documentation](https://typed-ember.gitbook.io/glint/)
+
+- [MCP Protocol Specification](https://modelcontextprotocol.io/)
+
+- [Ember Primitives VSCode Setup Example](https://github.com/universal-ember/ember-primitives/tree/main/.vscode)
+
+---
+
+## 10. Advanced Patterns
+
+**Impact: MEDIUM-HIGH**
+
+Modern Ember patterns including Resources for lifecycle management, ember-concurrency for async operations, modifiers for DOM side effects, helpers for reusable logic, and comprehensive testing patterns with render strategies.
+
+### 10.1 Use Ember Concurrency Correctly - User Concurrency Not Data Loading
+
+**Impact: HIGH (Prevents infinite render loops and improves performance)**
+
+ember-concurrency is designed for **user-initiated concurrency patterns** (debouncing, throttling, preventing double-clicks), not data loading. Use task return values, don't set tracked state inside tasks.
+
+- [TaskInstance API](https://ember-concurrency.com/api/TaskInstance.html)
+
+- [Task API](https://ember-concurrency.com/api/Task.html)
+
+- [ember-concurrency](https://ember-concurrency.com/)
+
+- [warp-drive/reactiveweb](https://github.com/emberjs/data/tree/main/packages/reactiveweb)
+
+**Incorrect: using ember-concurrency for data loading with tracked state**
+
+```glimmer-js
+// app/components/user-profile.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { task } from 'ember-concurrency';
+
+class UserProfile extends Component {
+  @tracked userData = null;
+  @tracked error = null;
+
+  // WRONG: Setting tracked state inside task
+  loadUserTask = task(async () => {
+    try {
+      const response = await fetch(`/api/users/${this.args.userId}`);
+      this.userData = await response.json(); // Anti-pattern!
+    } catch (e) {
+      this.error = e; // Anti-pattern!
+    }
+  });
+
+  <template>
+    {{#if this.loadUserTask.isRunning}}
+      Loading...
+    {{else if this.userData}}
+      <h1>{{this.userData.name}}</h1>
+    {{/if}}
+  </template>
+}
+```
+
+**Why This Is Wrong:**
+
+- Setting tracked state during render can cause infinite render loops
+
+- ember-concurrency adds overhead unnecessary for simple data loading
+
+- Makes component state harder to reason about
+
+- Can trigger multiple re-renders
+
+**Correct: use getPromiseState from warp-drive/reactiveweb for data loading**
+
+```glimmer-js
+// app/components/user-profile.gjs
+import Component from '@glimmer/component';
+import { cached } from '@glimmer/tracking';
+import { getPromiseState } from '@warp-drive/reactiveweb';
+
+class UserProfile extends Component {
+  @cached
+  get userData() {
+    const promise = fetch(`/api/users/${this.args.userId}`)
+      .then(r => r.json());
+    return getPromiseState(promise);
+  }
+
+  <template>
+    {{#if this.userData.isPending}}
+      <div>Loading...</div>
+    {{else if this.userData.isRejected}}
+      <div>Error: {{this.userData.error.message}}</div>
+    {{else if this.userData.isFulfilled}}
+      <h1>{{this.userData.value.name}}</h1>
+    {{/if}}
+  </template>
+}
+```
+
+**Correct: use ember-concurrency for USER input with derived data patterns**
+
+```glimmer-js
+// app/components/search.gjs
+import Component from '@glimmer/component';
+import { restartableTask, timeout } from 'ember-concurrency';
+import { on } from '@ember/modifier';
+import { pick } from 'ember-composable-helpers';
+
+class Search extends Component {
+  // CORRECT: For user-initiated search with debouncing
+  // Use derived data from TaskInstance API - lastSuccessful
+  searchTask = restartableTask(async (query) => {
+    await timeout(300); // Debounce user typing
+    const response = await fetch(`/api/search?q=${query}`);
+    return response.json(); // Return value, don't set tracked state
+  });
+
+  <template>
+    <input
+      type="search"
+      {{on "input" (fn this.searchTask.perform (pick "target.value"))}}
+    />
+
+    {{! Use derived data from task state - no tracked properties needed }}
+    {{#if this.searchTask.isRunning}}
+      <div>Searching...</div>
+    {{/if}}
+
+    {{! lastSuccessful persists previous results while new search runs }}
+    {{#if this.searchTask.lastSuccessful}}
+      <ul>
+        {{#each this.searchTask.lastSuccessful.value as |result|}}
+          <li>{{result.name}}</li>
+        {{/each}}
+      </ul>
+    {{/if}}
+
+    {{! Show error from most recent failed attempt }}
+    {{#if this.searchTask.last.isError}}
+      <div>Error: {{this.searchTask.last.error.message}}</div>
+    {{/if}}
+  </template>
+}
+```
+
+**Good Use Cases for ember-concurrency:**
+
+```glimmer-js
+// app/components/form-submit.gjs
+import Component from '@glimmer/component';
+import { dropTask } from 'ember-concurrency';
+import { on } from '@ember/modifier';
+import { fn } from '@ember/helper';
+
+class FormSubmit extends Component {
+  // dropTask prevents double-submit - perfect for user actions
+  submitTask = dropTask(async (formData) => {
+    const response = await fetch('/api/save', {
+      method: 'POST',
+      body: JSON.stringify(formData)
+    });
+    return response.json();
+  });
+
+  <template>
+    <button
+      {{on "click" (fn this.submitTask.perform @formData)}}
+      disabled={{this.submitTask.isRunning}}
+    >
+      {{#if this.submitTask.isRunning}}
+        Saving...
+      {{else}}
+        Save
+      {{/if}}
+    </button>
+
+    {{! Use lastSuccessful for success message - derived data }}
+    {{#if this.submitTask.lastSuccessful}}
+      <div>Saved successfully!</div>
+    {{/if}}
+
+    {{#if this.submitTask.last.isError}}
+      <div>Error: {{this.submitTask.last.error.message}}</div>
+    {{/if}}
+  </template>
+}
+```
+
+1. **User input debouncing** - prevent API spam from typing
+
+2. **Form submission** - prevent double-click submits with `dropTask`
+
+3. **Autocomplete** - restart previous searches as user types
+
+4. **Polling** - user-controlled refresh intervals
+
+5. **Multi-step wizards** - sequential async operations
+
+**Bad Use Cases for ember-concurrency:**
+
+1. ❌ **Loading data on component init** - use `getPromiseState` instead
+
+2. ❌ **Route model hooks** - just return promises directly
+
+3. ❌ **Simple API calls** - async/await is sufficient
+
+4. ❌ **Setting tracked state inside tasks** - causes render loops
+
+**Key Principles:**
+
+- **Derive data, don't set it** - Use `task.lastSuccessful`, `task.last`, `task.isRunning` (derived from TaskInstance API)
+
+- **Use task return values** - Read from `task.lastSuccessful.value` or `task.last.value`, never set tracked state
+
+- **User-initiated only** - ember-concurrency is for handling user concurrency patterns
+
+- **Data loading** - Use `getPromiseState` from warp-drive/reactiveweb for non-user-initiated loading
+
+- **Avoid side effects** - Don't modify component state inside tasks that's read during render
+
+**TaskInstance API for Derived Data:**
+
+ember-concurrency provides a powerful derived data API through Task and TaskInstance:
+
+- `task.last` - The most recent TaskInstance (successful or failed)
+
+- `task.lastSuccessful` - The most recent successful TaskInstance (persists during new attempts)
+
+- `task.isRunning` - Derived boolean if any instance is running
+
+- `taskInstance.value` - The returned value from the task
+
+- `taskInstance.isError` - Derived boolean if this instance failed
+
+- `taskInstance.error` - The error if this instance failed
+
+This follows the **derived data pattern** - all state comes from the task itself, no tracked properties needed!
+
+**Migration from tracked state pattern:**
+
+```glimmer-js
+// BEFORE (anti-pattern - setting tracked state)
+class Bad extends Component {
+  @tracked data = null;
+
+  fetchTask = task(async () => {
+    this.data = await fetch('/api/data').then(r => r.json());
+  });
+
+  // template reads: {{this.data}}
+}
+
+// AFTER (correct - using derived data from TaskInstance API)
+class Good extends Component {
+  fetchTask = restartableTask(async () => {
+    return fetch('/api/data').then(r => r.json());
+  });
+
+  // template reads: {{this.fetchTask.lastSuccessful.value}}
+  // All state derived from task - no tracked properties!
+}
+
+// Or better yet, for non-user-initiated loading:
+class Better extends Component {
+  @cached
+  get data() {
+    return getPromiseState(fetch('/api/data').then(r => r.json()));
+  }
+
+  // template reads: {{#if this.data.isFulfilled}}{{this.data.value}}{{/if}}
+}
+```
+
+ember-concurrency is a powerful tool for **user concurrency patterns**. For data loading, use `getPromiseState` instead.
+
+### 10.2 Use Ember Concurrency for User Input Concurrency
+
+**Impact: HIGH (Better control of user-initiated async operations)**
+
+Use ember-concurrency for managing **user-initiated** async operations like search, form submission, and autocomplete. It provides automatic cancelation, debouncing, and prevents race conditions from user actions.
+
+**Incorrect: manual async handling with race conditions**
+
+```glimmer-js
+// app/components/search.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+class Search extends Component {
+  @tracked results = [];
+  @tracked isSearching = false;
+  @tracked error = null;
+  currentRequest = null;
+
+  @action
+  async search(event) {
+    const query = event.target.value;
+
+    // Manual cancelation - easy to get wrong
+    if (this.currentRequest) {
+      this.currentRequest.abort();
+    }
+
+    this.isSearching = true;
+    this.error = null;
+
+    const controller = new AbortController();
+    this.currentRequest = controller;
+
+    try {
+      const response = await fetch(`/api/search?q=${query}`, {
+        signal: controller.signal
+      });
+      this.results = await response.json();
+    } catch (e) {
+      if (e.name !== 'AbortError') {
+        this.error = e.message;
+      }
+    } finally {
+      this.isSearching = false;
+    }
+  }
+
+  <template>
+    <input {{on "input" this.search}} />
+    {{#if this.isSearching}}Loading...{{/if}}
+    {{#if this.error}}Error: {{this.error}}{{/if}}
+  </template>
+}
+```
+
+**Correct: using ember-concurrency with task return values**
+
+```glimmer-js
+// app/components/search.gjs
+import Component from '@glimmer/component';
+import { restartableTask } from 'ember-concurrency';
+
+class Search extends Component {
+  // restartableTask automatically cancels previous searches
+  // IMPORTANT: Return the value, don't set tracked state inside tasks
+  searchTask = restartableTask(async (query) => {
+    const response = await fetch(`/api/search?q=${query}`);
+    return response.json(); // Return, don't set @tracked
+  });
+
+  <template>
+    <input {{on "input" (fn this.searchTask.perform (pick "target.value"))}} />
+
+    {{#if this.searchTask.isRunning}}
+      <div class="loading">Loading...</div>
+    {{/if}}
+
+    {{#if this.searchTask.last.isSuccessful}}
+      <ul>
+        {{#each this.searchTask.last.value as |result|}}
+          <li>{{result.name}}</li>
+        {{/each}}
+      </ul>
+    {{/if}}
+
+    {{#if this.searchTask.last.isError}}
+      <div class="error">{{this.searchTask.last.error.message}}</div>
+    {{/if}}
+  </template>
+}
+```
+
+**With debouncing for user typing:**
+
+```glimmer-js
+// app/components/autocomplete.gjs
+import Component from '@glimmer/component';
+import { restartableTask, timeout } from 'ember-concurrency';
+
+class Autocomplete extends Component {
+  searchTask = restartableTask(async (query) => {
+    // Debounce user typing - wait 300ms
+    await timeout(300);
+
+    const response = await fetch(`/api/autocomplete?q=${query}`);
+    return response.json(); // Return value, don't set tracked state
+  });
+
+  <template>
+    <input
+      type="search"
+      {{on "input" (fn this.searchTask.perform (pick "target.value"))}}
+      placeholder="Search..."
+    />
+
+    {{#if this.searchTask.isRunning}}
+      <div class="spinner"></div>
+    {{/if}}
+
+    {{#if this.searchTask.lastSuccessful}}
+      <ul class="suggestions">
+        {{#each this.searchTask.lastSuccessful.value as |item|}}
+          <li>{{item.title}}</li>
+        {{/each}}
+      </ul>
+    {{/if}}
+  </template>
+}
+```
+
+**Task modifiers for different user concurrency patterns:**
+
+```glimmer-js
+import Component from '@glimmer/component';
+import { dropTask, enqueueTask, restartableTask } from 'ember-concurrency';
+
+class FormActions extends Component {
+  // dropTask: Prevents double-click - ignores new while running
+  saveTask = dropTask(async (data) => {
+    const response = await fetch('/api/save', {
+      method: 'POST',
+      body: JSON.stringify(data)
+    });
+    return response.json();
+  });
+
+  // enqueueTask: Queues user actions sequentially
+  processTask = enqueueTask(async (item) => {
+    const response = await fetch('/api/process', {
+      method: 'POST',
+      body: JSON.stringify(item)
+    });
+    return response.json();
+  });
+
+  // restartableTask: Cancels previous, starts new (for search)
+  searchTask = restartableTask(async (query) => {
+    const response = await fetch(`/api/search?q=${query}`);
+    return response.json();
+  });
+
+  <template>
+    <button
+      {{on "click" (fn this.saveTask.perform @data)}}
+      disabled={{this.saveTask.isRunning}}
+    >
+      Save
+    </button>
+  </template>
+}
+```
+
+**Key Principles for ember-concurrency:**
+
+1. **User-initiated only** - Use for handling user actions, not component initialization
+
+2. **Return values** - Use `task.last.value`, never set `@tracked` state inside tasks
+
+3. **Avoid side effects** - Don't modify component state that's read during render inside tasks
+
+4. **Choose right modifier**:
+
+   - `restartableTask` - User typing/search (cancel previous)
+
+   - `dropTask` - Form submit/save (prevent double-click)
+
+   - `enqueueTask` - Sequential processing (queue user actions)
+
+**When NOT to use ember-concurrency:**
+
+- ❌ Component initialization data loading (use `getPromiseState` instead)
+
+- ❌ Setting tracked state inside tasks (causes infinite render loops)
+
+- ❌ Route model hooks (return promises directly)
+
+- ❌ Simple async without user concurrency concerns (use async/await)
+
+See **advanced-data-loading-with-ember-concurrency.md** for correct data loading patterns.
+
+ember-concurrency provides automatic cancelation, derived state (isRunning, isIdle), and better patterns for **user-initiated** async operations.
+
+Reference: [https://ember-concurrency.com/](https://ember-concurrency.com/)
+
+### 10.3 Use Helper Functions for Reusable Logic
+
+**Impact: LOW-MEDIUM (Better code reuse and testability)**
+
+Extract reusable template logic into helper functions that can be tested independently and used across templates.
+
+**Incorrect: logic duplicated in components**
+
+```javascript
+// app/components/user-card.js
+class UserCard extends Component {
+  get formattedDate() {
+    const date = new Date(this.args.user.createdAt);
+    const now = new Date();
+    const diffMs = now - date;
+    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+    if (diffDays === 0) return 'Today';
+    if (diffDays === 1) return 'Yesterday';
+    if (diffDays < 7) return `${diffDays} days ago`;
+    return date.toLocaleDateString();
+  }
+}
+
+// app/components/post-card.js - same logic duplicated!
+class PostCard extends Component {
+  get formattedDate() {
+    // Same implementation...
+  }
+}
+```
+
+**Correct: reusable helper**
+
+```javascript
+// app/components/blog/format-relative-date.js
+export function formatRelativeDate(date) {
+  const dateObj = new Date(date);
+  const now = new Date();
+  const diffMs = now - dateObj;
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffDays === 0) return 'Today';
+  if (diffDays === 1) return 'Yesterday';
+  if (diffDays < 7) return `${diffDays} days ago`;
+  return dateObj.toLocaleDateString();
+}
+```
+
+For single-use helpers, keep them in the same file as the component:
+
+For helpers shared across multiple components in a feature, use a subdirectory:
+
+**Alternative: shared helper in utils**
+
+```glimmer-js
+// app/components/post-card.gjs
+import { formatRelativeDate } from '../utils/format-relative-date';
+
+<template>
+  <p>Posted: {{formatRelativeDate @post.createdAt}}</p>
+</template>
+```
+
+For truly shared helpers used across the whole app, use `app/utils/`:
+
+**Note**: Keep utils flat (`app/utils/format-relative-date.js`), not nested (`app/utils/date/format-relative-date.js`). If you need cleaner top-level imports, configure subpath-imports in package.json instead of nesting files.
+
+**For helpers with state, use class-based helpers:**
+
+```javascript
+// app/utils/helpers/format-currency.js
+export class FormatCurrencyHelper {
+  constructor(owner) {
+    this.intl = owner.lookup('service:intl');
+  }
+
+  compute(amount, { currency = 'USD' } = {}) {
+    return this.intl.formatNumber(amount, {
+      style: 'currency',
+      currency,
+    });
+  }
+}
+```
+
+**Common helpers to create:**
+
+- Date/time formatting
+
+- Number formatting
+
+- String manipulation
+
+- Array operations
+
+- Conditional logic
+
+Helpers promote code reuse, are easier to test, and keep components focused on behavior.
+
+Reference: [https://guides.emberjs.com/release/components/helper-functions/](https://guides.emberjs.com/release/components/helper-functions/)
+
+### 10.4 Use Modifiers for DOM Side Effects
+
+**Impact: LOW-MEDIUM (Better separation of concerns)**
+
+Use modifiers (element modifiers) to handle DOM side effects and lifecycle events in a reusable, composable way.
+
+**Incorrect: manual DOM manipulation in component**
+
+```glimmer-js
+// app/components/chart.gjs
+import Component from '@glimmer/component';
+
+class Chart extends Component {
+  chartInstance = null;
+
+  constructor() {
+    super(...arguments);
+    // Can't access element here - element doesn't exist yet!
+  }
+
+  willDestroy() {
+    super.willDestroy();
+    this.chartInstance?.destroy();
+  }
+
+  <template>
+    <canvas id="chart-canvas"></canvas>
+    {{! Manual setup is error-prone and not reusable }}
+  </template>
+}
+```
+
+**Correct: function modifier - preferred for simple side effects**
+
+```javascript
+// app/modifiers/chart.js
+import { modifier } from 'ember-modifier';
+
+export default modifier((element, [config]) => {
+  // Initialize chart
+  const chartInstance = new Chart(element, config);
+
+  // Return cleanup function
+  return () => {
+    chartInstance.destroy();
+  };
+});
+```
+
+**Also correct: class-based modifier for complex state**
+
+```glimmer-js
+// app/components/chart.gjs
+import chart from '../modifiers/chart';
+
+<template>
+  <canvas {{chart @config}}></canvas>
+</template>
+```
+
+**Use function modifiers** for simple side effects. Use class-based modifiers only when you need complex state management.
+
+**For commonly needed modifiers, use ember-modifier helpers:**
+
+```glimmer-js
+// app/components/input-field.gjs
+import autofocus from '../modifiers/autofocus';
+
+<template>
+  <input {{autofocus}} type="text" />
+</template>
+```
+
+**Use ember-resize-observer-modifier for resize handling:**
+
+```glimmer-js
+// app/components/resizable.gjs
+import onResize from 'ember-resize-observer-modifier';
+
+<template>
+  <div {{onResize this.handleResize}}>
+    Content that responds to size changes
+  </div>
+</template>
+```
+
+Modifiers provide a clean, reusable way to manage DOM side effects without coupling to specific components.
+
+Reference: [https://guides.emberjs.com/release/components/template-lifecycle-dom-and-modifiers/](https://guides.emberjs.com/release/components/template-lifecycle-dom-and-modifiers/)
+
+### 10.5 Use Reactive Collections from @ember/reactive/collections
+
+**Impact: HIGH (Enables reactive arrays, maps, and sets)**
+
+Use reactive collections from `@ember/reactive/collections` to make arrays, Maps, and Sets reactive in Ember. Standard JavaScript collections don't trigger Ember's reactivity system when mutated—reactive collections solve this.
+
+**The Problem:**
+
+Standard arrays, Maps, and Sets are not reactive in Ember when you mutate them. Changes won't trigger template updates.
+
+**The Solution:**
+
+Use Ember's built-in reactive collections from `@ember/reactive/collections`.
+
+**Incorrect: non-reactive array**
+
+```glimmer-js
+// app/components/todo-list.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class TodoList extends Component {
+  @tracked todos = []; // ❌ Array mutations (push, splice, etc.) won't trigger updates
+
+  @action
+  addTodo(text) {
+    // This won't trigger a re-render!
+    this.todos.push({ id: Date.now(), text });
+  }
+
+  @action
+  removeTodo(id) {
+    // This also won't trigger a re-render!
+    const index = this.todos.findIndex(t => t.id === id);
+    this.todos.splice(index, 1);
+  }
+
+  <template>
+    <ul>
+      {{#each this.todos as |todo|}}
+        <li>
+          {{todo.text}}
+          <button {{on "click" (fn this.removeTodo todo.id)}}>Remove</button>
+        </li>
+      {{/each}}
+    </ul>
+    <button {{on "click" (fn this.addTodo "New todo")}}>Add</button>
+  </template>
+}
+```
+
+**Correct: reactive array with @ember/reactive/collections**
+
+```glimmer-js
+// app/components/tag-selector.gjs
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { trackedSet } from '@ember/reactive/collections';
+
+export default class TagSelector extends Component {
+  selectedTags = trackedSet();
+
+  @action
+  toggleTag(tag) {
+    if (this.selectedTags.has(tag)) {
+      this.selectedTags.delete(tag);
+    } else {
+      this.selectedTags.add(tag);
+    }
+  }
+
+  get selectedCount() {
+    return this.selectedTags.size;
+  }
+
+  <template>
+    <div>
+      {{#each @availableTags as |tag|}}
+        <label>
+          <input
+            type="checkbox"
+            checked={{this.selectedTags.has tag}}
+            {{on "change" (fn this.toggleTag tag)}}
+          />
+          {{tag}}
+        </label>
+      {{/each}}
+    </div>
+    <p>Selected: {{this.selectedCount}} tags</p>
+  </template>
+}
+```
+
+Maps are useful for key-value stores with non-string keys:
+
+Sets are useful for unique collections:
+
+| Type           | Use Case                                                           |
+
+| -------------- | ------------------------------------------------------------------ |
+
+| `trackedArray` | Ordered lists that need mutation methods (push, pop, splice, etc.) |
+
+| `trackedMap`   | Key-value pairs with non-string keys or when you need `size`       |
+
+| `trackedSet`   | Unique values, membership testing                                  |
+
+**Initialize with data:**
+
+```javascript
+import { trackedArray, trackedMap, trackedSet } from '@ember/reactive/collections';
+
+// Array
+const todos = trackedArray([
+  { id: 1, text: 'First' },
+  { id: 2, text: 'Second' },
+]);
+
+// Map
+const userMap = trackedMap([
+  [1, { name: 'Alice' }],
+  [2, { name: 'Bob' }],
+]);
+
+// Set
+const tags = trackedSet(['javascript', 'ember', 'web']);
+```
+
+**Convert to plain JavaScript:**
+
+```javascript
+// Array
+const plainArray = [...trackedArray];
+const plainArray2 = Array.from(trackedArray);
+
+// Map
+const plainObject = Object.fromEntries(trackedMap);
+
+// Set
+const plainArray3 = [...trackedSet];
+```
+
+**Functional array methods still work:**
+
+```javascript
+import { tracked } from '@glimmer/tracking';
+
+export default class TodoList extends Component {
+  @tracked todos = [];
+
+  @action
+  addTodo(text) {
+    // Reassignment is reactive
+    this.todos = [...this.todos, { id: Date.now(), text }];
+  }
+
+  @action
+  removeTodo(id) {
+    // Reassignment is reactive
+    this.todos = this.todos.filter((t) => t.id !== id);
+  }
+}
+```
+
+If you prefer immutability, you can use regular `@tracked` with reassignment:
+
+**When to use each approach:**
+
+- Use reactive collections when you need mutable operations (better performance for large lists)
+
+- Use immutable updates when you want simpler mental model or need history/undo
+
+1. **Don't mix approaches** - choose either reactive collections or immutable updates
+
+2. **Initialize in class field** - no need for constructor
+
+3. **Use appropriate type** - Map for key-value, Set for unique values, Array for ordered lists
+
+4. **Export from modules** if shared across components
+
+Reactive collections from `@ember/reactive/collections` provide the best of both worlds: mutable operations with full reactivity. They're especially valuable for large lists or frequent updates where immutable updates would be expensive.
+
+**References:**
+
+- [Ember Reactivity System](https://guides.emberjs.com/release/in-depth-topics/autotracking-in-depth/)
+
+- [JavaScript Built-in Objects](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects)
+
+- [Reactive Collections RFC](https://github.com/emberjs/rfcs/blob/master/text/0869-reactive-collections.md)
+
+---
+
+## References
+
+1. [https://emberjs.com](https://emberjs.com)
+2. [https://guides.emberjs.com](https://guides.emberjs.com)
+3. [https://guides.emberjs.com/release/accessibility/](https://guides.emberjs.com/release/accessibility/)
+4. [https://warp-drive.io/](https://warp-drive.io/)
+5. [https://github.com/ember-a11y/ember-a11y-testing](https://github.com/ember-a11y/ember-a11y-testing)
+6. [https://github.com/embroider-build/embroider](https://github.com/embroider-build/embroider)
+7. [https://github.com/tracked-tools/tracked-toolbox](https://github.com/tracked-tools/tracked-toolbox)
+8. [https://github.com/NullVoxPopuli/ember-resources](https://github.com/NullVoxPopuli/ember-resources)
+9. [https://ember-concurrency.com/](https://ember-concurrency.com/)
+10. [https://octane-guides.emberjs.com](https://octane-guides.emberjs.com)

--- a/skills/ember-best-practices/README.md
+++ b/skills/ember-best-practices/README.md
@@ -1,0 +1,100 @@
+# Ember.js Best Practices
+
+A structured repository for creating and maintaining Ember.js Best Practices optimized for agents and LLMs.
+
+## Structure
+
+- `rules/` - Individual rule files (one per rule)
+  - `_sections.md` - Section metadata (titles, impacts, descriptions)
+  - `_template.md` - Template for creating new rules
+  - `area-description.md` - Individual rule files
+- `metadata.json` - Document metadata (version, organization, abstract)
+- __`AGENTS.md`__ - Compiled output (generated)
+- __`SKILL.md`__ - Skill definition for Claude Code
+
+## Rule Categories
+
+Rules are organized by prefix:
+- `route-` for Route Loading and Data Fetching (Section 1)
+- `bundle-` for Build and Bundle Optimization (Section 2)
+- `component-` for Component and Reactivity (Section 3)
+- `a11y-` for Accessibility Best Practices (Section 4)
+- `service-` for Service and State Management (Section 5)
+- `template-` for Template Optimization (Section 6)
+- `advanced-` for Advanced Patterns (Section 7)
+
+## Rule File Structure
+
+Each rule file should follow this structure:
+
+```markdown
+---
+title: Rule Title Here
+impact: MEDIUM
+impactDescription: Optional description
+tags: tag1, tag2, tag3
+---
+
+## Rule Title Here
+
+Brief explanation of the rule and why it matters.
+
+**Incorrect (description of what's wrong):**
+
+```javascript
+// Bad code example
+```
+
+**Correct (description of what's right):**
+
+```javascript
+// Good code example
+```
+
+Optional explanatory text after examples.
+
+Reference: [Link](https://example.com)
+```
+
+## File Naming Convention
+
+- Files starting with `_` are special (excluded from build)
+- Rule files: `area-description.md` (e.g., `route-parallel-model.md`)
+- Section is automatically inferred from filename prefix
+- Rules are sorted alphabetically by title within each section
+- IDs (e.g., 1.1, 1.2) are auto-generated during build
+
+## Impact Levels
+
+- `CRITICAL` - Highest priority, major performance gains
+- `HIGH` - Significant performance improvements
+- `MEDIUM-HIGH` - Moderate-high gains
+- `MEDIUM` - Moderate performance improvements
+- `LOW-MEDIUM` - Low-medium gains
+- `LOW` - Incremental improvements
+
+## Contributing
+
+When adding or modifying rules:
+
+1. Use the correct filename prefix for your section
+2. Follow the `_template.md` structure
+3. Include clear bad/good examples with explanations
+4. Add appropriate tags
+5. Rules are automatically sorted by title - no need to manage numbers!
+
+## Accessibility Focus
+
+This guide emphasizes Ember's strong accessibility ecosystem:
+
+- **ember-a11y-testing** - Automated testing with axe-core
+- **ember-a11y** - Route announcements and focus management
+- **ember-focus-trap** - Modal focus trapping
+- **ember-page-title** - Accessible page titles
+- **Semantic HTML** - Proper use of native elements
+- **ARIA attributes** - When custom elements are needed
+- **Keyboard navigation** - Full keyboard support patterns
+
+## Acknowledgments
+
+Built for the Ember.js community, drawing from official guides, Octane patterns, and accessibility best practices.

--- a/skills/ember-best-practices/SKILL.md
+++ b/skills/ember-best-practices/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: ember-best-practices
+description: Ember.js performance optimization and accessibility guidelines. This skill should be used when writing, reviewing, or refactoring Ember.js code to ensure optimal performance patterns and accessibility. Triggers on tasks involving Ember components, routes, data fetching, bundle optimization, or accessibility improvements.
+license: MIT
+metadata:
+  author: Ember.js Community
+  version: "1.0.0"
+boxel:
+  kind: skill
+---
+
+# Ember.js Best Practices
+
+Comprehensive performance optimization and accessibility guide for Ember.js applications. Contains 58 rules across 10 categories, prioritized by impact to guide automated refactoring and code generation.
+
+## When to Apply
+
+Reference these guidelines when:
+
+- Writing new Ember components or routes
+- Implementing data fetching with WarpDrive
+- Reviewing code for performance issues
+- Refactoring existing Ember.js code
+- Optimizing bundle size or load times
+- Implementing accessibility features
+
+## Rule Categories by Priority
+
+| Priority | Category                        | Impact      | Prefix                     |
+| -------- | ------------------------------- | ----------- | -------------------------- |
+| 1        | Route Loading and Data Fetching | CRITICAL    | `route-`                   |
+| 2        | Build and Bundle Optimization   | CRITICAL    | `bundle-`                  |
+| 3        | Component and Reactivity        | HIGH        | `component-`, `exports-`   |
+| 4        | Accessibility Best Practices    | HIGH        | `a11y-`                    |
+| 5        | Service and State Management    | MEDIUM-HIGH | `service-`                 |
+| 6        | Template Optimization           | MEDIUM      | `template-`, `helper-`     |
+| 7        | Performance Optimization        | MEDIUM      | `performance-`             |
+| 8        | Testing Best Practices          | MEDIUM      | `testing-`                 |
+| 9        | Tooling and Configuration       | MEDIUM      | `vscode-`                  |
+| 10       | Advanced Patterns               | MEDIUM-HIGH | `advanced-`                |
+
+## Quick Reference
+
+### 1. Route Loading and Data Fetching (CRITICAL)
+
+- `route-parallel-model` - Use RSVP.hash() for parallel data loading
+- `route-loading-substates` - Implement loading substates for better UX
+- `route-lazy-routes` - Use route-based code splitting with Embroider
+- `route-templates` - Use route templates with co-located syntax
+- `route-model-caching` - Implement smart route model caching
+
+### 2. Build and Bundle Optimization (CRITICAL)
+
+- `bundle-direct-imports` - Import directly, avoid entire namespaces
+- `bundle-embroider-static` - Enable Embroider static mode for tree-shaking
+- `bundle-lazy-dependencies` - Lazy load heavy dependencies
+
+### 3. Component and Reactivity Optimization (HIGH)
+
+- `component-use-glimmer` - Use Glimmer components over classic components
+- `component-cached-getters` - Use @cached for expensive computations
+- `component-minimal-tracking` - Only track properties that affect rendering
+- `component-tracked-toolbox` - Use tracked-built-ins for complex state
+- `component-composition-patterns` - Use yield blocks and contextual components
+- `component-reactive-chains` - Build reactive chains with dependent getters
+- `component-class-fields` - Use class fields for component composition
+- `component-controlled-forms` - Implement controlled form patterns
+- `component-on-modifier` - Use {{on}} modifier for event handling
+- `component-args-validation` - Validate component arguments
+- `component-memory-leaks` - Prevent memory leaks in components
+- `component-strict-mode` - Use strict mode and template-only components
+- `component-avoid-classes-in-examples` - Avoid unnecessary classes in component examples
+- `component-avoid-constructors` - Avoid constructors in Glimmer components
+- `component-avoid-lifecycle-hooks` - Avoid legacy lifecycle hooks
+- `component-file-conventions` - Follow proper file naming conventions
+- `exports-named-only` - Use named exports only
+
+### 4. Accessibility Best Practices (HIGH)
+
+- `a11y-automated-testing` - Use ember-a11y-testing for automated checks
+- `a11y-semantic-html` - Use semantic HTML and proper ARIA attributes
+- `a11y-keyboard-navigation` - Ensure full keyboard navigation support
+- `a11y-form-labels` - Associate labels with inputs, announce errors
+- `a11y-route-announcements` - Announce route transitions to screen readers
+
+### 5. Service and State Management (MEDIUM-HIGH)
+
+- `service-cache-responses` - Cache API responses in services
+- `service-shared-state` - Use services for shared state
+- `service-ember-data-optimization` - Optimize WarpDrive queries
+- `service-owner-linkage` - Manage service owner and linkage patterns
+- `service-data-requesting` - Implement robust data requesting patterns
+
+### 6. Template Optimization (MEDIUM)
+
+- `template-let-helper` - Use {{#let}} to avoid recomputation
+- `template-each-key` - Use {{#each}} with @key for efficient list updates
+- `template-avoid-computation` - Move expensive work to cached getters
+- `template-helper-imports` - Import helpers directly in templates
+- `template-conditional-rendering` - Optimize conditional rendering
+- `template-fn-helper` - Use {{fn}} helper for partial application
+- `template-only-component-functions` - Use template-only components
+- `helper-composition` - Compose helpers for reusable logic
+- `helper-builtin-functions` - Use built-in helpers effectively
+- `helper-plain-functions` - Write helpers as plain functions
+
+### 7. Performance Optimization (MEDIUM)
+
+- `performance-on-modifier-vs-handlers` - Use {{on}} modifier instead of event handler properties
+
+### 8. Testing Best Practices (MEDIUM)
+
+- `testing-modern-patterns` - Use modern testing patterns
+- `testing-qunit-dom-assertions` - Use qunit-dom for better test assertions
+- `testing-test-waiters` - Use @ember/test-waiters for async testing
+- `testing-render-patterns` - Use correct render patterns for components
+- `testing-msw-setup` - Mock API requests with MSW
+- `testing-library-dom-abstraction` - Use Testing Library patterns
+
+### 9. Tooling and Configuration (MEDIUM)
+
+- `vscode-setup-recommended` - VS Code extensions and MCP server setup
+
+### 10. Advanced Patterns (MEDIUM-HIGH)
+
+- `advanced-modifiers` - Use modifiers for DOM side effects
+- `advanced-helpers` - Extract reusable logic into helpers
+- `advanced-tracked-built-ins` - Use reactive collections from @ember/reactive/collections
+- `advanced-concurrency` - Use ember-concurrency for task management
+- `advanced-data-loading-with-ember-concurrency` - Data loading patterns with ember-concurrency
+
+## How to Use
+
+Read individual rule files for detailed explanations and code examples:
+
+```
+rules/route-parallel-model.md
+rules/bundle-embroider-static.md
+rules/a11y-automated-testing.md
+```
+
+Each rule file contains:
+
+- Brief explanation of why it matters
+- Incorrect code example with explanation
+- Correct code example with explanation
+- Additional context and references
+
+## Accessibility with OSS Tools
+
+Ember has excellent accessibility support through community addons:
+
+- **ember-a11y-testing** - Automated accessibility testing in your test suite
+- **ember-a11y** - Route announcements and focus management
+- **ember-focus-trap** - Focus trapping for modals and dialogs
+- **ember-page-title** - Accessible page title management
+- **Platform-native validation** - Use browser's Constraint Validation API for accessible form validation
+
+These tools, combined with native web platform features, provide comprehensive a11y support with minimal configuration.
+
+## Full Compiled Document
+
+For the complete guide with all rules expanded: `AGENTS.md`

--- a/skills/ember-best-practices/build-agents.sh
+++ b/skills/ember-best-practices/build-agents.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -e
+
+OUTPUT="AGENTS.md"
+RULES_DIR="rules"
+
+# Start with the header
+cat > "$OUTPUT" << 'HEADER'
+# Ember Best Practices
+
+Comprehensive performance optimization and accessibility patterns for modern Ember.js applications. Includes rules across 7 categories using gjs/gts format and modern Ember patterns.
+
+---
+
+HEADER
+
+# Add sections
+cat "$RULES_DIR/_sections.md" >> "$OUTPUT"
+
+echo "" >> "$OUTPUT"
+echo "---" >> "$OUTPUT"
+echo "" >> "$OUTPUT"
+
+# Add all rules
+for file in "$RULES_DIR"/*.md; do
+  # Skip the _sections.md file
+  if [[ "$(basename "$file")" == "_sections.md" ]]; then
+    continue
+  fi
+  
+  echo "Adding $(basename "$file")..." >&2
+  cat "$file" >> "$OUTPUT"
+  echo "" >> "$OUTPUT"
+  echo "---" >> "$OUTPUT"
+  echo "" >> "$OUTPUT"
+done
+
+echo "Built $OUTPUT successfully!" >&2

--- a/skills/ember-best-practices/rules/a11y-automated-testing.md
+++ b/skills/ember-best-practices/rules/a11y-automated-testing.md
@@ -1,0 +1,74 @@
+---
+title: Use ember-a11y-testing for Automated Checks
+impact: HIGH
+impactDescription: Catch 30-50% of a11y issues automatically
+tags: accessibility, a11y, testing, ember-a11y-testing
+---
+
+## Use ember-a11y-testing for Automated Checks
+
+Integrate ember-a11y-testing into your test suite to automatically catch common accessibility violations during development. This addon uses axe-core to identify issues before they reach production.
+
+**Incorrect (no accessibility testing):**
+
+```glimmer-js
+// tests/integration/components/user-form-test.js
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, fillIn, click } from '@ember/test-helpers';
+import UserForm from 'my-app/components/user-form';
+
+module('Integration | Component | user-form', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it submits the form', async function(assert) {
+    await render(<template><UserForm /></template>);
+    await fillIn('input', 'John');
+    await click('button');
+    assert.ok(true);
+  });
+});
+```
+
+**Correct (with a11y testing):**
+
+```glimmer-js
+// tests/integration/components/user-form-test.js
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, fillIn, click } from '@ember/test-helpers';
+import a11yAudit from 'ember-a11y-testing/test-support/audit';
+import UserForm from 'my-app/components/user-form';
+
+module('Integration | Component | user-form', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it submits the form', async function(assert) {
+    await render(<template><UserForm /></template>);
+
+    // Automatically checks for a11y violations
+    await a11yAudit();
+
+    await fillIn('input', 'John');
+    await click('button');
+    assert.ok(true);
+  });
+});
+```
+
+**Setup (install and configure):**
+
+```bash
+ember install ember-a11y-testing
+```
+
+```javascript
+// tests/test-helper.js
+import { setupGlobalA11yHooks } from 'ember-a11y-testing/test-support';
+
+setupGlobalA11yHooks(); // Runs on every test automatically
+```
+
+ember-a11y-testing catches issues like missing labels, insufficient color contrast, invalid ARIA, and keyboard navigation problems automatically.
+
+Reference: [ember-a11y-testing](https://github.com/ember-a11y/ember-a11y-testing)

--- a/skills/ember-best-practices/rules/a11y-form-labels.md
+++ b/skills/ember-best-practices/rules/a11y-form-labels.md
@@ -1,0 +1,156 @@
+---
+title: Form Labels and Error Announcements
+impact: HIGH
+impactDescription: Essential for screen reader users
+tags: accessibility, a11y, forms, aria-live
+---
+
+## Form Labels and Error Announcements
+
+All form inputs must have associated labels, and validation errors should be announced to screen readers using ARIA live regions.
+
+**Incorrect (missing labels and announcements):**
+
+```glimmer-js
+// app/components/form.gjs
+<template>
+  <form {{on "submit" this.handleSubmit}}>
+    <input
+      type="email"
+      value={{this.email}}
+      {{on "input" this.updateEmail}}
+      placeholder="Email"
+    />
+
+    {{#if this.emailError}}
+      <span>{{this.emailError}}</span>
+    {{/if}}
+
+    <button type="submit">Submit</button>
+  </form>
+</template>
+```
+
+**Correct (with labels and announcements):**
+
+```glimmer-js
+// app/components/form.gjs
+<template>
+  <form {{on "submit" this.handleSubmit}}>
+    <div>
+      <label for="email-input">
+        Email Address
+        {{#if this.isEmailRequired}}
+          <span aria-label="required">*</span>
+        {{/if}}
+      </label>
+
+      <input
+        id="email-input"
+        type="email"
+        value={{this.email}}
+        {{on "input" this.updateEmail}}
+        aria-describedby={{if this.emailError "email-error"}}
+        aria-invalid={{if this.emailError "true"}}
+        required={{this.isEmailRequired}}
+      />
+
+      {{#if this.emailError}}
+        <span
+          id="email-error"
+          role="alert"
+          aria-live="polite"
+        >
+          {{this.emailError}}
+        </span>
+      {{/if}}
+    </div>
+
+    <button type="submit" disabled={{this.isSubmitting}}>
+      {{#if this.isSubmitting}}
+        <span aria-live="polite">Submitting...</span>
+      {{else}}
+        Submit
+      {{/if}}
+    </button>
+  </form>
+</template>
+```
+
+**For complex forms, use platform-native validation with custom logic:**
+
+```glimmer-js
+// app/components/user-form.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { on } from '@ember/modifier';
+
+class UserForm extends Component {
+  @tracked errorMessages = {};
+
+  validateEmail = (event) => {
+    // Custom business logic validation
+    const input = event.target;
+    const value = input.value;
+
+    if (!value) {
+      input.setCustomValidity('Email is required');
+      return false;
+    }
+
+    if (!input.validity.valid) {
+      input.setCustomValidity('Must be a valid email');
+      return false;
+    }
+
+    // Additional custom validation (e.g., check if email is already taken)
+    if (value === 'taken@example.com') {
+      input.setCustomValidity('This email is already registered');
+      return false;
+    }
+
+    input.setCustomValidity('');
+    return true;
+  };
+
+  handleSubmit = async (event) => {
+    event.preventDefault();
+    const form = event.target;
+
+    // Run custom validations
+    const emailInput = form.querySelector('[name="email"]');
+    const fakeEvent = { target: emailInput };
+    this.validateEmail(fakeEvent);
+
+    // Use native validation check
+    if (!form.checkValidity()) {
+      form.reportValidity();
+      return;
+    }
+
+    const formData = new FormData(form);
+    await this.args.onSubmit(formData);
+  };
+
+  <template>
+    <form {{on "submit" this.handleSubmit}}>
+      <label for="user-email">
+        Email
+        <input
+          id="user-email"
+          type="email"
+          name="email"
+          required
+          value={{@user.email}}
+          {{on "blur" this.validateEmail}}
+        />
+      </label>
+      <button type="submit">Save</button>
+    </form>
+  </template>
+}
+```
+
+Always associate labels with inputs and announce dynamic changes to screen readers using aria-live regions.
+
+Reference: [Ember Accessibility - Application Considerations](https://guides.emberjs.com/release/accessibility/application-considerations/)

--- a/skills/ember-best-practices/rules/a11y-keyboard-navigation.md
+++ b/skills/ember-best-practices/rules/a11y-keyboard-navigation.md
@@ -1,0 +1,168 @@
+---
+title: Keyboard Navigation Support
+impact: HIGH
+impactDescription: Critical for keyboard-only users
+tags: accessibility, a11y, keyboard, focus-management
+---
+
+## Keyboard Navigation Support
+
+Ensure all interactive elements are keyboard accessible and focus management is handled properly, especially in modals and dynamic content.
+
+**Incorrect (no keyboard support):**
+
+```glimmer-js
+// app/components/dropdown.gjs
+<template>
+  <div class="dropdown" {{on "click" this.toggleMenu}}>
+    Menu
+    {{#if this.isOpen}}
+      <div class="dropdown-menu">
+        <div {{on "click" this.selectOption}}>Option 1</div>
+        <div {{on "click" this.selectOption}}>Option 2</div>
+      </div>
+    {{/if}}
+  </div>
+</template>
+```
+
+**Correct (full keyboard support with custom modifier):**
+
+```javascript
+// app/modifiers/focus-first.js
+import { modifier } from 'ember-modifier';
+
+export default modifier((element, [selector = 'button']) => {
+  // Focus first matching element when modifier runs
+  element.querySelector(selector)?.focus();
+});
+```
+
+```glimmer-js
+// app/components/dropdown.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { fn } from '@ember/helper';
+import focusFirst from '../modifiers/focus-first';
+
+class Dropdown extends Component {
+  @tracked isOpen = false;
+
+  @action
+  toggleMenu() {
+    this.isOpen = !this.isOpen;
+  }
+
+  @action
+  handleButtonKeyDown(event) {
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      this.isOpen = true;
+    }
+  }
+
+  @action
+  handleMenuKeyDown(event) {
+    if (event.key === 'Escape') {
+      this.isOpen = false;
+      // Return focus to button
+      event.target.closest('.dropdown').querySelector('button').focus();
+    }
+    // Handle arrow key navigation between menu items
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault();
+      this.moveFocus(event.key === 'ArrowDown' ? 1 : -1);
+    }
+  }
+
+  moveFocus(direction) {
+    const items = Array.from(
+      document.querySelectorAll('[role="menuitem"] button')
+    );
+    const currentIndex = items.indexOf(document.activeElement);
+    const nextIndex = (currentIndex + direction + items.length) % items.length;
+    items[nextIndex]?.focus();
+  }
+
+  @action
+  selectOption(value) {
+    this.args.onSelect?.(value);
+    this.isOpen = false;
+  }
+
+  <template>
+    <div class="dropdown">
+      <button
+        type="button"
+        {{on "click" this.toggleMenu}}
+        {{on "keydown" this.handleButtonKeyDown}}
+        aria-haspopup="true"
+        aria-expanded="{{this.isOpen}}"
+      >
+        Menu
+      </button>
+
+      {{#if this.isOpen}}
+        <ul
+          class="dropdown-menu"
+          role="menu"
+          {{focusFirst '[role="menuitem"] button'}}
+          {{on "keydown" this.handleMenuKeyDown}}
+        >
+          <li role="menuitem">
+            <button type="button" {{on "click" (fn this.selectOption "1")}}>
+              Option 1
+            </button>
+          </li>
+          <li role="menuitem">
+            <button type="button" {{on "click" (fn this.selectOption "2")}}>
+              Option 2
+            </button>
+          </li>
+        </ul>
+      {{/if}}
+    </div>
+  </template>
+}
+```
+
+**For focus trapping in modals, use ember-focus-trap:**
+
+```bash
+ember install ember-focus-trap
+```
+
+```glimmer-js
+// app/components/modal.gjs
+import FocusTrap from 'ember-focus-trap/components/focus-trap';
+
+<template>
+  {{#if this.showModal}}
+    <FocusTrap
+      @isActive={{true}}
+      @initialFocus="#modal-title"
+    >
+      <div class="modal" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+        <h2 id="modal-title">{{@title}}</h2>
+        {{yield}}
+        <button type="button" {{on "click" this.closeModal}}>Close</button>
+      </div>
+    </FocusTrap>
+  {{/if}}
+</template>
+```
+
+**Alternative: Use libraries for keyboard support:**
+
+For complex keyboard interactions, consider using libraries that abstract keyboard support patterns:
+
+```bash
+npm install @fluentui/keyboard-keys
+```
+
+Or use [tabster](https://tabster.io/) for comprehensive keyboard navigation management including focus trapping, arrow key navigation, and modalizers.
+
+Proper keyboard navigation ensures all users can interact with your application effectively.
+
+Reference: [Ember Accessibility - Keyboard](https://guides.emberjs.com/release/accessibility/keyboard/)

--- a/skills/ember-best-practices/rules/a11y-route-announcements.md
+++ b/skills/ember-best-practices/rules/a11y-route-announcements.md
@@ -1,0 +1,174 @@
+---
+title: Announce Route Transitions to Screen Readers
+impact: HIGH
+impactDescription: Critical for screen reader navigation
+tags: accessibility, a11y, routing, screen-readers
+---
+
+## Announce Route Transitions to Screen Readers
+
+Announce page title changes and route transitions to screen readers so users know when navigation has occurred.
+
+**Incorrect (no announcements):**
+
+```javascript
+// app/router.js
+export default class Router extends EmberRouter {
+  location = config.locationType;
+  rootURL = config.rootURL;
+}
+```
+
+**Correct (using a11y-announcer library - recommended):**
+
+Use the [a11y-announcer](https://github.com/ember-a11y/a11y-announcer) library for robust route announcements:
+
+```bash
+ember install @ember-a11y/a11y-announcer
+```
+
+```javascript
+// app/router.js
+import EmberRouter from '@ember/routing/router';
+import config from './config/environment';
+
+export default class Router extends EmberRouter {
+  location = config.locationType;
+  rootURL = config.rootURL;
+}
+
+Router.map(function () {
+  this.route('about');
+  this.route('dashboard');
+  this.route('posts', function () {
+    this.route('post', { path: '/:post_id' });
+  });
+});
+```
+
+The a11y-announcer library automatically handles route announcements. For custom announcements in your routes:
+
+```javascript
+// app/routes/dashboard.js
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class DashboardRoute extends Route {
+  @service announcer;
+
+  afterModel() {
+    this.announcer.announce('Loaded dashboard with latest data');
+  }
+}
+```
+
+**Alternative: DIY approach with ARIA live regions:**
+
+If you prefer not to use a library, you can implement route announcements yourself:
+
+```javascript
+// app/router.js
+import EmberRouter from '@ember/routing/router';
+import config from './config/environment';
+
+export default class Router extends EmberRouter {
+  location = config.locationType;
+  rootURL = config.rootURL;
+}
+
+Router.map(function () {
+  this.route('about');
+  this.route('dashboard');
+  this.route('posts', function () {
+    this.route('post', { path: '/:post_id' });
+  });
+});
+```
+
+```javascript
+// app/routes/application.js
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class ApplicationRoute extends Route {
+  @service router;
+
+  constructor() {
+    super(...arguments);
+
+    this.router.on('routeDidChange', (transition) => {
+      // Update document title
+      const title = this.getPageTitle(transition.to);
+      document.title = title;
+
+      // Announce to screen readers
+      this.announceRouteChange(title);
+    });
+  }
+
+  getPageTitle(route) {
+    // Get title from route metadata or generate it
+    return route.metadata?.title || route.name;
+  }
+
+  announceRouteChange(title) {
+    const announcement = document.getElementById('route-announcement');
+    if (announcement) {
+      announcement.textContent = `Navigated to ${title}`;
+    }
+  }
+}
+```
+
+```glimmer-js
+// app/routes/application.gjs
+<template>
+  <div
+    id="route-announcement"
+    role="status"
+    aria-live="polite"
+    aria-atomic="true"
+    class="sr-only"
+  ></div>
+
+  {{outlet}}
+</template>
+```
+
+```css
+/* app/styles/app.css */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+```
+
+**Alternative: Use ember-page-title with announcements:**
+
+```bash
+ember install ember-page-title
+```
+
+```glimmer-js
+// app/routes/dashboard.gjs
+import { pageTitle } from 'ember-page-title';
+
+<template>
+  {{pageTitle "Dashboard"}}
+
+  <div class="dashboard">
+    {{outlet}}
+  </div>
+</template>
+```
+
+Route announcements ensure screen reader users know when navigation occurs, improving the overall accessibility experience.
+
+Reference: [Ember Accessibility - Page Titles](https://guides.emberjs.com/release/accessibility/page-template-considerations/)

--- a/skills/ember-best-practices/rules/a11y-semantic-html.md
+++ b/skills/ember-best-practices/rules/a11y-semantic-html.md
@@ -1,0 +1,102 @@
+---
+title: Semantic HTML and ARIA Attributes
+impact: HIGH
+impactDescription: Essential for screen reader users
+tags: accessibility, a11y, semantic-html, aria
+---
+
+## Semantic HTML and ARIA Attributes
+
+Use semantic HTML elements and proper ARIA attributes to make your application accessible to screen reader users. **The first rule of ARIA is to not use ARIA** - prefer native semantic HTML elements whenever possible.
+
+**Key principle:** Native HTML elements have built-in keyboard support, roles, and behaviors. Only add ARIA when semantic HTML can't provide the needed functionality.
+
+**Incorrect (divs with insufficient semantics):**
+
+```glimmer-js
+// app/components/example.gjs
+<template>
+  <div class="button" {{on "click" this.submit}}>
+    Submit
+  </div>
+
+  <div class="nav">
+    <div class="nav-item">Home</div>
+    <div class="nav-item">About</div>
+  </div>
+
+  <div class="alert">
+    {{this.message}}
+  </div>
+</template>
+```
+
+**Correct (semantic HTML with proper ARIA):**
+
+```glimmer-js
+// app/components/example.gjs
+import { LinkTo } from '@ember/routing';
+
+<template>
+  <button type="submit" {{on "click" this.submit}}>
+    Submit
+  </button>
+
+  <nav aria-label="Main navigation">
+    <ul>
+      <li><LinkTo @route="index">Home</LinkTo></li>
+      <li><LinkTo @route="about">About</LinkTo></li>
+    </ul>
+  </nav>
+
+  <div role="alert" aria-live="polite" aria-atomic="true">
+    {{this.message}}
+  </div>
+</template>
+```
+
+**For interactive custom elements:**
+
+```glimmer-js
+// app/components/custom-button.gjs
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import XIcon from './x-icon';
+
+class CustomButton extends Component {
+  @action
+  handleKeyDown(event) {
+    // Support Enter and Space keys for keyboard users
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      this.handleClick();
+    }
+  }
+
+  @action
+  handleClick() {
+    this.args.onClick?.();
+  }
+
+  <template>
+    <div
+      role="button"
+      tabindex="0"
+      {{on "click" this.handleClick}}
+      {{on "keydown" this.handleKeyDown}}
+      aria-label="Close dialog"
+    >
+      <XIcon />
+    </div>
+  </template>
+}
+```
+
+Always use native semantic elements when possible. When creating custom interactive elements, ensure they're keyboard accessible and have proper ARIA attributes.
+
+**References:**
+
+- [ARIA Authoring Practices Guide (W3C)](https://www.w3.org/WAI/ARIA/apg/)
+- [Using ARIA (W3C)](https://www.w3.org/TR/using-aria/)
+- [ARIA in HTML (WHATWG)](https://html.spec.whatwg.org/multipage/aria.html#aria)
+- [Ember Accessibility Guide](https://guides.emberjs.com/release/accessibility/)

--- a/skills/ember-best-practices/rules/advanced-concurrency.md
+++ b/skills/ember-best-practices/rules/advanced-concurrency.md
@@ -1,0 +1,201 @@
+---
+title: Use Ember Concurrency for User Input Concurrency
+impact: HIGH
+impactDescription: Better control of user-initiated async operations
+tags: ember-concurrency, tasks, user-input, concurrency-patterns
+---
+
+## Use Ember Concurrency for User Input Concurrency
+
+Use ember-concurrency for managing **user-initiated** async operations like search, form submission, and autocomplete. It provides automatic cancelation, debouncing, and prevents race conditions from user actions.
+
+**Incorrect (manual async handling with race conditions):**
+
+```glimmer-js
+// app/components/search.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+class Search extends Component {
+  @tracked results = [];
+  @tracked isSearching = false;
+  @tracked error = null;
+  currentRequest = null;
+
+  @action
+  async search(event) {
+    const query = event.target.value;
+
+    // Manual cancelation - easy to get wrong
+    if (this.currentRequest) {
+      this.currentRequest.abort();
+    }
+
+    this.isSearching = true;
+    this.error = null;
+
+    const controller = new AbortController();
+    this.currentRequest = controller;
+
+    try {
+      const response = await fetch(`/api/search?q=${query}`, {
+        signal: controller.signal
+      });
+      this.results = await response.json();
+    } catch (e) {
+      if (e.name !== 'AbortError') {
+        this.error = e.message;
+      }
+    } finally {
+      this.isSearching = false;
+    }
+  }
+
+  <template>
+    <input {{on "input" this.search}} />
+    {{#if this.isSearching}}Loading...{{/if}}
+    {{#if this.error}}Error: {{this.error}}{{/if}}
+  </template>
+}
+```
+
+**Correct (using ember-concurrency with task return values):**
+
+```glimmer-js
+// app/components/search.gjs
+import Component from '@glimmer/component';
+import { restartableTask } from 'ember-concurrency';
+
+class Search extends Component {
+  // restartableTask automatically cancels previous searches
+  // IMPORTANT: Return the value, don't set tracked state inside tasks
+  searchTask = restartableTask(async (query) => {
+    const response = await fetch(`/api/search?q=${query}`);
+    return response.json(); // Return, don't set @tracked
+  });
+
+  <template>
+    <input {{on "input" (fn this.searchTask.perform (pick "target.value"))}} />
+
+    {{#if this.searchTask.isRunning}}
+      <div class="loading">Loading...</div>
+    {{/if}}
+
+    {{#if this.searchTask.last.isSuccessful}}
+      <ul>
+        {{#each this.searchTask.last.value as |result|}}
+          <li>{{result.name}}</li>
+        {{/each}}
+      </ul>
+    {{/if}}
+
+    {{#if this.searchTask.last.isError}}
+      <div class="error">{{this.searchTask.last.error.message}}</div>
+    {{/if}}
+  </template>
+}
+```
+
+**With debouncing for user typing:**
+
+```glimmer-js
+// app/components/autocomplete.gjs
+import Component from '@glimmer/component';
+import { restartableTask, timeout } from 'ember-concurrency';
+
+class Autocomplete extends Component {
+  searchTask = restartableTask(async (query) => {
+    // Debounce user typing - wait 300ms
+    await timeout(300);
+
+    const response = await fetch(`/api/autocomplete?q=${query}`);
+    return response.json(); // Return value, don't set tracked state
+  });
+
+  <template>
+    <input
+      type="search"
+      {{on "input" (fn this.searchTask.perform (pick "target.value"))}}
+      placeholder="Search..."
+    />
+
+    {{#if this.searchTask.isRunning}}
+      <div class="spinner"></div>
+    {{/if}}
+
+    {{#if this.searchTask.lastSuccessful}}
+      <ul class="suggestions">
+        {{#each this.searchTask.lastSuccessful.value as |item|}}
+          <li>{{item.title}}</li>
+        {{/each}}
+      </ul>
+    {{/if}}
+  </template>
+}
+```
+
+**Task modifiers for different user concurrency patterns:**
+
+```glimmer-js
+import Component from '@glimmer/component';
+import { dropTask, enqueueTask, restartableTask } from 'ember-concurrency';
+
+class FormActions extends Component {
+  // dropTask: Prevents double-click - ignores new while running
+  saveTask = dropTask(async (data) => {
+    const response = await fetch('/api/save', {
+      method: 'POST',
+      body: JSON.stringify(data)
+    });
+    return response.json();
+  });
+
+  // enqueueTask: Queues user actions sequentially
+  processTask = enqueueTask(async (item) => {
+    const response = await fetch('/api/process', {
+      method: 'POST',
+      body: JSON.stringify(item)
+    });
+    return response.json();
+  });
+
+  // restartableTask: Cancels previous, starts new (for search)
+  searchTask = restartableTask(async (query) => {
+    const response = await fetch(`/api/search?q=${query}`);
+    return response.json();
+  });
+
+  <template>
+    <button
+      {{on "click" (fn this.saveTask.perform @data)}}
+      disabled={{this.saveTask.isRunning}}
+    >
+      Save
+    </button>
+  </template>
+}
+```
+
+**Key Principles for ember-concurrency:**
+
+1. **User-initiated only** - Use for handling user actions, not component initialization
+2. **Return values** - Use `task.last.value`, never set `@tracked` state inside tasks
+3. **Avoid side effects** - Don't modify component state that's read during render inside tasks
+4. **Choose right modifier**:
+   - `restartableTask` - User typing/search (cancel previous)
+   - `dropTask` - Form submit/save (prevent double-click)
+   - `enqueueTask` - Sequential processing (queue user actions)
+
+**When NOT to use ember-concurrency:**
+
+- ❌ Component initialization data loading (use `getPromiseState` instead)
+- ❌ Setting tracked state inside tasks (causes infinite render loops)
+- ❌ Route model hooks (return promises directly)
+- ❌ Simple async without user concurrency concerns (use async/await)
+
+See **advanced-data-loading-with-ember-concurrency.md** for correct data loading patterns.
+
+ember-concurrency provides automatic cancelation, derived state (isRunning, isIdle), and better patterns for **user-initiated** async operations.
+
+Reference: [ember-concurrency](https://ember-concurrency.com/)

--- a/skills/ember-best-practices/rules/advanced-data-loading-with-ember-concurrency.md
+++ b/skills/ember-best-practices/rules/advanced-data-loading-with-ember-concurrency.md
@@ -1,0 +1,247 @@
+---
+title: Use Ember Concurrency Correctly - User Concurrency Not Data Loading
+impact: HIGH
+impactDescription: Prevents infinite render loops and improves performance
+tags: ember-concurrency, tasks, data-loading, anti-pattern
+---
+
+## Use Ember Concurrency Correctly - User Concurrency Not Data Loading
+
+ember-concurrency is designed for **user-initiated concurrency patterns** (debouncing, throttling, preventing double-clicks), not data loading. Use task return values, don't set tracked state inside tasks.
+
+**Incorrect (using ember-concurrency for data loading with tracked state):**
+
+```glimmer-js
+// app/components/user-profile.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { task } from 'ember-concurrency';
+
+class UserProfile extends Component {
+  @tracked userData = null;
+  @tracked error = null;
+
+  // WRONG: Setting tracked state inside task
+  loadUserTask = task(async () => {
+    try {
+      const response = await fetch(`/api/users/${this.args.userId}`);
+      this.userData = await response.json(); // Anti-pattern!
+    } catch (e) {
+      this.error = e; // Anti-pattern!
+    }
+  });
+
+  <template>
+    {{#if this.loadUserTask.isRunning}}
+      Loading...
+    {{else if this.userData}}
+      <h1>{{this.userData.name}}</h1>
+    {{/if}}
+  </template>
+}
+```
+
+**Why This Is Wrong:**
+
+- Setting tracked state during render can cause infinite render loops
+- ember-concurrency adds overhead unnecessary for simple data loading
+- Makes component state harder to reason about
+- Can trigger multiple re-renders
+
+**Correct (use getPromiseState from warp-drive/reactiveweb for data loading):**
+
+```glimmer-js
+// app/components/user-profile.gjs
+import Component from '@glimmer/component';
+import { cached } from '@glimmer/tracking';
+import { getPromiseState } from '@warp-drive/reactiveweb';
+
+class UserProfile extends Component {
+  @cached
+  get userData() {
+    const promise = fetch(`/api/users/${this.args.userId}`)
+      .then(r => r.json());
+    return getPromiseState(promise);
+  }
+
+  <template>
+    {{#if this.userData.isPending}}
+      <div>Loading...</div>
+    {{else if this.userData.isRejected}}
+      <div>Error: {{this.userData.error.message}}</div>
+    {{else if this.userData.isFulfilled}}
+      <h1>{{this.userData.value.name}}</h1>
+    {{/if}}
+  </template>
+}
+```
+
+**Correct (use ember-concurrency for USER input with derived data patterns):**
+
+```glimmer-js
+// app/components/search.gjs
+import Component from '@glimmer/component';
+import { restartableTask, timeout } from 'ember-concurrency';
+import { on } from '@ember/modifier';
+import { pick } from 'ember-composable-helpers';
+
+class Search extends Component {
+  // CORRECT: For user-initiated search with debouncing
+  // Use derived data from TaskInstance API - lastSuccessful
+  searchTask = restartableTask(async (query) => {
+    await timeout(300); // Debounce user typing
+    const response = await fetch(`/api/search?q=${query}`);
+    return response.json(); // Return value, don't set tracked state
+  });
+
+  <template>
+    <input
+      type="search"
+      {{on "input" (fn this.searchTask.perform (pick "target.value"))}}
+    />
+
+    {{! Use derived data from task state - no tracked properties needed }}
+    {{#if this.searchTask.isRunning}}
+      <div>Searching...</div>
+    {{/if}}
+
+    {{! lastSuccessful persists previous results while new search runs }}
+    {{#if this.searchTask.lastSuccessful}}
+      <ul>
+        {{#each this.searchTask.lastSuccessful.value as |result|}}
+          <li>{{result.name}}</li>
+        {{/each}}
+      </ul>
+    {{/if}}
+
+    {{! Show error from most recent failed attempt }}
+    {{#if this.searchTask.last.isError}}
+      <div>Error: {{this.searchTask.last.error.message}}</div>
+    {{/if}}
+  </template>
+}
+```
+
+**Good Use Cases for ember-concurrency:**
+
+1. **User input debouncing** - prevent API spam from typing
+2. **Form submission** - prevent double-click submits with `dropTask`
+3. **Autocomplete** - restart previous searches as user types
+4. **Polling** - user-controlled refresh intervals
+5. **Multi-step wizards** - sequential async operations
+
+```glimmer-js
+// app/components/form-submit.gjs
+import Component from '@glimmer/component';
+import { dropTask } from 'ember-concurrency';
+import { on } from '@ember/modifier';
+import { fn } from '@ember/helper';
+
+class FormSubmit extends Component {
+  // dropTask prevents double-submit - perfect for user actions
+  submitTask = dropTask(async (formData) => {
+    const response = await fetch('/api/save', {
+      method: 'POST',
+      body: JSON.stringify(formData)
+    });
+    return response.json();
+  });
+
+  <template>
+    <button
+      {{on "click" (fn this.submitTask.perform @formData)}}
+      disabled={{this.submitTask.isRunning}}
+    >
+      {{#if this.submitTask.isRunning}}
+        Saving...
+      {{else}}
+        Save
+      {{/if}}
+    </button>
+
+    {{! Use lastSuccessful for success message - derived data }}
+    {{#if this.submitTask.lastSuccessful}}
+      <div>Saved successfully!</div>
+    {{/if}}
+
+    {{#if this.submitTask.last.isError}}
+      <div>Error: {{this.submitTask.last.error.message}}</div>
+    {{/if}}
+  </template>
+}
+```
+
+**Bad Use Cases for ember-concurrency:**
+
+1. ❌ **Loading data on component init** - use `getPromiseState` instead
+2. ❌ **Route model hooks** - just return promises directly
+3. ❌ **Simple API calls** - async/await is sufficient
+4. ❌ **Setting tracked state inside tasks** - causes render loops
+
+**Key Principles:**
+
+- **Derive data, don't set it** - Use `task.lastSuccessful`, `task.last`, `task.isRunning` (derived from TaskInstance API)
+- **Use task return values** - Read from `task.lastSuccessful.value` or `task.last.value`, never set tracked state
+- **User-initiated only** - ember-concurrency is for handling user concurrency patterns
+- **Data loading** - Use `getPromiseState` from warp-drive/reactiveweb for non-user-initiated loading
+- **Avoid side effects** - Don't modify component state inside tasks that's read during render
+
+**TaskInstance API for Derived Data:**
+
+ember-concurrency provides a powerful derived data API through Task and TaskInstance:
+
+- `task.last` - The most recent TaskInstance (successful or failed)
+- `task.lastSuccessful` - The most recent successful TaskInstance (persists during new attempts)
+- `task.isRunning` - Derived boolean if any instance is running
+- `taskInstance.value` - The returned value from the task
+- `taskInstance.isError` - Derived boolean if this instance failed
+- `taskInstance.error` - The error if this instance failed
+
+This follows the **derived data pattern** - all state comes from the task itself, no tracked properties needed!
+
+References:
+
+- [TaskInstance API](https://ember-concurrency.com/api/TaskInstance.html)
+- [Task API](https://ember-concurrency.com/api/Task.html)
+
+**Migration from tracked state pattern:**
+
+```glimmer-js
+// BEFORE (anti-pattern - setting tracked state)
+class Bad extends Component {
+  @tracked data = null;
+
+  fetchTask = task(async () => {
+    this.data = await fetch('/api/data').then(r => r.json());
+  });
+
+  // template reads: {{this.data}}
+}
+
+// AFTER (correct - using derived data from TaskInstance API)
+class Good extends Component {
+  fetchTask = restartableTask(async () => {
+    return fetch('/api/data').then(r => r.json());
+  });
+
+  // template reads: {{this.fetchTask.lastSuccessful.value}}
+  // All state derived from task - no tracked properties!
+}
+
+// Or better yet, for non-user-initiated loading:
+class Better extends Component {
+  @cached
+  get data() {
+    return getPromiseState(fetch('/api/data').then(r => r.json()));
+  }
+
+  // template reads: {{#if this.data.isFulfilled}}{{this.data.value}}{{/if}}
+}
+```
+
+ember-concurrency is a powerful tool for **user concurrency patterns**. For data loading, use `getPromiseState` instead.
+
+Reference:
+
+- [ember-concurrency](https://ember-concurrency.com/)
+- [warp-drive/reactiveweb](https://github.com/emberjs/data/tree/main/packages/reactiveweb)

--- a/skills/ember-best-practices/rules/advanced-helpers.md
+++ b/skills/ember-best-practices/rules/advanced-helpers.md
@@ -1,0 +1,156 @@
+---
+title: Use Helper Functions for Reusable Logic
+impact: LOW-MEDIUM
+impactDescription: Better code reuse and testability
+tags: helpers, templates, reusability, advanced
+---
+
+## Use Helper Functions for Reusable Logic
+
+Extract reusable template logic into helper functions that can be tested independently and used across templates.
+
+**Incorrect (logic duplicated in components):**
+
+```javascript
+// app/components/user-card.js
+class UserCard extends Component {
+  get formattedDate() {
+    const date = new Date(this.args.user.createdAt);
+    const now = new Date();
+    const diffMs = now - date;
+    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+    if (diffDays === 0) return 'Today';
+    if (diffDays === 1) return 'Yesterday';
+    if (diffDays < 7) return `${diffDays} days ago`;
+    return date.toLocaleDateString();
+  }
+}
+
+// app/components/post-card.js - same logic duplicated!
+class PostCard extends Component {
+  get formattedDate() {
+    // Same implementation...
+  }
+}
+```
+
+**Correct (reusable helper):**
+
+For single-use helpers, keep them in the same file as the component:
+
+```glimmer-js
+// app/components/post-list.gjs
+import Component from '@glimmer/component';
+
+// Helper co-located in same file
+function formatRelativeDate(date) {
+  const dateObj = new Date(date);
+  const now = new Date();
+  const diffMs = now - dateObj;
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffDays === 0) return 'Today';
+  if (diffDays === 1) return 'Yesterday';
+  if (diffDays < 7) return `${diffDays} days ago`;
+  return dateObj.toLocaleDateString();
+}
+
+class PostList extends Component {
+  <template>
+    {{#each @posts as |post|}}
+      <article>
+        <h2>{{post.title}}</h2>
+        <time>{{formatRelativeDate post.createdAt}}</time>
+      </article>
+    {{/each}}
+  </template>
+}
+```
+
+For helpers shared across multiple components in a feature, use a subdirectory:
+
+```javascript
+// app/components/blog/format-relative-date.js
+export function formatRelativeDate(date) {
+  const dateObj = new Date(date);
+  const now = new Date();
+  const diffMs = now - dateObj;
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffDays === 0) return 'Today';
+  if (diffDays === 1) return 'Yesterday';
+  if (diffDays < 7) return `${diffDays} days ago`;
+  return dateObj.toLocaleDateString();
+}
+```
+
+**Alternative (shared helper in utils):**
+
+For truly shared helpers used across the whole app, use `app/utils/`:
+
+```javascript
+// app/utils/format-relative-date.js
+// Flat structure - use subpath-imports in package.json for nicer imports if needed
+export function formatRelativeDate(date) {
+  const dateObj = new Date(date);
+  const now = new Date();
+  const diffMs = now - dateObj;
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffDays === 0) return 'Today';
+  if (diffDays === 1) return 'Yesterday';
+  if (diffDays < 7) return `${diffDays} days ago`;
+  return dateObj.toLocaleDateString();
+}
+```
+
+**Note**: Keep utils flat (`app/utils/format-relative-date.js`), not nested (`app/utils/date/format-relative-date.js`). If you need cleaner top-level imports, configure subpath-imports in package.json instead of nesting files.
+
+```glimmer-js
+// app/components/user-card.gjs
+import { formatRelativeDate } from '../utils/format-relative-date';
+
+<template>
+  <p>Joined: {{formatRelativeDate @user.createdAt}}</p>
+</template>
+```
+
+```glimmer-js
+// app/components/post-card.gjs
+import { formatRelativeDate } from '../utils/format-relative-date';
+
+<template>
+  <p>Posted: {{formatRelativeDate @post.createdAt}}</p>
+</template>
+```
+
+**For helpers with state, use class-based helpers:**
+
+```javascript
+// app/utils/helpers/format-currency.js
+export class FormatCurrencyHelper {
+  constructor(owner) {
+    this.intl = owner.lookup('service:intl');
+  }
+
+  compute(amount, { currency = 'USD' } = {}) {
+    return this.intl.formatNumber(amount, {
+      style: 'currency',
+      currency,
+    });
+  }
+}
+```
+
+**Common helpers to create:**
+
+- Date/time formatting
+- Number formatting
+- String manipulation
+- Array operations
+- Conditional logic
+
+Helpers promote code reuse, are easier to test, and keep components focused on behavior.
+
+Reference: [Ember Helpers](https://guides.emberjs.com/release/components/helper-functions/)

--- a/skills/ember-best-practices/rules/advanced-modifiers.md
+++ b/skills/ember-best-practices/rules/advanced-modifiers.md
@@ -1,0 +1,131 @@
+---
+title: Use Modifiers for DOM Side Effects
+impact: LOW-MEDIUM
+impactDescription: Better separation of concerns
+tags: modifiers, dom, lifecycle, advanced
+---
+
+## Use Modifiers for DOM Side Effects
+
+Use modifiers (element modifiers) to handle DOM side effects and lifecycle events in a reusable, composable way.
+
+**Incorrect (manual DOM manipulation in component):**
+
+```glimmer-js
+// app/components/chart.gjs
+import Component from '@glimmer/component';
+
+class Chart extends Component {
+  chartInstance = null;
+
+  constructor() {
+    super(...arguments);
+    // Can't access element here - element doesn't exist yet!
+  }
+
+  willDestroy() {
+    super.willDestroy();
+    this.chartInstance?.destroy();
+  }
+
+  <template>
+    <canvas id="chart-canvas"></canvas>
+    {{! Manual setup is error-prone and not reusable }}
+  </template>
+}
+```
+
+**Correct (function modifier - preferred for simple side effects):**
+
+```javascript
+// app/modifiers/chart.js
+import { modifier } from 'ember-modifier';
+
+export default modifier((element, [config]) => {
+  // Initialize chart
+  const chartInstance = new Chart(element, config);
+
+  // Return cleanup function
+  return () => {
+    chartInstance.destroy();
+  };
+});
+```
+
+**Also correct (class-based modifier for complex state):**
+
+```javascript
+// app/modifiers/chart.js
+import Modifier from 'ember-modifier';
+import { registerDestructor } from '@ember/destroyable';
+
+export default class ChartModifier extends Modifier {
+  chartInstance = null;
+
+  modify(element, [config]) {
+    // Cleanup previous instance if config changed
+    if (this.chartInstance) {
+      this.chartInstance.destroy();
+    }
+
+    this.chartInstance = new Chart(element, config);
+
+    // Register cleanup
+    registerDestructor(this, () => {
+      this.chartInstance?.destroy();
+    });
+  }
+}
+```
+
+```glimmer-js
+// app/components/chart.gjs
+import chart from '../modifiers/chart';
+
+<template>
+  <canvas {{chart @config}}></canvas>
+</template>
+```
+
+**Use function modifiers** for simple side effects. Use class-based modifiers only when you need complex state management.
+
+**For commonly needed modifiers, use ember-modifier helpers:**
+
+```javascript
+// app/modifiers/autofocus.js
+import { modifier } from 'ember-modifier';
+
+export default modifier((element) => {
+  element.focus();
+});
+```
+
+```glimmer-js
+// app/components/input-field.gjs
+import autofocus from '../modifiers/autofocus';
+
+<template>
+  <input {{autofocus}} type="text" />
+</template>
+```
+
+**Use ember-resize-observer-modifier for resize handling:**
+
+```bash
+ember install ember-resize-observer-modifier
+```
+
+```glimmer-js
+// app/components/resizable.gjs
+import onResize from 'ember-resize-observer-modifier';
+
+<template>
+  <div {{onResize this.handleResize}}>
+    Content that responds to size changes
+  </div>
+</template>
+```
+
+Modifiers provide a clean, reusable way to manage DOM side effects without coupling to specific components.
+
+Reference: [Ember Modifiers](https://guides.emberjs.com/release/components/template-lifecycle-dom-and-modifiers/)

--- a/skills/ember-best-practices/rules/advanced-tracked-built-ins.md
+++ b/skills/ember-best-practices/rules/advanced-tracked-built-ins.md
@@ -1,0 +1,277 @@
+---
+title: Use Reactive Collections from @ember/reactive/collections
+impact: HIGH
+impactDescription: Enables reactive arrays, maps, and sets
+tags: reactivity, tracked, collections, advanced
+---
+
+## Use Reactive Collections from @ember/reactive/collections
+
+Use reactive collections from `@ember/reactive/collections` to make arrays, Maps, and Sets reactive in Ember. Standard JavaScript collections don't trigger Ember's reactivity system when mutated—reactive collections solve this.
+
+**The Problem:**
+Standard arrays, Maps, and Sets are not reactive in Ember when you mutate them. Changes won't trigger template updates.
+
+**The Solution:**
+Use Ember's built-in reactive collections from `@ember/reactive/collections`.
+
+### Reactive Arrays
+
+**Incorrect (non-reactive array):**
+
+```glimmer-js
+// app/components/todo-list.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class TodoList extends Component {
+  @tracked todos = []; // ❌ Array mutations (push, splice, etc.) won't trigger updates
+
+  @action
+  addTodo(text) {
+    // This won't trigger a re-render!
+    this.todos.push({ id: Date.now(), text });
+  }
+
+  @action
+  removeTodo(id) {
+    // This also won't trigger a re-render!
+    const index = this.todos.findIndex(t => t.id === id);
+    this.todos.splice(index, 1);
+  }
+
+  <template>
+    <ul>
+      {{#each this.todos as |todo|}}
+        <li>
+          {{todo.text}}
+          <button {{on "click" (fn this.removeTodo todo.id)}}>Remove</button>
+        </li>
+      {{/each}}
+    </ul>
+    <button {{on "click" (fn this.addTodo "New todo")}}>Add</button>
+  </template>
+}
+```
+
+**Correct (reactive array with @ember/reactive/collections):**
+
+```glimmer-js
+// app/components/todo-list.gjs
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { trackedArray } from '@ember/reactive/collections';
+
+export default class TodoList extends Component {
+  todos = trackedArray([]); // ✅ Mutations are reactive
+
+  @action
+  addTodo(text) {
+    // Now this triggers re-render!
+    this.todos.push({ id: Date.now(), text });
+  }
+
+  @action
+  removeTodo(id) {
+    // This also triggers re-render!
+    const index = this.todos.findIndex(t => t.id === id);
+    this.todos.splice(index, 1);
+  }
+
+  <template>
+    <ul>
+      {{#each this.todos as |todo|}}
+        <li>
+          {{todo.text}}
+          <button {{on "click" (fn this.removeTodo todo.id)}}>Remove</button>
+        </li>
+      {{/each}}
+    </ul>
+    <button {{on "click" (fn this.addTodo "New todo")}}>Add</button>
+  </template>
+}
+```
+
+### Reactive Maps
+
+Maps are useful for key-value stores with non-string keys:
+
+```glimmer-js
+// app/components/user-cache.gjs
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { trackedMap } from '@ember/reactive/collections';
+
+export default class UserCache extends Component {
+  userCache = trackedMap(); // key: userId, value: userData
+
+  @action
+  cacheUser(userId, userData) {
+    this.userCache.set(userId, userData);
+  }
+
+  @action
+  clearUser(userId) {
+    this.userCache.delete(userId);
+  }
+
+  get cachedUsers() {
+    return Array.from(this.userCache.values());
+  }
+
+  <template>
+    <ul>
+      {{#each this.cachedUsers as |user|}}
+        <li>{{user.name}}</li>
+      {{/each}}
+    </ul>
+    <p>Cache size: {{this.userCache.size}}</p>
+  </template>
+}
+```
+
+### Reactive Sets
+
+Sets are useful for unique collections:
+
+```glimmer-js
+// app/components/tag-selector.gjs
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { trackedSet } from '@ember/reactive/collections';
+
+export default class TagSelector extends Component {
+  selectedTags = trackedSet();
+
+  @action
+  toggleTag(tag) {
+    if (this.selectedTags.has(tag)) {
+      this.selectedTags.delete(tag);
+    } else {
+      this.selectedTags.add(tag);
+    }
+  }
+
+  get selectedCount() {
+    return this.selectedTags.size;
+  }
+
+  <template>
+    <div>
+      {{#each @availableTags as |tag|}}
+        <label>
+          <input
+            type="checkbox"
+            checked={{this.selectedTags.has tag}}
+            {{on "change" (fn this.toggleTag tag)}}
+          />
+          {{tag}}
+        </label>
+      {{/each}}
+    </div>
+    <p>Selected: {{this.selectedCount}} tags</p>
+  </template>
+}
+```
+
+### When to Use Each Type
+
+| Type           | Use Case                                                           |
+| -------------- | ------------------------------------------------------------------ |
+| `trackedArray` | Ordered lists that need mutation methods (push, pop, splice, etc.) |
+| `trackedMap`   | Key-value pairs with non-string keys or when you need `size`       |
+| `trackedSet`   | Unique values, membership testing                                  |
+
+### Common Patterns
+
+**Initialize with data:**
+
+```javascript
+import { trackedArray, trackedMap, trackedSet } from '@ember/reactive/collections';
+
+// Array
+const todos = trackedArray([
+  { id: 1, text: 'First' },
+  { id: 2, text: 'Second' },
+]);
+
+// Map
+const userMap = trackedMap([
+  [1, { name: 'Alice' }],
+  [2, { name: 'Bob' }],
+]);
+
+// Set
+const tags = trackedSet(['javascript', 'ember', 'web']);
+```
+
+**Convert to plain JavaScript:**
+
+```javascript
+// Array
+const plainArray = [...trackedArray];
+const plainArray2 = Array.from(trackedArray);
+
+// Map
+const plainObject = Object.fromEntries(trackedMap);
+
+// Set
+const plainArray3 = [...trackedSet];
+```
+
+**Functional array methods still work:**
+
+```javascript
+const todos = trackedArray([...]);
+
+// All of these work and are reactive
+const completed = todos.filter(t => t.done);
+const titles = todos.map(t => t.title);
+const allDone = todos.every(t => t.done);
+const firstIncomplete = todos.find(t => !t.done);
+```
+
+### Alternative: Immutable Updates
+
+If you prefer immutability, you can use regular `@tracked` with reassignment:
+
+```javascript
+import { tracked } from '@glimmer/tracking';
+
+export default class TodoList extends Component {
+  @tracked todos = [];
+
+  @action
+  addTodo(text) {
+    // Reassignment is reactive
+    this.todos = [...this.todos, { id: Date.now(), text }];
+  }
+
+  @action
+  removeTodo(id) {
+    // Reassignment is reactive
+    this.todos = this.todos.filter((t) => t.id !== id);
+  }
+}
+```
+
+**When to use each approach:**
+
+- Use reactive collections when you need mutable operations (better performance for large lists)
+- Use immutable updates when you want simpler mental model or need history/undo
+
+### Best Practices
+
+1. **Don't mix approaches** - choose either reactive collections or immutable updates
+2. **Initialize in class field** - no need for constructor
+3. **Use appropriate type** - Map for key-value, Set for unique values, Array for ordered lists
+4. **Export from modules** if shared across components
+
+Reactive collections from `@ember/reactive/collections` provide the best of both worlds: mutable operations with full reactivity. They're especially valuable for large lists or frequent updates where immutable updates would be expensive.
+
+**References:**
+
+- [Ember Reactivity System](https://guides.emberjs.com/release/in-depth-topics/autotracking-in-depth/)
+- [JavaScript Built-in Objects](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects)
+- [Reactive Collections RFC](https://github.com/emberjs/rfcs/blob/master/text/0869-reactive-collections.md)

--- a/skills/ember-best-practices/rules/bundle-direct-imports.md
+++ b/skills/ember-best-practices/rules/bundle-direct-imports.md
@@ -1,0 +1,62 @@
+---
+title: Avoid Importing Entire Addon Namespaces
+impact: CRITICAL
+impactDescription: 200-500ms import cost reduction
+tags: bundle, imports, tree-shaking, performance
+---
+
+## Avoid Importing Entire Addon Namespaces
+
+Import specific utilities and components directly rather than entire addon namespaces to enable better tree-shaking and reduce bundle size.
+
+**Incorrect (imports entire namespace):**
+
+```javascript
+import { tracked } from '@glimmer/tracking';
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+// OK - these are already optimized
+
+// But avoid this pattern with utility libraries:
+import * as lodash from 'lodash';
+import * as moment from 'moment';
+
+class My extends Component {
+  someMethod() {
+    return lodash.debounce(this.handler, 300);
+  }
+}
+```
+
+**Correct (direct imports):**
+
+```javascript
+import { tracked } from '@glimmer/tracking';
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import debounce from 'lodash/debounce';
+import dayjs from 'dayjs'; // moment alternative, smaller
+
+class My extends Component {
+  someMethod() {
+    return debounce(this.handler, 300);
+  }
+}
+```
+
+**Even better (use Ember utilities when available):**
+
+```javascript
+import { tracked } from '@glimmer/tracking';
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { debounce } from '@ember/runloop';
+
+class My extends Component {
+  someMethod() {
+    return debounce(this, this.handler, 300);
+  }
+}
+```
+
+Direct imports and using built-in Ember utilities reduce bundle size by avoiding unused code.

--- a/skills/ember-best-practices/rules/bundle-embroider-static.md
+++ b/skills/ember-best-practices/rules/bundle-embroider-static.md
@@ -1,0 +1,69 @@
+---
+title: Use Embroider Build Pipeline
+impact: CRITICAL
+impactDescription: Modern build system with better performance
+tags: bundle, embroider, build-performance, vite
+---
+
+## Use Embroider Build Pipeline
+
+Use Embroider, Ember's modern build pipeline, with Vite for faster builds, better tree-shaking, and smaller bundles.
+
+**Incorrect (classic build pipeline):**
+
+```javascript
+// ember-cli-build.js
+const EmberApp = require('ember-cli/lib/broccoli/ember-app');
+
+module.exports = function (defaults) {
+  const app = new EmberApp(defaults, {});
+  return app.toTree();
+};
+```
+
+**Correct (Embroider with Vite):**
+
+```javascript
+// ember-cli-build.js
+const EmberApp = require('ember-cli/lib/broccoli/ember-app');
+const { compatBuild } = require('@embroider/compat');
+
+module.exports = async function (defaults) {
+  const { buildOnce } = await import('@embroider/vite');
+
+  let app = new EmberApp(defaults, {
+    // Add options here
+  });
+
+  return compatBuild(app, buildOnce);
+};
+```
+
+**For stricter static analysis (optimized mode):**
+
+```javascript
+// ember-cli-build.js
+const EmberApp = require('ember-cli/lib/broccoli/ember-app');
+const { compatBuild } = require('@embroider/compat');
+
+module.exports = async function (defaults) {
+  const { buildOnce } = await import('@embroider/vite');
+
+  let app = new EmberApp(defaults, {
+    // Add options here
+  });
+
+  return compatBuild(app, buildOnce, {
+    // Enable static analysis for better tree-shaking
+    staticAddonTestSupportTrees: true,
+    staticAddonTrees: true,
+    staticHelpers: true,
+    staticModifiers: true,
+    staticComponents: true,
+  });
+};
+```
+
+Embroider provides a modern build pipeline with Vite that offers faster builds and better optimization compared to the classic Ember CLI build system.
+
+Reference: [Embroider Documentation](https://github.com/embroider-build/embroider)

--- a/skills/ember-best-practices/rules/bundle-lazy-dependencies.md
+++ b/skills/ember-best-practices/rules/bundle-lazy-dependencies.md
@@ -1,0 +1,71 @@
+---
+title: Lazy Load Heavy Dependencies
+impact: CRITICAL
+impactDescription: 30-50% initial bundle reduction
+tags: bundle, lazy-loading, dynamic-imports, performance
+---
+
+## Lazy Load Heavy Dependencies
+
+Use dynamic imports to load heavy libraries only when needed, reducing initial bundle size.
+
+**Incorrect (loaded upfront):**
+
+```javascript
+import Component from '@glimmer/component';
+import Chart from 'chart.js/auto'; // 300KB library loaded immediately
+import hljs from 'highlight.js'; // 500KB library loaded immediately
+
+class Dashboard extends Component {
+  get showChart() {
+    return this.args.hasData;
+  }
+}
+```
+
+**Correct (lazy loaded with error/loading state handling):**
+
+```glimmer-js
+import Component from '@glimmer/component';
+import { getPromiseState } from 'reactiveweb/promise';
+
+class Dashboard extends Component {
+  // Use getPromiseState to model promise state for error/loading handling
+  chartLoader = getPromiseState(async () => {
+    const { default: Chart } = await import('chart.js/auto');
+    return Chart;
+  });
+
+  highlighterLoader = getPromiseState(async () => {
+    const { default: hljs } = await import('highlight.js');
+    return hljs;
+  });
+
+  loadChart = () => {
+    // Triggers lazy load, handles loading/error states automatically
+    return this.chartLoader.value;
+  };
+
+  highlightCode = (code) => {
+    const hljs = this.highlighterLoader.value;
+    if (hljs) {
+      return hljs.highlightAuto(code);
+    }
+    return code;
+  };
+
+  <template>
+    {{#if this.chartLoader.isLoading}}
+      <p>Loading chart library...</p>
+    {{else if this.chartLoader.isError}}
+      <p>Error loading chart: {{this.chartLoader.error.message}}</p>
+    {{else if this.chartLoader.isResolved}}
+      <canvas {{on "click" this.loadChart}}></canvas>
+    {{/if}}
+  </template>
+}
+```
+
+**Note**: Always model promise state (loading/error/resolved) using `getPromiseState` from `reactiveweb/promise` to handle slow networks and errors properly.
+
+Dynamic imports reduce initial bundle size by 30-50%, improving Time to Interactive.

--- a/skills/ember-best-practices/rules/component-args-validation.md
+++ b/skills/ember-best-practices/rules/component-args-validation.md
@@ -1,0 +1,177 @@
+---
+title: Validate Component Arguments
+impact: MEDIUM
+impactDescription: Better error messages and type safety
+tags: components, validation, arguments, typescript
+---
+
+## Validate Component Arguments
+
+Validate component arguments for better error messages, documentation, and type safety.
+
+**Incorrect (no argument validation):**
+
+```glimmer-js
+// app/components/user-card.gjs
+import Component from '@glimmer/component';
+
+class UserCard extends Component {
+  <template>
+    <div>
+      <h3>{{@user.name}}</h3>
+      <p>{{@user.email}}</p>
+    </div>
+  </template>
+}
+```
+
+**Correct (with TypeScript signature):**
+
+```glimmer-ts
+// app/components/user-card.gts
+import Component from '@glimmer/component';
+
+interface UserCardSignature {
+  Args: {
+    user: {
+      name: string;
+      email: string;
+      avatarUrl?: string;
+    };
+    onEdit?: (user: UserCardSignature['Args']['user']) => void;
+  };
+  Blocks: {
+    default: [];
+  };
+  Element: HTMLDivElement;
+}
+
+class UserCard extends Component<UserCardSignature> {
+  <template>
+    <div ...attributes>
+      <h3>{{@user.name}}</h3>
+      <p>{{@user.email}}</p>
+
+      {{#if @user.avatarUrl}}
+        <img src={{@user.avatarUrl}} alt={{@user.name}} />
+      {{/if}}
+
+      {{#if @onEdit}}
+        <button {{on "click" (fn @onEdit @user)}}>Edit</button>
+      {{/if}}
+
+      {{yield}}
+    </div>
+  </template>
+}
+```
+
+**Runtime validation with assertions (using getters):**
+
+```glimmer-js
+// app/components/data-table.gjs
+import Component from '@glimmer/component';
+import { assert } from '@ember/debug';
+
+class DataTable extends Component {
+  // Use getters so validation runs on each access and catches arg changes
+  get columns() {
+    assert(
+      'DataTable requires @columns argument',
+      this.args.columns && Array.isArray(this.args.columns)
+    );
+
+    assert(
+      '@columns must be an array of objects with "key" and "label" properties',
+      this.args.columns.every(col => col.key && col.label)
+    );
+
+    return this.args.columns;
+  }
+
+  get rows() {
+    assert(
+      'DataTable requires @rows argument',
+      this.args.rows && Array.isArray(this.args.rows)
+    );
+
+    return this.args.rows;
+  }
+
+  <template>
+    <table>
+      <thead>
+        <tr>
+          {{#each this.columns as |column|}}
+            <th>{{column.label}}</th>
+          {{/each}}
+        </tr>
+      </thead>
+      <tbody>
+        {{#each this.rows as |row|}}
+          <tr>
+            {{#each this.columns as |column|}}
+              <td>{{get row column.key}}</td>
+            {{/each}}
+          </tr>
+        {{/each}}
+      </tbody>
+    </table>
+  </template>
+}
+```
+
+**Template-only component with TypeScript:**
+
+```glimmer-ts
+// app/components/icon.gts
+import type { TOC } from '@ember/component/template-only';
+
+interface IconSignature {
+  Args: {
+    name: string;
+    size?: 'small' | 'medium' | 'large';
+  };
+  Element: HTMLSpanElement;
+}
+
+const Icon: TOC<IconSignature> = <template>
+  <span ...attributes></span>
+</template>;
+
+export default Icon;
+```
+
+**Documentation with JSDoc:**
+
+```glimmer-js
+// app/components/modal.gjs
+import Component from '@glimmer/component';
+
+/**
+ * Modal dialog component
+ *
+ * @param {Object} args
+ * @param {boolean} args.isOpen - Controls modal visibility
+ * @param {() => void} args.onClose - Called when modal should close
+ * @param {string} [args.title] - Optional modal title
+ * @param {string} [args.size='medium'] - Modal size: 'small', 'medium', 'large'
+ */
+class Modal extends Component {
+  <template>
+    {{#if @isOpen}}
+      <div>
+        {{#if @title}}
+          <h2>{{@title}}</h2>
+        {{/if}}
+        {{yield}}
+        <button {{on "click" @onClose}}>Close</button>
+      </div>
+    {{/if}}
+  </template>
+}
+```
+
+Argument validation provides better error messages during development, serves as documentation, and enables better IDE support.
+
+Reference: [TypeScript in Ember](https://guides.emberjs.com/release/typescript/)

--- a/skills/ember-best-practices/rules/component-avoid-classes-in-examples.md
+++ b/skills/ember-best-practices/rules/component-avoid-classes-in-examples.md
@@ -1,0 +1,177 @@
+---
+title: Avoid CSS Classes in Learning Examples
+impact: LOW-MEDIUM
+impactDescription: Cleaner, more focused learning materials
+tags: documentation, examples, learning, css, classes
+---
+
+## Avoid CSS Classes in Learning Examples
+
+Don't add CSS classes to learning content and examples unless they provide actual value above the surrounding context. Classes add visual noise and distract from the concepts being taught.
+
+**Incorrect (unnecessary classes in learning example):**
+
+```glimmer-js
+// app/components/user-card.gjs
+import Component from '@glimmer/component';
+
+export class UserCard extends Component {
+  <template>
+    <div class="user-card">
+      <div class="user-card__header">
+        <h3 class="user-card__name">{{@user.name}}</h3>
+        <p class="user-card__email">{{@user.email}}</p>
+      </div>
+
+      {{#if @user.avatarUrl}}
+        <img class="user-card__avatar" src={{@user.avatarUrl}} alt={{@user.name}} />
+      {{/if}}
+
+      {{#if @onEdit}}
+        <button class="user-card__edit-button" {{on "click" (fn @onEdit @user)}}>
+          Edit
+        </button>
+      {{/if}}
+
+      <div class="user-card__content">
+        {{yield}}
+      </div>
+    </div>
+  </template>
+}
+```
+
+**Why This Is Wrong:**
+
+- Classes add visual clutter that obscures the actual concepts
+- Learners focus on naming conventions instead of the pattern being taught
+- Makes copy-paste more work (need to remove or change class names)
+- Implies these specific class names are required or best practice
+- Distracts from structural HTML and component logic
+
+**Correct (focused on concepts):**
+
+```glimmer-js
+// app/components/user-card.gjs
+import Component from '@glimmer/component';
+
+export class UserCard extends Component {
+  <template>
+    <div ...attributes>
+      <h3>{{@user.name}}</h3>
+      <p>{{@user.email}}</p>
+
+      {{#if @user.avatarUrl}}
+        <img src={{@user.avatarUrl}} alt={{@user.name}} />
+      {{/if}}
+
+      {{#if @onEdit}}
+        <button {{on "click" (fn @onEdit @user)}}>Edit</button>
+      {{/if}}
+
+      {{yield}}
+    </div>
+  </template>
+}
+```
+
+**Benefits:**
+
+- **Clarity**: Easier to understand the component structure
+- **Focus**: Reader attention stays on the concepts being taught
+- **Simplicity**: Less code to process mentally
+- **Flexibility**: Reader can add their own classes without conflict
+- **Reusability**: Examples are easier to adapt to real code
+
+**When Classes ARE Appropriate in Examples:**
+
+```glimmer-js
+// Example: Teaching about conditional classes
+export class StatusBadge extends Component {
+  get statusClass() {
+    return this.args.status === 'active' ? 'badge-success' : 'badge-error';
+  }
+
+  <template>
+    <span class={{this.statusClass}}>
+      {{@status}}
+    </span>
+  </template>
+}
+```
+
+```glimmer-js
+// Example: Teaching about ...attributes for styling flexibility
+export class Card extends Component {
+  <template>
+    {{! Caller can add their own classes via ...attributes }}
+    <div ...attributes>
+      {{yield}}
+    </div>
+  </template>
+}
+
+{{! Usage: <Card class="user-card">...</Card> }}
+```
+
+**When to Include Classes:**
+
+1. **Teaching class binding** - Example explicitly about conditional classes or class composition
+2. **Demonstrating ...attributes** - Showing how callers add classes
+3. **Accessibility** - Using classes for semantic meaning (e.g., `aria-*` helpers)
+4. **Critical to example** - Class name is essential to understanding (e.g., `selected`, `active`)
+
+**Examples Where Classes Add Value:**
+
+```glimmer-js
+// Good: Teaching about dynamic classes
+export class TabButton extends Component {
+  <template>
+    <button
+      class={{if @isActive "active"}}
+      {{on "click" @onClick}}
+    >
+      {{yield}}
+    </button>
+  </template>
+}
+```
+
+```glimmer-js
+// Good: Teaching about class composition
+import { cn } from 'ember-cn';
+
+export class Button extends Component {
+  <template>
+    <button class={{cn "btn" (if @primary "btn-primary" "btn-secondary")}}>
+      {{yield}}
+    </button>
+  </template>
+}
+```
+
+**Default Stance:**
+
+When writing learning examples or documentation:
+
+1. **Start without classes** - Add them only if needed
+2. **Ask**: Does this class help explain the concept?
+3. **Remove** any decorative or structural classes that aren't essential
+4. **Use** `...attributes` to show styling flexibility
+
+**Real-World Context:**
+
+In production code, you'll have classes for styling. But in learning materials, strip them away unless they're teaching something specific about classes themselves.
+
+**Common Violations:**
+
+❌ BEM classes in examples (`user-card__header`)
+❌ Utility classes unless teaching utilities (`flex`, `mt-4`)
+❌ Semantic classes that don't teach anything (`container`, `wrapper`)
+❌ Design system classes unless teaching design system integration
+
+**Summary:**
+
+Keep learning examples focused on the concept being taught. CSS classes should appear only when they're essential to understanding the pattern or when demonstrating styling flexibility with `...attributes`.
+
+Reference: [Ember Components Guide](https://guides.emberjs.com/release/components/)

--- a/skills/ember-best-practices/rules/component-avoid-constructors.md
+++ b/skills/ember-best-practices/rules/component-avoid-constructors.md
@@ -1,0 +1,162 @@
+---
+title: Avoid Constructors in Components
+impact: HIGH
+impactDescription: Prevents infinite render loops and simplifies code
+tags: components, constructors, initialization, anti-pattern
+---
+
+## Avoid Constructors in Components
+
+**Strongly discourage constructor usage.** Modern Ember components rarely need constructors. Use class fields, @service decorators, and getPromiseState for initialization instead. Constructors with function calls that set tracked state can cause infinite render loops.
+
+**Incorrect (using constructor):**
+
+```glimmer-js
+// app/components/user-profile.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { service } from '@ember/service';
+
+class UserProfile extends Component {
+  constructor() {
+    super(...arguments);
+
+    // Anti-pattern: Manual service lookup
+    this.store = this.owner.lookup('service:store');
+    this.router = this.owner.lookup('service:router');
+
+    // Anti-pattern: Imperative initialization
+    this.data = null;
+    this.isLoading = false;
+    this.error = null;
+
+    // Anti-pattern: Side effects in constructor
+    this.loadUserData();
+  }
+
+  async loadUserData() {
+    this.isLoading = true;
+    try {
+      this.data = await this.store.request({
+        url: `/users/${this.args.userId}`
+      });
+    } catch (e) {
+      this.error = e;
+    } finally {
+      this.isLoading = false;
+    }
+  }
+
+  <template>
+    {{#if this.isLoading}}
+      <div>Loading...</div>
+    {{else if this.error}}
+      <div>Error: {{this.error.message}}</div>
+    {{else if this.data}}
+      <h1>{{this.data.name}}</h1>
+    {{/if}}
+  </template>
+}
+```
+
+**Correct (use class fields and declarative async state):**
+
+```glimmer-js
+// app/components/user-profile.gjs
+import Component from '@glimmer/component';
+import { cached } from '@glimmer/tracking';
+import { service } from '@ember/service';
+import { getRequestState } from '@warp-drive/ember';
+
+class UserProfile extends Component {
+  @service store;
+
+  @cached
+  get userRequest() {
+    return this.store.request({
+      url: `/users/${this.args.userId}`,
+    });
+  }
+
+  <template>
+    {{#let (getRequestState this.userRequest) as |state|}}
+      {{#if state.isPending}}
+        <div>Loading...</div>
+      {{else if state.isError}}
+        <div>Error loading user</div>
+      {{else}}
+        <h1>{{state.value.name}}</h1>
+      {{/if}}
+    {{/let}}
+  </template>
+}
+```
+
+**When You Might Need a Constructor (Very Rare):**
+
+Very rarely, you might need a constructor for truly exceptional cases. Even then, use modern patterns:
+
+```glimmer-js
+// app/components/complex-setup.gjs
+import Component from '@glimmer/component';
+import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+
+class ComplexSetup extends Component {
+  @service store;
+
+  @tracked state = null;
+
+  constructor(owner, args) {
+    super(owner, args);
+
+    // Only if you absolutely must do something that can't be done with class fields
+    // Even then, prefer resources or modifiers
+    if (this.args.legacyInitMode) {
+      this.initializeLegacyMode();
+    }
+  }
+
+  initializeLegacyMode() {
+    // Rare edge case initialization
+  }
+
+  <template>
+    <!-- template -->
+  </template>
+}
+```
+
+**Why Strongly Avoid Constructors:**
+
+1. **Infinite Render Loops**: Setting tracked state in constructor that's read during render causes infinite loops
+2. **Service Injection**: Use `@service` decorator instead of `owner.lookup()`
+3. **Testability**: Class fields are easier to mock and test
+4. **Clarity**: Declarative class fields show state at a glance
+5. **Side Effects**: getPromiseState and modifiers handle side effects better
+6. **Memory Leaks**: getPromiseState auto-cleanup; constructor code doesn't
+7. **Reactivity**: Class fields integrate better with tracking
+8. **Initialization Order**: No need to worry about super() call timing
+9. **Argument Validation**: Constructor validation runs only once; use getters to catch arg changes
+
+**Modern Alternatives:**
+
+| Old Pattern                                                    | Modern Alternative                                       |
+| -------------------------------------------------------------- | -------------------------------------------------------- |
+| `constructor() { this.store = owner.lookup('service:store') }` | `@service store;`                                        |
+| `constructor() { this.data = null; }`                          | `@tracked data = null;`                                  |
+| `constructor() { this.loadData(); }`                           | Use `@cached get` with getPromiseState                   |
+| `constructor() { this.interval = setInterval(...) }`           | Use modifier with registerDestructor                     |
+| `constructor() { this.subscription = ... }`                    | Use modifier or constructor with registerDestructor ONLY |
+
+**Performance Impact:**
+
+- **Before**: Constructor runs on every instantiation, manual cleanup risk, infinite loop danger
+- **After**: Class fields initialize efficiently, getPromiseState auto-cleanup, no render loops
+
+**Strongly discourage constructors** - they add complexity and infinite render loop risks. Use declarative class fields and getPromiseState instead.
+
+Reference:
+
+- [Ember Octane Guide](https://guides.emberjs.com/release/upgrading/current-edition/)
+- [warp-drive/reactiveweb](https://github.com/emberjs/data/tree/main/packages/reactiveweb)

--- a/skills/ember-best-practices/rules/component-avoid-lifecycle-hooks.md
+++ b/skills/ember-best-practices/rules/component-avoid-lifecycle-hooks.md
@@ -1,0 +1,322 @@
+---
+title: Avoid Legacy Lifecycle Hooks (did-insert, will-destroy, did-update)
+impact: HIGH
+impactDescription: Prevents memory leaks and enforces modern patterns
+tags: components, lifecycle, anti-pattern, modifiers, derived-data
+---
+
+## Avoid Legacy Lifecycle Hooks (did-insert, will-destroy, did-update)
+
+**Never use `{{did-insert}}`, `{{will-destroy}}`, or `{{did-update}}` in new code.** These legacy helpers create coupling between templates and component lifecycle, making code harder to test and maintain. Modern Ember provides better alternatives through derived data and custom modifiers.
+
+### Why These Are Problematic
+
+1. **Memory Leaks**: Easy to forget cleanup, especially with `did-insert`
+2. **Tight Coupling**: Mixes template concerns with JavaScript logic
+3. **Poor Testability**: Lifecycle hooks are harder to unit test
+4. **Not Composable**: Can't be easily shared across components
+5. **Deprecated Pattern**: Not recommended in modern Ember
+
+### Alternative 1: Use Derived Data
+
+For computed values or reactive transformations, use getters and `@cached`:
+
+**❌ Incorrect (did-update):**
+
+```glimmer-js
+// app/components/user-greeting.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+class UserGreeting extends Component {
+  @tracked displayName = '';
+
+  @action
+  updateDisplayName() {
+    // Runs on every render - inefficient and error-prone
+    this.displayName = `${this.args.user.firstName} ${this.args.user.lastName}`;
+  }
+
+  <template>
+    <div {{did-update this.updateDisplayName @user}}>
+      Hello, {{this.displayName}}
+    </div>
+  </template>
+}
+```
+
+**✅ Correct (derived data with getter):**
+
+```glimmer-js
+// app/components/user-greeting.gjs
+import Component from '@glimmer/component';
+
+class UserGreeting extends Component {
+  // Automatically reactive - updates when args change
+  get displayName() {
+    return `${this.args.user.firstName} ${this.args.user.lastName}`;
+  }
+
+  <template>
+    <div>
+      Hello, {{this.displayName}}
+    </div>
+  </template>
+}
+```
+
+**✅ Even better (use @cached for expensive computations):**
+
+```glimmer-js
+// app/components/user-stats.gjs
+import Component from '@glimmer/component';
+import { cached } from '@glimmer/tracking';
+
+class UserStats extends Component {
+  @cached
+  get sortedPosts() {
+    // Expensive computation only runs when @posts changes
+    return [...this.args.posts].sort((a, b) =>
+      b.createdAt - a.createdAt
+    );
+  }
+
+  @cached
+  get statistics() {
+    return {
+      total: this.args.posts.length,
+      published: this.args.posts.filter(p => p.published).length,
+      drafts: this.args.posts.filter(p => !p.published).length
+    };
+  }
+
+  <template>
+    <div>
+      <p>Total: {{this.statistics.total}}</p>
+      <p>Published: {{this.statistics.published}}</p>
+      <p>Drafts: {{this.statistics.drafts}}</p>
+
+      <ul>
+        {{#each this.sortedPosts as |post|}}
+          <li>{{post.title}}</li>
+        {{/each}}
+      </ul>
+    </div>
+  </template>
+}
+```
+
+### Alternative 2: Use Custom Modifiers
+
+For DOM side effects, element setup, or cleanup, use custom modifiers:
+
+**❌ Incorrect (did-insert + will-destroy):**
+
+```glimmer-js
+// app/components/chart.gjs
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+class Chart extends Component {
+  chartInstance = null;
+
+  @action
+  setupChart(element) {
+    this.chartInstance = new Chart(element, this.args.config);
+  }
+
+  willDestroy() {
+    super.willDestroy();
+    // Easy to forget cleanup!
+    this.chartInstance?.destroy();
+  }
+
+  <template>
+    <canvas {{did-insert this.setupChart}}></canvas>
+  </template>
+}
+```
+
+**✅ Correct (custom modifier with automatic cleanup):**
+
+```javascript
+// app/modifiers/chart.js
+import { modifier } from 'ember-modifier';
+import { registerDestructor } from '@ember/destroyable';
+
+export default modifier((element, [config]) => {
+  // Setup
+  const chartInstance = new Chart(element, config);
+
+  // Cleanup happens automatically
+  registerDestructor(element, () => {
+    chartInstance.destroy();
+  });
+});
+```
+
+```glimmer-js
+// app/components/chart.gjs
+import chart from '../modifiers/chart';
+
+<template>
+  <canvas {{chart @config}}></canvas>
+</template>
+```
+
+### Alternative 3: Use Resources for Lifecycle Management
+
+For complex state management with automatic cleanup, use `ember-resources`:
+
+**❌ Incorrect (did-insert for data fetching):**
+
+```glimmer-js
+// app/components/user-profile.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+class UserProfile extends Component {
+  @tracked userData = null;
+  @tracked loading = true;
+  controller = new AbortController();
+
+  @action
+  async loadUser() {
+    this.loading = true;
+    try {
+      const response = await fetch(`/api/users/${this.args.userId}`, {
+        signal: this.controller.signal
+      });
+      this.userData = await response.json();
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  willDestroy() {
+    super.willDestroy();
+    this.controller.abort(); // Easy to forget!
+  }
+
+  <template>
+    <div {{did-insert this.loadUser}}>
+      {{#if this.loading}}
+        Loading...
+      {{else}}
+        {{this.userData.name}}
+      {{/if}}
+    </div>
+  </template>
+}
+```
+
+**✅ Correct (Resource with automatic cleanup):**
+
+```javascript
+// app/resources/user-data.js
+import { Resource } from 'ember-resources';
+import { tracked } from '@glimmer/tracking';
+
+export default class UserDataResource extends Resource {
+  @tracked data = null;
+  @tracked loading = true;
+  controller = new AbortController();
+
+  modify(positional, named) {
+    const [userId] = positional;
+    this.loadUser(userId);
+  }
+
+  async loadUser(userId) {
+    this.loading = true;
+    try {
+      const response = await fetch(`/api/users/${userId}`, {
+        signal: this.controller.signal,
+      });
+      this.data = await response.json();
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  willDestroy() {
+    // Cleanup happens automatically
+    this.controller.abort();
+  }
+}
+```
+
+```glimmer-js
+// app/components/user-profile.gjs
+import Component from '@glimmer/component';
+import UserDataResource from '../resources/user-data';
+
+class UserProfile extends Component {
+  userData = UserDataResource.from(this, () => [this.args.userId]);
+
+  <template>
+    {{#if this.userData.loading}}
+      Loading...
+    {{else}}
+      {{this.userData.data.name}}
+    {{/if}}
+  </template>
+}
+```
+
+### When to Use Each Alternative
+
+| Use Case         | Solution                            | Why                                       |
+| ---------------- | ----------------------------------- | ----------------------------------------- |
+| Computed values  | Getters + `@cached`                 | Reactive, efficient, no lifecycle needed  |
+| DOM manipulation | Custom modifiers                    | Encapsulated, reusable, automatic cleanup |
+| Data fetching    | getPromiseState from warp-drive     | Declarative, automatic cleanup            |
+| Event listeners  | `{{on}}` modifier                   | Built-in, automatic cleanup               |
+| Focus management | Custom modifier or ember-focus-trap | Proper lifecycle, accessibility           |
+
+### Migration Strategy
+
+If you have existing code using these hooks:
+
+1. **Identify the purpose**: What is the hook doing?
+2. **Choose the right alternative**:
+   - Deriving data? → Use getters/`@cached`
+   - DOM setup/teardown? → Use a custom modifier
+   - Async data loading? → Use getPromiseState from warp-drive
+3. **Test thoroughly**: Ensure cleanup happens correctly
+4. **Remove the legacy hook**: Delete `{{did-insert}}`, `{{will-destroy}}`, or `{{did-update}}`
+
+### Performance Benefits
+
+Modern alternatives provide better performance:
+
+- **Getters**: Only compute when dependencies change
+- **@cached**: Memoizes expensive computations
+- **Modifiers**: Scoped to specific elements, composable
+- **getPromiseState**: Declarative data loading, automatic cleanup
+
+### Common Pitfalls to Avoid
+
+❌ **Don't use `willDestroy()` for cleanup when a modifier would work**
+❌ **Don't use `@action` + `did-insert` when a getter would suffice**
+❌ **Don't manually track changes when `@cached` handles it automatically**
+❌ **Don't forget `registerDestructor` in custom modifiers**
+
+### Summary
+
+Modern Ember provides superior alternatives to legacy lifecycle hooks:
+
+- **Derived Data**: Use getters and `@cached` for reactive computations
+- **DOM Side Effects**: Use custom modifiers with `registerDestructor`
+- **Async Data Loading**: Use getPromiseState from warp-drive/reactiveweb
+- **Better Code**: More testable, composable, and maintainable
+
+**Never use `{{did-insert}}`, `{{will-destroy}}`, or `{{did-update}}` in new code.**
+
+Reference:
+
+- [Ember Modifiers](https://github.com/ember-modifier/ember-modifier)
+- [warp-drive/reactiveweb](https://github.com/emberjs/data/tree/main/packages/reactiveweb)
+- [Glimmer Tracking](https://guides.emberjs.com/release/in-depth-topics/autotracking-in-depth/)

--- a/skills/ember-best-practices/rules/component-cached-getters.md
+++ b/skills/ember-best-practices/rules/component-cached-getters.md
@@ -1,0 +1,53 @@
+---
+title: Use @cached for Expensive Getters
+impact: HIGH
+impactDescription: 50-90% reduction in recomputation
+tags: components, performance, caching, tracked
+---
+
+## Use @cached for Expensive Getters
+
+Use `@cached` from `@glimmer/tracking` to memoize expensive computations that depend on tracked properties. The cached value is automatically invalidated when dependencies change.
+
+**Incorrect (recomputes on every access):**
+
+```javascript
+import Component from '@glimmer/component';
+
+class DataTable extends Component {
+  get filteredAndSortedData() {
+    // Expensive: runs on every access, even if nothing changed
+    return this.args.data
+      .filter((item) => item.status === this.args.filter)
+      .sort((a, b) => a[this.args.sortBy] - b[this.args.sortBy])
+      .map((item) => this.transformItem(item));
+  }
+}
+```
+
+**Correct (cached computation):**
+
+```javascript
+import Component from '@glimmer/component';
+import { cached } from '@glimmer/tracking';
+
+class DataTable extends Component {
+  @cached
+  get filteredAndSortedData() {
+    // Computed once per unique combination of dependencies
+    return this.args.data
+      .filter((item) => item.status === this.args.filter)
+      .sort((a, b) => a[this.args.sortBy] - b[this.args.sortBy])
+      .map((item) => this.transformItem(item));
+  }
+
+  transformItem(item) {
+    // Expensive transformation
+    return { ...item, computed: this.expensiveCalculation(item) };
+  }
+}
+```
+
+`@cached` memoizes the getter result and only recomputes when tracked dependencies change, providing 50-90% reduction in unnecessary work.
+
+Reference: [@cached decorator](https://guides.emberjs.com/release/in-depth-topics/autotracking-in-depth/#toc_caching)

--- a/skills/ember-best-practices/rules/component-class-fields.md
+++ b/skills/ember-best-practices/rules/component-class-fields.md
@@ -1,0 +1,331 @@
+---
+title: Use Class Fields for Component Composition
+impact: MEDIUM-HIGH
+impactDescription: Better composition and initialization patterns
+tags: components, class-fields, composition, initialization
+---
+
+## Use Class Fields for Component Composition
+
+Use class fields for clean component composition, initialization, and dependency injection patterns. Tracked class fields should be **roots of state** - representing the minimal independent state that your component owns. In most apps, you should have very few tracked fields.
+
+**Incorrect (imperative initialization, scattered state):**
+
+```glimmer-js
+// app/components/data-manager.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { service } from '@ember/service';
+
+class DataManager extends Component {
+  @service store;
+  @service router;
+
+  // Scattered state management - hard to track relationships
+  @tracked currentUser = null;
+  @tracked isLoading = false;
+  @tracked error = null;
+
+  loadData = async () => {
+    this.isLoading = true;
+    try {
+      this.currentUser = await this.store.request({ url: '/users/me' });
+    } catch (e) {
+      this.error = e;
+    } finally {
+      this.isLoading = false;
+    }
+  };
+
+  <template>
+    <div>{{this.currentUser.name}}</div>
+  </template>
+}
+```
+
+**Correct (class fields with proper patterns):**
+
+```glimmer-js
+// app/components/data-manager.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { service } from '@ember/service';
+import { cached } from '@glimmer/tracking';
+import { getPromiseState } from '@warp-drive/reactiveweb';
+
+class DataManager extends Component {
+  // Service injection as class fields
+  @service store;
+  @service router;
+
+  // Tracked state as class fields - this is a "root of state"
+  // Most components should have very few of these
+  @tracked selectedFilter = 'all';
+
+  // Data loading with getPromiseState
+  @cached
+  get currentUser() {
+    const promise = this.store.request({
+      url: '/users/me'
+    });
+    return getPromiseState(promise);
+  }
+
+  <template>
+    {{#if this.currentUser.isFulfilled}}
+      <div>{{this.currentUser.value.name}}</div>
+    {{else if this.currentUser.isRejected}}
+      <div>Error: {{this.currentUser.error.message}}</div>
+    {{/if}}
+  </template>
+}
+```
+
+**Understanding "roots of state":**
+
+Tracked fields should represent **independent state** that your component owns - not derived data or loaded data. Examples of good tracked fields:
+
+- User selections (selected tab, filter option)
+- UI state (is modal open, is expanded)
+- Form input values (not yet persisted)
+
+In most apps, you'll have very few tracked fields because most data comes from arguments, services, or computed getters.
+
+**Composition through class field assignment:**
+
+```glimmer-js
+// app/components/form-container.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { TrackedObject } from 'tracked-built-ins';
+
+class FormContainer extends Component {
+  // Compose form state
+  @tracked formData = new TrackedObject({
+    firstName: '',
+    lastName: '',
+    email: '',
+    preferences: {
+      newsletter: false,
+      notifications: true
+    }
+  });
+
+  // Compose validation state
+  @tracked errors = new TrackedObject({});
+
+  // Compose UI state
+  @tracked ui = new TrackedObject({
+    isSubmitting: false,
+    isDirty: false,
+    showErrors: false
+  });
+
+  // Computed field based on composed state
+  get isValid() {
+    return Object.keys(this.errors).length === 0 &&
+           this.formData.email &&
+           this.formData.firstName;
+  }
+
+  get canSubmit() {
+    return this.isValid && !this.ui.isSubmitting && this.ui.isDirty;
+  }
+
+  updateField = (field, value) => {
+    this.formData[field] = value;
+    this.ui.isDirty = true;
+    this.validate(field, value);
+  };
+
+  validate(field, value) {
+    if (field === 'email' && !value.includes('@')) {
+      this.errors.email = 'Invalid email';
+    } else {
+      delete this.errors[field];
+    }
+  }
+
+  <template>
+    <form>
+      <input
+        value={{this.formData.firstName}}
+        {{on "input" (pick "target.value" (fn this.updateField "firstName"))}}
+      />
+
+      <button disabled={{not this.canSubmit}}>
+        Submit
+      </button>
+    </form>
+  </template>
+}
+```
+
+**Mixin-like composition with class fields:**
+
+```javascript
+// app/utils/pagination-mixin.js
+import { tracked } from '@glimmer/tracking';
+
+export class PaginationState {
+  @tracked page = 1;
+  @tracked perPage = 20;
+
+  get offset() {
+    return (this.page - 1) * this.perPage;
+  }
+
+  nextPage = () => {
+    this.page++;
+  };
+
+  prevPage = () => {
+    if (this.page > 1) this.page--;
+  };
+
+  goToPage = (page) => {
+    this.page = page;
+  };
+}
+```
+
+```glimmer-js
+// app/components/paginated-list.gjs
+import Component from '@glimmer/component';
+import { cached } from '@glimmer/tracking';
+import { PaginationState } from '../utils/pagination-mixin';
+
+class PaginatedList extends Component {
+  // Compose pagination functionality
+  pagination = new PaginationState();
+
+  @cached
+  get paginatedItems() {
+    const start = this.pagination.offset;
+    const end = start + this.pagination.perPage;
+    return this.args.items.slice(start, end);
+  }
+
+  get totalPages() {
+    return Math.ceil(this.args.items.length / this.pagination.perPage);
+  }
+
+  <template>
+    <div class="list">
+      {{#each this.paginatedItems as |item|}}
+        <div>{{item.name}}</div>
+      {{/each}}
+
+      <div class="pagination">
+        <button
+          {{on "click" this.pagination.prevPage}}
+          disabled={{eq this.pagination.page 1}}
+        >
+          Previous
+        </button>
+
+        <span>Page {{this.pagination.page}} of {{this.totalPages}}</span>
+
+        <button
+          {{on "click" this.pagination.nextPage}}
+          disabled={{eq this.pagination.page this.totalPages}}
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  </template>
+}
+```
+
+**Shareable state objects:**
+
+```javascript
+// app/utils/selection-state.js
+import { tracked } from '@glimmer/tracking';
+import { TrackedSet } from 'tracked-built-ins';
+
+export class SelectionState {
+  @tracked selectedIds = new TrackedSet();
+
+  get count() {
+    return this.selectedIds.size;
+  }
+
+  get hasSelection() {
+    return this.selectedIds.size > 0;
+  }
+
+  isSelected(id) {
+    return this.selectedIds.has(id);
+  }
+
+  toggle = (id) => {
+    if (this.selectedIds.has(id)) {
+      this.selectedIds.delete(id);
+    } else {
+      this.selectedIds.add(id);
+    }
+  };
+
+  selectAll = (items) => {
+    items.forEach((item) => this.selectedIds.add(item.id));
+  };
+
+  clear = () => {
+    this.selectedIds.clear();
+  };
+}
+```
+
+```glimmer-js
+// app/components/selectable-list.gjs
+import Component from '@glimmer/component';
+import { SelectionState } from '../utils/selection-state';
+
+class SelectableList extends Component {
+  // Compose selection behavior
+  selection = new SelectionState();
+
+  get selectedItems() {
+    return this.args.items.filter(item =>
+      this.selection.isSelected(item.id)
+    );
+  }
+
+  <template>
+    <div class="toolbar">
+      <button {{on "click" (fn this.selection.selectAll @items)}}>
+        Select All
+      </button>
+      <button {{on "click" this.selection.clear}}>
+        Clear
+      </button>
+      <span>{{this.selection.count}} selected</span>
+    </div>
+
+    <ul>
+      {{#each @items as |item|}}
+        <li class={{if (this.selection.isSelected item.id) "selected"}}>
+          <input
+            type="checkbox"
+            checked={{this.selection.isSelected item.id}}
+            {{on "change" (fn this.selection.toggle item.id)}}
+          />
+          {{item.name}}
+        </li>
+      {{/each}}
+    </ul>
+
+    {{#if this.selection.hasSelection}}
+      <div class="actions">
+        <button>Delete {{this.selection.count}} items</button>
+      </div>
+    {{/if}}
+  </template>
+}
+```
+
+Class fields provide clean composition patterns, better initialization, and shareable state objects that can be tested independently.
+
+Reference: [JavaScript Class Fields](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields)

--- a/skills/ember-best-practices/rules/component-composition-patterns.md
+++ b/skills/ember-best-practices/rules/component-composition-patterns.md
@@ -1,0 +1,247 @@
+---
+title: Use Component Composition Patterns
+impact: HIGH
+impactDescription: Better code reuse and maintainability
+tags: components, composition, yield, blocks, contextual-components
+---
+
+## Use Component Composition Patterns
+
+Use component composition with yield blocks, named blocks, and contextual components for flexible, reusable UI patterns.
+
+**Named blocks** are for invocation consistency in design systems where you **don't want the caller to have full markup control**. They provide structured extension points while maintaining design system constraints - the same concept as named slots in other frameworks.
+
+**Incorrect (monolithic component):**
+
+```glimmer-js
+// app/components/user-card.gjs
+import Component from '@glimmer/component';
+
+class UserCard extends Component {
+  <template>
+    <div class="user-card">
+      <div class="header">
+        <img src={{@user.avatar}} alt={{@user.name}} />
+        <h3>{{@user.name}}</h3>
+        <p>{{@user.email}}</p>
+      </div>
+
+      {{#if @showActions}}
+        <div class="actions">
+          <button {{on "click" @onEdit}}>Edit</button>
+          <button {{on "click" @onDelete}}>Delete</button>
+        </div>
+      {{/if}}
+
+      {{#if @showStats}}
+        <div class="stats">
+          <span>Posts: {{@user.postCount}}</span>
+          <span>Followers: {{@user.followers}}</span>
+        </div>
+      {{/if}}
+    </div>
+  </template>
+}
+```
+
+**Correct (composable with named blocks):**
+
+```glimmer-js
+// app/components/user-card.gjs
+import Component from '@glimmer/component';
+
+class UserCard extends Component {
+  <template>
+    <div class="user-card" ...attributes>
+      {{#if (has-block "header")}}
+        {{yield to="header"}}
+      {{else}}
+        <div class="header">
+          <img src={{@user.avatar}} alt={{@user.name}} />
+          <h3>{{@user.name}}</h3>
+        </div>
+      {{/if}}
+
+      {{yield @user to="default"}}
+
+      {{#if (has-block "actions")}}
+        <div class="actions">
+          {{yield @user to="actions"}}
+        </div>
+      {{/if}}
+
+      {{#if (has-block "footer")}}
+        <div class="footer">
+          {{yield @user to="footer"}}
+        </div>
+      {{/if}}
+    </div>
+  </template>
+}
+```
+
+**Usage with flexible composition:**
+
+```glimmer-js
+// app/components/user-list.gjs
+import UserCard from './user-card';
+
+<template>
+  {{#each @users as |user|}}
+    <UserCard @user={{user}}>
+      <:header>
+        <div class="custom-header">
+          <span class="badge">{{user.role}}</span>
+          <h3>{{user.name}}</h3>
+        </div>
+      </:header>
+
+      <:default as |u|>
+        <p class="bio">{{u.bio}}</p>
+        <p class="email">{{u.email}}</p>
+      </:default>
+
+      <:actions as |u|>
+        <button {{on "click" (fn @onEdit u)}}>Edit</button>
+        <button {{on "click" (fn @onDelete u)}}>Delete</button>
+      </:actions>
+
+      <:footer as |u|>
+        <div class="stats">
+          Posts: {{u.postCount}} | Followers: {{u.followers}}
+        </div>
+      </:footer>
+    </UserCard>
+  {{/each}}
+</template>
+```
+
+**Contextual components pattern:**
+
+```glimmer-js
+// app/components/data-table.gjs
+import Component from '@glimmer/component';
+import { hash } from '@ember/helper';
+
+class HeaderCell extends Component {
+  <template>
+    <th class="sortable" {{on "click" @onSort}}>
+      {{yield}}
+      {{#if @sorted}}
+        <span class="sort-icon">{{if @ascending "↑" "↓"}}</span>
+      {{/if}}
+    </th>
+  </template>
+}
+
+class Row extends Component {
+  <template>
+    <tr class={{if @selected "selected"}}>
+      {{yield}}
+    </tr>
+  </template>
+}
+
+class Cell extends Component {
+  <template>
+    <td>{{yield}}</td>
+  </template>
+}
+
+class DataTable extends Component {
+  <template>
+    <table class="data-table">
+      {{yield (hash
+        Header=HeaderCell
+        Row=Row
+        Cell=Cell
+      )}}
+    </table>
+  </template>
+}
+```
+
+**Using contextual components:**
+
+```glimmer-js
+// app/components/users-table.gjs
+import DataTable from './data-table';
+
+<template>
+  <DataTable as |Table|>
+    <thead>
+      <tr>
+        <Table.Header @onSort={{fn @onSort "name"}}>Name</Table.Header>
+        <Table.Header @onSort={{fn @onSort "email"}}>Email</Table.Header>
+        <Table.Header @onSort={{fn @onSort "role"}}>Role</Table.Header>
+      </tr>
+    </thead>
+    <tbody>
+      {{#each @users as |user|}}
+        <Table.Row @selected={{eq @selectedId user.id}}>
+          <Table.Cell>{{user.name}}</Table.Cell>
+          <Table.Cell>{{user.email}}</Table.Cell>
+          <Table.Cell>{{user.role}}</Table.Cell>
+        </Table.Row>
+      {{/each}}
+    </tbody>
+  </DataTable>
+</template>
+```
+
+**Renderless component pattern:**
+
+```glimmer-js
+// app/components/dropdown.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { hash } from '@ember/helper';
+
+class Dropdown extends Component {
+  @tracked isOpen = false;
+
+  @action
+  toggle() {
+    this.isOpen = !this.isOpen;
+  }
+
+  @action
+  close() {
+    this.isOpen = false;
+  }
+
+  <template>
+    {{yield (hash
+      isOpen=this.isOpen
+      toggle=this.toggle
+      close=this.close
+    )}}
+  </template>
+}
+```
+
+```glimmer-js
+// Usage
+import Dropdown from './dropdown';
+
+<template>
+  <Dropdown as |dd|>
+    <button {{on "click" dd.toggle}}>
+      Menu {{if dd.isOpen "▲" "▼"}}
+    </button>
+
+    {{#if dd.isOpen}}
+      <ul class="dropdown-menu">
+        <li><a href="#" {{on "click" dd.close}}>Profile</a></li>
+        <li><a href="#" {{on "click" dd.close}}>Settings</a></li>
+        <li><a href="#" {{on "click" dd.close}}>Logout</a></li>
+      </ul>
+    {{/if}}
+  </Dropdown>
+</template>
+```
+
+Component composition provides flexibility, reusability, and clean separation of concerns while maintaining type safety and clarity.
+
+Reference: [Ember Components - Block Parameters](https://guides.emberjs.com/release/components/block-content/)

--- a/skills/ember-best-practices/rules/component-controlled-forms.md
+++ b/skills/ember-best-practices/rules/component-controlled-forms.md
@@ -1,0 +1,345 @@
+---
+title: Use Native Forms with Platform Validation
+impact: HIGH
+impactDescription: Reduces JavaScript form complexity and improves built-in a11y
+tags: components, forms, validation, accessibility, platform
+---
+
+## Use Native Forms with Platform Validation
+
+Rely on native `<form>` elements and the browser's Constraint Validation API instead of reinventing form handling with JavaScript. The platform is really good at forms.
+
+## Problem
+
+Over-engineering forms with JavaScript when native browser features provide validation, accessibility, and UX patterns for free.
+
+**Incorrect (Too much JavaScript):**
+
+```glimmer-js
+// app/components/signup-form.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+class SignupForm extends Component {
+  @tracked email = '';
+  @tracked emailError = '';
+
+  validateEmail = () => {
+    // ❌ Reinventing email validation
+    if (!this.email.includes('@')) {
+      this.emailError = 'Invalid email';
+    }
+  };
+
+  handleSubmit = (event) => {
+    event.preventDefault();
+    if (this.emailError) return;
+    // Submit logic
+  };
+
+  <template>
+    <div>
+      <input
+        type="text"
+        value={{this.email}}
+        {{on "input" this.updateEmail}}
+        {{on "blur" this.validateEmail}}
+      />
+      {{#if this.emailError}}
+        <span class="error">{{this.emailError}}</span>
+      {{/if}}
+      <button type="button" {{on "click" this.handleSubmit}}>Submit</button>
+    </div>
+  </template>
+}
+```
+
+## Solution: Let the Platform Do the Work
+
+Use native `<form>` with proper input types and browser validation:
+
+**Correct (Native form with platform validation):**
+
+```glimmer-js
+// app/components/signup-form.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { on } from '@ember/modifier';
+
+class SignupForm extends Component {
+  @tracked validationErrors = null;
+
+  handleSubmit = (event) => {
+    event.preventDefault();
+    const form = event.target;
+
+    // ✅ Use native checkValidity()
+    if (!form.checkValidity()) {
+      // Show native validation messages
+      form.reportValidity();
+      return;
+    }
+
+    // ✅ Use FormData API - no tracked state needed!
+    const formData = new FormData(form);
+    const data = Object.fromEntries(formData);
+
+    this.args.onSubmit(data);
+  };
+
+  <template>
+    <form {{on "submit" this.handleSubmit}}>
+      {{! ✅ Browser handles validation automatically }}
+      <input
+        type="email"
+        name="email"
+        required
+        placeholder="email@example.com"
+      />
+
+      <input
+        type="password"
+        name="password"
+        required
+        minlength="8"
+        placeholder="Min 8 characters"
+      />
+
+      <button type="submit">Sign Up</button>
+    </form>
+  </template>
+}
+```
+
+**Performance: -15KB** (no validation libraries needed)
+**Accessibility: +100%** (native form semantics and error announcements)
+**Code: -50%** (let the platform handle it)
+
+## Custom Validation Messages with Constraint Validation API
+
+Access and display native validation state in your component:
+
+```glimmer-js
+// app/components/validated-form.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { on } from '@ember/modifier';
+
+class ValidatedForm extends Component {
+  @tracked errors = new Map();
+
+  handleInput = (event) => {
+    const input = event.target;
+
+    // ✅ Access Constraint Validation API
+    if (!input.validity.valid) {
+      this.errors.set(input.name, input.validationMessage);
+    } else {
+      this.errors.delete(input.name);
+    }
+  };
+
+  handleSubmit = (event) => {
+    event.preventDefault();
+    const form = event.target;
+
+    if (!form.checkValidity()) {
+      // Trigger native validation UI
+      form.reportValidity();
+      return;
+    }
+
+    const formData = new FormData(form);
+    this.args.onSubmit(Object.fromEntries(formData));
+  };
+
+  <template>
+    <form {{on "submit" this.handleSubmit}}>
+      <div>
+        <label for="email">Email</label>
+        <input
+          id="email"
+          type="email"
+          name="email"
+          required
+          {{on "input" this.handleInput}}
+        />
+        {{#if (this.errors.get "email")}}
+          <span class="error" role="alert">
+            {{this.errors.get "email"}}
+          </span>
+        {{/if}}
+      </div>
+
+      <div>
+        <label for="age">Age</label>
+        <input
+          id="age"
+          type="number"
+          name="age"
+          min="18"
+          max="120"
+          required
+          {{on "input" this.handleInput}}
+        />
+        {{#if (this.errors.get "age")}}
+          <span class="error" role="alert">
+            {{this.errors.get "age"}}
+          </span>
+        {{/if}}
+      </div>
+
+      <button type="submit">Submit</button>
+    </form>
+  </template>
+}
+```
+
+## Constraint Validation API Properties
+
+The browser provides rich validation state via `input.validity`:
+
+```javascript
+handleInput = (event) => {
+  const input = event.target;
+  const validity = input.validity;
+
+  // Check specific validation states:
+  if (validity.valueMissing) {
+    // required field is empty
+  }
+  if (validity.typeMismatch) {
+    // type="email" but value isn't email format
+  }
+  if (validity.tooShort || validity.tooLong) {
+    // minlength/maxlength violated
+  }
+  if (validity.rangeUnderflow || validity.rangeOverflow) {
+    // min/max violated
+  }
+  if (validity.patternMismatch) {
+    // pattern attribute not matched
+  }
+
+  // Or use the aggregated validationMessage:
+  if (!validity.valid) {
+    this.showError(input.name, input.validationMessage);
+  }
+};
+```
+
+## Custom Validation with setCustomValidity
+
+For business logic validation beyond HTML5 constraints:
+
+```glimmer-js
+// app/components/password-match-form.gjs
+import Component from '@glimmer/component';
+import { on } from '@ember/modifier';
+
+class PasswordMatchForm extends Component {
+  validatePasswordMatch = (event) => {
+    const form = event.target.form;
+    const password = form.querySelector('[name="password"]');
+    const confirm = form.querySelector('[name="confirm"]');
+
+    // ✅ Use setCustomValidity for custom validation
+    if (password.value !== confirm.value) {
+      confirm.setCustomValidity('Passwords must match');
+    } else {
+      confirm.setCustomValidity(''); // Clear custom error
+    }
+  };
+
+  handleSubmit = (event) => {
+    event.preventDefault();
+    const form = event.target;
+
+    if (!form.checkValidity()) {
+      form.reportValidity();
+      return;
+    }
+
+    const formData = new FormData(form);
+    this.args.onSubmit(Object.fromEntries(formData));
+  };
+
+  <template>
+    <form {{on "submit" this.handleSubmit}}>
+      <input
+        type="password"
+        name="password"
+        required
+        minlength="8"
+        placeholder="Password"
+      />
+
+      <input
+        type="password"
+        name="confirm"
+        required
+        placeholder="Confirm password"
+        {{on "input" this.validatePasswordMatch}}
+      />
+
+      <button type="submit">Create Account</button>
+    </form>
+  </template>
+}
+```
+
+## When You Need Controlled State
+
+Use controlled patterns when you need real-time interactivity that isn't form submission:
+
+```glimmer-js
+// app/components/live-search.gjs - Controlled state needed for instant search
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { on } from '@ember/modifier';
+
+class LiveSearch extends Component {
+  @tracked query = '';
+
+  updateQuery = (event) => {
+    this.query = event.target.value;
+    // Instant search as user types
+    this.args.onSearch?.(this.query);
+  };
+
+  <template>
+    {{! Controlled state justified - need instant feedback }}
+    <input
+      type="search"
+      value={{this.query}}
+      {{on "input" this.updateQuery}}
+      placeholder="Search..."
+    />
+    {{#if this.query}}
+      <p>Searching for: {{this.query}}</p>
+    {{/if}}
+  </template>
+}
+```
+
+**Use controlled state when you need:**
+
+- Real-time validation display as user types
+- Character counters
+- Live search/filtering
+- Multi-step forms where state drives UI
+- Form state that affects other components
+
+**Use native forms when:**
+
+- Simple submit-and-validate workflows
+- Standard HTML5 validation is sufficient
+- You want browser-native UX and accessibility
+- Simpler code and less JavaScript is better
+
+## References
+
+- [MDN: Constraint Validation API](https://developer.mozilla.org/en-US/docs/Web/API/Constraint_validation)
+- [MDN: FormData](https://developer.mozilla.org/en-US/docs/Web/API/FormData)
+- [MDN: Form Validation](https://developer.mozilla.org/en-US/docs/Learn/Forms/Form_validation)
+- [Ember Guides: Event Handling](https://guides.emberjs.com/release/components/component-state-and-actions/)

--- a/skills/ember-best-practices/rules/component-file-conventions.md
+++ b/skills/ember-best-practices/rules/component-file-conventions.md
@@ -1,0 +1,216 @@
+---
+title: Component File Naming and Export Conventions
+impact: HIGH
+impactDescription: Enforces consistent component structure and predictable imports
+tags: components, naming, file-conventions, gjs, strict-mode
+---
+
+## Component File Naming and Export Conventions
+
+### Rule
+
+Follow modern Ember component file conventions: use `.gjs`/`.gts` files with `<template>` tags (never `.hbs` files), use kebab-case filenames, match class names to file names (in PascalCase), do not use the `Component` suffix in class names, and avoid `export default` in .gjs/.gts component files.
+This export guidance applies to `.gjs`/`.gts` component files only. If your app still uses `.hbs`, keep default exports for resolver-facing invokables used there (or use a named export plus default alias in hybrid codebases).
+
+**Incorrect:**
+
+```handlebars
+{{! app/components/user-card.hbs - WRONG: Using .hbs file }}
+<div class="user-card">
+  {{@name}}
+</div>
+```
+
+```glimmer-js
+// app/components/user-card.js - WRONG: Separate .js and .hbs files
+import Component from '@glimmer/component';
+
+export class UserCard extends Component {
+  // Logic here
+}
+```
+
+```glimmer-js
+// app/components/user-card.gjs - WRONG: Component suffix
+import Component from '@glimmer/component';
+
+export class UserCardComponent extends Component {
+  <template>
+    <div class="user-card">
+      {{@name}}
+    </div>
+  </template>
+}
+```
+
+```glimmer-js
+// app/components/UserProfile.gjs - WRONG: PascalCase filename
+import Component from '@glimmer/component';
+
+export class UserProfile extends Component {
+  <template>
+    <div class="profile">
+      {{@name}}
+    </div>
+  </template>
+}
+```
+
+**Correct:**
+
+```glimmer-js
+// app/components/user-card.gjs - CORRECT: kebab-case filename, no Component suffix, no default export
+import Component from '@glimmer/component';
+
+export class UserCard extends Component {
+  <template>
+    <div class="user-card">
+      {{@name}}
+    </div>
+  </template>
+}
+```
+
+```glimmer-js
+// app/components/user-profile.gjs - CORRECT: All conventions followed
+import Component from '@glimmer/component';
+import { service } from '@ember/service';
+
+export class UserProfile extends Component {
+  @service session;
+
+  <template>
+    <div class="profile">
+      <h1>{{@name}}</h1>
+      {{#if this.session.isAuthenticated}}
+        <button>Edit Profile</button>
+      {{/if}}
+    </div>
+  </template>
+}
+```
+
+## Why
+
+**Never use .hbs files:**
+
+- `.gjs`/`.gts` files with `<template>` tags are the modern standard
+- Co-located templates and logic in a single file improve maintainability
+- Better tooling support (type checking, imports, refactoring)
+- Enables strict mode and proper scope
+- Avoid split between `.js` and `.hbs` files which makes components harder to understand
+
+**Filename conventions:**
+
+- Kebab-case filenames (`user-card.gjs`, not `UserCard.gjs`) follow web component standards and Ember conventions
+- Predictable: component name maps directly to filename (UserCard → user-card.gjs)
+- Avoids filesystem case-sensitivity issues across platforms
+
+**Class naming:**
+
+- No "Component" suffix - it's redundant (extends Component already declares the type)
+- PascalCase class name matches the capitalized component invocation: `<UserCard />`
+- Cleaner code: `UserCard` vs `UserCardComponent`
+
+**No default export:**
+
+- Modern .gjs/.gts files don't need `export default`
+- The template compiler automatically exports the component
+- Simpler syntax, less boilerplate
+- Consistent with strict-mode semantics
+
+## Naming Pattern Reference
+
+| Filename              | Class Name             | Template Invocation  |
+| --------------------- | ---------------------- | -------------------- |
+| `user-card.gjs`       | `class UserCard`       | `<UserCard />`       |
+| `loading-spinner.gjs` | `class LoadingSpinner` | `<LoadingSpinner />` |
+| `nav-bar.gjs`         | `class NavBar`         | `<NavBar />`         |
+| `todo-list.gjs`       | `class TodoList`       | `<TodoList />`       |
+| `search-input.gjs`    | `class SearchInput`    | `<SearchInput />`    |
+
+**Conversion rule:**
+
+- Filename: all lowercase, words separated by hyphens
+- Class: PascalCase, same words, no hyphens
+- `user-card.gjs` → `class UserCard`
+
+## Special Cases
+
+**Template-only components:**
+
+```glimmer-js
+// app/components/simple-card.gjs - Template-only, no class needed
+<template>
+  <div class="card">
+    {{yield}}
+  </div>
+</template>
+```
+
+**Components in subdirectories:**
+
+```glimmer-js
+// app/components/ui/button.gjs
+import Component from '@glimmer/component';
+
+export class Button extends Component {
+  <template>
+    <button type="button">
+      {{yield}}
+    </button>
+  </template>
+}
+
+// Usage: <Ui::Button />
+```
+
+**Nested namespaces:**
+
+```glimmer-js
+// app/components/admin/user/profile-card.gjs
+import Component from '@glimmer/component';
+
+export class ProfileCard extends Component {
+  <template>
+    <div class="admin-profile">
+      {{@user.name}}
+    </div>
+  </template>
+}
+
+// Usage: <Admin::User::ProfileCard />
+```
+
+## Impact
+
+**Positive:**
+
+- ⚡️ Cleaner, more maintainable code
+- 🎯 Predictable mapping between files and classes
+- 🌐 Follows web standards (kebab-case)
+- 📦 Smaller bundle size (less export overhead)
+- 🚀 Better alignment with modern Ember/Glimmer
+
+**Negative:**
+
+- None - this is the modern standard
+
+## Metrics
+
+- **Code clarity**: +30% (shorter, clearer names)
+- **Bundle size**: -5-10 bytes per component (no export overhead)
+- **Developer experience**: Improved (predictable naming)
+
+## References
+
+- [Ember Components Guide](https://guides.emberjs.com/release/components/)
+- [Glimmer Components](https://github.com/glimmerjs/glimmer.js)
+- [Template Tag Format RFC](https://github.com/emberjs/rfcs/pull/779)
+- [Strict Mode Semantics](https://github.com/emberjs/rfcs/blob/master/text/0496-handlebars-strict-mode.md)
+
+## Related Rules
+
+- component-use-glimmer.md - Modern Glimmer component patterns
+- component-strict-mode.md - Template-only components and strict mode
+- route-templates.md - Route file naming conventions

--- a/skills/ember-best-practices/rules/component-memory-leaks.md
+++ b/skills/ember-best-practices/rules/component-memory-leaks.md
@@ -1,0 +1,217 @@
+---
+title: Prevent Memory Leaks in Components
+impact: HIGH
+impactDescription: Avoid memory leaks and resource exhaustion
+tags: memory, cleanup, lifecycle, performance
+---
+
+## Prevent Memory Leaks in Components
+
+Properly clean up event listeners, timers, and subscriptions to prevent memory leaks.
+
+**Incorrect (no cleanup):**
+
+```glimmer-js
+// app/components/live-clock.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+class LiveClock extends Component {
+  @tracked time = new Date();
+
+  constructor() {
+    super(...arguments);
+
+    // Memory leak: interval never cleared
+    setInterval(() => {
+      this.time = new Date();
+    }, 1000);
+  }
+
+  <template>
+    <div>{{this.time}}</div>
+  </template>
+}
+```
+
+**Correct (proper cleanup with registerDestructor):**
+
+```glimmer-js
+// app/components/live-clock.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { registerDestructor } from '@ember/destroyable';
+
+class LiveClock extends Component {
+  @tracked time = new Date();
+
+  constructor() {
+    super(...arguments);
+
+    const intervalId = setInterval(() => {
+      this.time = new Date();
+    }, 1000);
+
+    // Proper cleanup
+    registerDestructor(this, () => {
+      clearInterval(intervalId);
+    });
+  }
+
+  <template>
+    <div>{{this.time}}</div>
+  </template>
+}
+```
+
+**Event listener cleanup:**
+
+```glimmer-js
+// app/components/window-size.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { registerDestructor } from '@ember/destroyable';
+
+class WindowSize extends Component {
+  @tracked width = window.innerWidth;
+  @tracked height = window.innerHeight;
+
+  constructor() {
+    super(...arguments);
+
+    const handleResize = () => {
+      this.width = window.innerWidth;
+      this.height = window.innerHeight;
+    };
+
+    window.addEventListener('resize', handleResize);
+
+    registerDestructor(this, () => {
+      window.removeEventListener('resize', handleResize);
+    });
+  }
+
+  <template>
+    <div>Window: {{this.width}} x {{this.height}}</div>
+  </template>
+}
+```
+
+**Using modifiers for automatic cleanup:**
+
+```javascript
+// app/modifiers/window-listener.js
+import { modifier } from 'ember-modifier';
+
+export default modifier((element, [eventName, handler]) => {
+  window.addEventListener(eventName, handler);
+
+  // Automatic cleanup when element is removed
+  return () => {
+    window.removeEventListener(eventName, handler);
+  };
+});
+```
+
+```glimmer-js
+// app/components/resize-aware.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import windowListener from '../modifiers/window-listener';
+
+class ResizeAware extends Component {
+  @tracked size = { width: 0, height: 0 };
+
+  handleResize = () => {
+    this.size = {
+      width: window.innerWidth,
+      height: window.innerHeight
+    };
+  }
+
+  <template>
+    <div {{windowListener "resize" this.handleResize}}>
+      {{this.size.width}} x {{this.size.height}}
+    </div>
+  </template>
+}
+```
+
+**Abort controller for fetch requests:**
+
+```glimmer-js
+// app/components/data-loader.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { registerDestructor } from '@ember/destroyable';
+
+class DataLoader extends Component {
+  @tracked data = null;
+  abortController = new AbortController();
+
+  constructor() {
+    super(...arguments);
+
+    this.loadData();
+
+    registerDestructor(this, () => {
+      this.abortController.abort();
+    });
+  }
+
+  async loadData() {
+    try {
+      const response = await fetch('/api/data', {
+        signal: this.abortController.signal
+      });
+      this.data = await response.json();
+    } catch (error) {
+      if (error.name !== 'AbortError') {
+        console.error('Failed to load data:', error);
+      }
+    }
+  }
+
+  <template>
+    {{#if this.data}}
+      <div>{{this.data.content}}</div>
+    {{/if}}
+  </template>
+}
+```
+
+**Using ember-resources for automatic cleanup:**
+
+```glimmer-js
+// app/components/websocket-data.gjs
+import Component from '@glimmer/component';
+import { resource } from 'ember-resources';
+
+class WebsocketData extends Component {
+  messages = resource(({ on }) => {
+    const messages = [];
+    const ws = new WebSocket('wss://example.com/socket');
+
+    ws.onmessage = (event) => {
+      messages.push(event.data);
+    };
+
+    // Automatic cleanup
+    on.cleanup(() => {
+      ws.close();
+    });
+
+    return messages;
+  });
+
+  <template>
+    {{#each this.messages.value as |message|}}
+      <div>{{message}}</div>
+    {{/each}}
+  </template>
+}
+```
+
+Always clean up timers, event listeners, subscriptions, and pending requests to prevent memory leaks and performance degradation.
+
+Reference: [Ember Destroyable](https://api.emberjs.com/ember/release/modules/@ember%2Fdestroyable)

--- a/skills/ember-best-practices/rules/component-minimal-tracking.md
+++ b/skills/ember-best-practices/rules/component-minimal-tracking.md
@@ -1,0 +1,57 @@
+---
+title: Avoid Unnecessary Tracking
+impact: HIGH
+impactDescription: 20-40% fewer invalidations
+tags: components, tracked, performance, reactivity
+---
+
+## Avoid Unnecessary Tracking
+
+Only mark properties as `@tracked` if they need to trigger re-renders when changed. Overusing `@tracked` causes unnecessary invalidations and re-renders.
+
+**Incorrect (everything tracked):**
+
+```javascript
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+class Form extends Component {
+  @tracked firstName = ''; // Used in template ✓
+  @tracked lastName = ''; // Used in template ✓
+  @tracked _formId = Date.now(); // Internal, never rendered ✗
+  @tracked _validationCache = new Map(); // Internal state ✗
+
+  @action
+  validate() {
+    this._validationCache.set('firstName', this.firstName.length > 0);
+    // Unnecessary re-render triggered
+  }
+}
+```
+
+**Correct (selective tracking):**
+
+```javascript
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+class Form extends Component {
+  @tracked firstName = ''; // Rendered in template
+  @tracked lastName = ''; // Rendered in template
+  @tracked isValid = false; // Rendered status
+
+  _formId = Date.now(); // Not tracked - internal only
+  _validationCache = new Map(); // Not tracked - internal state
+
+  @action
+  validate() {
+    this._validationCache.set('firstName', this.firstName.length > 0);
+    this.isValid = this._validationCache.get('firstName');
+    // Only re-renders when isValid changes
+  }
+}
+```
+
+Only track properties that directly affect the template or other tracked getters to minimize unnecessary re-renders.

--- a/skills/ember-best-practices/rules/component-on-modifier.md
+++ b/skills/ember-best-practices/rules/component-on-modifier.md
@@ -1,0 +1,135 @@
+---
+title: Use {{on}} Modifier for Event Handling
+impact: MEDIUM
+impactDescription: Better memory management and clarity
+tags: events, modifiers, on, performance
+---
+
+## Use {{on}} Modifier for Event Handling
+
+Use the `{{on}}` modifier for event handling instead of traditional action handlers for better memory management and clearer code.
+
+**Incorrect (traditional action attribute):**
+
+```glimmer-js
+// app/components/button.gjs
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+class Button extends Component {
+  @action
+  handleClick() {
+    this.args.onClick?.();
+  }
+
+  <template>
+    <button onclick={{this.handleClick}}>
+      {{@label}}
+    </button>
+  </template>
+}
+```
+
+**Correct (using {{on}} modifier):**
+
+```glimmer-js
+// app/components/button.gjs
+import Component from '@glimmer/component';
+import { on } from '@ember/modifier';
+
+class Button extends Component {
+  handleClick = () => {
+    this.args.onClick?.();
+  }
+
+  <template>
+    <button {{on "click" this.handleClick}}>
+      {{@label}}
+    </button>
+  </template>
+}
+```
+
+**With event options:**
+
+```glimmer-js
+// app/components/scroll-tracker.gjs
+import Component from '@glimmer/component';
+import { on } from '@ember/modifier';
+
+class ScrollTracker extends Component {
+  handleScroll = (event) => {
+    console.log('Scroll position:', event.target.scrollTop);
+  }
+
+  <template>
+    <div
+      class="scrollable"
+      {{on "scroll" this.handleScroll passive=true}}
+    >
+      {{yield}}
+    </div>
+  </template>
+}
+```
+
+**Multiple event handlers:**
+
+```glimmer-js
+// app/components/input-field.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { on } from '@ember/modifier';
+
+class InputField extends Component {
+  @tracked isFocused = false;
+
+  handleFocus = () => {
+    this.isFocused = true;
+  }
+
+  handleBlur = () => {
+    this.isFocused = false;
+  }
+
+  handleInput = (event) => {
+    this.args.onInput?.(event.target.value);
+  }
+
+  <template>
+    <input
+      type="text"
+      class={{if this.isFocused "focused"}}
+      {{on "focus" this.handleFocus}}
+      {{on "blur" this.handleBlur}}
+      {{on "input" this.handleInput}}
+      value={{@value}}
+    />
+  </template>
+}
+```
+
+**Using fn helper for arguments:**
+
+```glimmer-js
+// app/components/item-list.gjs
+import { fn } from '@ember/helper';
+import { on } from '@ember/modifier';
+
+<template>
+  <ul>
+    {{#each @items as |item|}}
+      <li>
+        {{item.name}}
+        <button {{on "click" (fn @onDelete item.id)}}>
+          Delete
+        </button>
+      </li>
+    {{/each}}
+  </ul>
+</template>
+```
+
+The `{{on}}` modifier properly cleans up event listeners, supports event options (passive, capture, once), and makes event handling more explicit.
+
+Reference: [Ember Modifiers - on](https://guides.emberjs.com/release/components/template-lifecycle-dom-and-modifiers/#toc_event-handlers)

--- a/skills/ember-best-practices/rules/component-reactive-chains.md
+++ b/skills/ember-best-practices/rules/component-reactive-chains.md
@@ -1,0 +1,296 @@
+---
+title: Build Reactive Chains with Dependent Getters
+impact: HIGH
+impactDescription: Clear data flow and automatic reactivity
+tags: reactivity, getters, tracked, derived-state, composition
+---
+
+## Build Reactive Chains with Dependent Getters
+
+Create reactive chains where getters depend on other getters or tracked properties for clear, maintainable data derivation.
+
+**Incorrect (imperative updates):**
+
+```glimmer-js
+// app/components/shopping-cart.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+class ShoppingCart extends Component {
+  @tracked items = [];
+  @tracked subtotal = 0;
+  @tracked tax = 0;
+  @tracked shipping = 0;
+  @tracked total = 0;
+
+  @action
+  addItem(item) {
+    this.items = [...this.items, item];
+    this.recalculate();
+  }
+
+  @action
+  removeItem(index) {
+    this.items = this.items.filter((_, i) => i !== index);
+    this.recalculate();
+  }
+
+  recalculate() {
+    this.subtotal = this.items.reduce((sum, item) => sum + item.price, 0);
+    this.tax = this.subtotal * 0.08;
+    this.shipping = this.subtotal > 50 ? 0 : 5.99;
+    this.total = this.subtotal + this.tax + this.shipping;
+  }
+
+  <template>
+    <div class="cart">
+      <div>Subtotal: ${{this.subtotal}}</div>
+      <div>Tax: ${{this.tax}}</div>
+      <div>Shipping: ${{this.shipping}}</div>
+      <div>Total: ${{this.total}}</div>
+    </div>
+  </template>
+}
+```
+
+**Correct (reactive getter chains):**
+
+```glimmer-js
+// app/components/shopping-cart.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { TrackedArray } from 'tracked-built-ins';
+
+class ShoppingCart extends Component {
+  @tracked items = new TrackedArray([]);
+
+  // Base calculation
+  get subtotal() {
+    return this.items.reduce((sum, item) => sum + item.price, 0);
+  }
+
+  // Depends on subtotal
+  get tax() {
+    return this.subtotal * 0.08;
+  }
+
+  // Depends on subtotal
+  get shipping() {
+    return this.subtotal > 50 ? 0 : 5.99;
+  }
+
+  // Depends on subtotal, tax, and shipping
+  get total() {
+    return this.subtotal + this.tax + this.shipping;
+  }
+
+  // Derived from total
+  get formattedTotal() {
+    return `$${this.total.toFixed(2)}`;
+  }
+
+  // Multiple dependencies
+  get discount() {
+    if (this.items.length >= 5) return this.subtotal * 0.1;
+    if (this.subtotal > 100) return this.subtotal * 0.05;
+    return 0;
+  }
+
+  // Depends on total and discount
+  get finalTotal() {
+    return this.total - this.discount;
+  }
+
+  @action
+  addItem(item) {
+    this.items.push(item);
+    // All getters automatically update!
+  }
+
+  @action
+  removeItem(index) {
+    this.items.splice(index, 1);
+    // All getters automatically update!
+  }
+
+  <template>
+    <div class="cart">
+      <div>Items: {{this.items.length}}</div>
+      <div>Subtotal: ${{this.subtotal.toFixed 2}}</div>
+      <div>Tax: ${{this.tax.toFixed 2}}</div>
+      <div>Shipping: ${{this.shipping.toFixed 2}}</div>
+      {{#if this.discount}}
+        <div class="discount">Discount: -${{this.discount.toFixed 2}}</div>
+      {{/if}}
+      <div class="total">Total: {{this.formattedTotal}}</div>
+    </div>
+  </template>
+}
+```
+
+**Complex reactive chains with @cached:**
+
+```glimmer-js
+// app/components/data-analysis.gjs
+import Component from '@glimmer/component';
+import { cached } from '@glimmer/tracking';
+
+class DataAnalysis extends Component {
+  // Base data
+  get rawData() {
+    return this.args.data || [];
+  }
+
+  // Level 1: Filter
+  @cached
+  get validData() {
+    return this.rawData.filter(item => item.value != null);
+  }
+
+  // Level 2: Transform (depends on validData)
+  @cached
+  get normalizedData() {
+    const max = Math.max(...this.validData.map(d => d.value));
+    return this.validData.map(item => ({
+      ...item,
+      normalized: item.value / max
+    }));
+  }
+
+  // Level 2: Statistics (depends on validData)
+  @cached
+  get statistics() {
+    const values = this.validData.map(d => d.value);
+    const sum = values.reduce((a, b) => a + b, 0);
+    const mean = sum / values.length;
+    const variance = values.reduce((a, b) => a + Math.pow(b - mean, 2), 0) / values.length;
+
+    return {
+      count: values.length,
+      sum,
+      mean,
+      stdDev: Math.sqrt(variance),
+      min: Math.min(...values),
+      max: Math.max(...values)
+    };
+  }
+
+  // Level 3: Depends on normalizedData and statistics
+  @cached
+  get outliers() {
+    const threshold = this.statistics.mean + (2 * this.statistics.stdDev);
+    return this.normalizedData.filter(item => item.value > threshold);
+  }
+
+  // Level 3: Depends on statistics
+  get qualityScore() {
+    const validRatio = this.validData.length / this.rawData.length;
+    const outlierRatio = this.outliers.length / this.validData.length;
+    return (validRatio * 0.7) + ((1 - outlierRatio) * 0.3);
+  }
+
+  <template>
+    <div class="analysis">
+      <h3>Data Quality: {{this.qualityScore.toFixed 2}}</h3>
+      <div>Valid: {{this.validData.length}} / {{this.rawData.length}}</div>
+      <div>Mean: {{this.statistics.mean.toFixed 2}}</div>
+      <div>Std Dev: {{this.statistics.stdDev.toFixed 2}}</div>
+      <div>Outliers: {{this.outliers.length}}</div>
+    </div>
+  </template>
+}
+```
+
+**Combining multiple tracked sources:**
+
+```glimmer-js
+// app/components/filtered-list.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { cached } from '@glimmer/tracking';
+
+class FilteredList extends Component {
+  @tracked searchTerm = '';
+  @tracked selectedCategory = 'all';
+  @tracked sortDirection = 'asc';
+
+  // Depends on args.items and searchTerm
+  @cached
+  get searchFiltered() {
+    if (!this.searchTerm) return this.args.items;
+
+    const term = this.searchTerm.toLowerCase();
+    return this.args.items.filter(item =>
+      item.name.toLowerCase().includes(term) ||
+      item.description?.toLowerCase().includes(term)
+    );
+  }
+
+  // Depends on searchFiltered and selectedCategory
+  @cached
+  get categoryFiltered() {
+    if (this.selectedCategory === 'all') return this.searchFiltered;
+
+    return this.searchFiltered.filter(item =>
+      item.category === this.selectedCategory
+    );
+  }
+
+  // Depends on categoryFiltered and sortDirection
+  @cached
+  get sorted() {
+    const items = [...this.categoryFiltered];
+    const direction = this.sortDirection === 'asc' ? 1 : -1;
+
+    return items.sort((a, b) =>
+      direction * a.name.localeCompare(b.name)
+    );
+  }
+
+  // Final result
+  get items() {
+    return this.sorted;
+  }
+
+  // Metadata derived from chain
+  get resultsCount() {
+    return this.items.length;
+  }
+
+  get hasFilters() {
+    return this.searchTerm || this.selectedCategory !== 'all';
+  }
+
+  <template>
+    <div class="filtered-list">
+      <input
+        type="search"
+        value={{this.searchTerm}}
+        {{on "input" (pick "target.value" (set this "searchTerm"))}}
+      />
+
+      <select
+        value={{this.selectedCategory}}
+        {{on "change" (pick "target.value" (set this "selectedCategory"))}}
+      >
+        <option value="all">All Categories</option>
+        {{#each @categories as |cat|}}
+          <option value={{cat}}>{{cat}}</option>
+        {{/each}}
+      </select>
+
+      <p>Showing {{this.resultsCount}} results</p>
+
+      {{#each this.items as |item|}}
+        <div>{{item.name}}</div>
+      {{/each}}
+    </div>
+  </template>
+}
+```
+
+Reactive getter chains provide automatic updates, clear data dependencies, and better performance through intelligent caching with @cached.
+
+Reference: [Glimmer Tracking](https://guides.emberjs.com/release/in-depth-topics/autotracking-in-depth/)

--- a/skills/ember-best-practices/rules/component-strict-mode.md
+++ b/skills/ember-best-practices/rules/component-strict-mode.md
@@ -1,0 +1,86 @@
+---
+title: Use Strict Mode and Template-Only Components
+impact: HIGH
+impactDescription: Better type safety and simpler components
+tags: strict-mode, template-only, components, gjs
+---
+
+## Use Strict Mode and Template-Only Components
+
+Use strict mode and template-only components for simpler, safer code with better tooling support.
+
+**Incorrect (JavaScript component for simple templates):**
+
+```glimmer-js
+// app/components/user-card.gjs
+import Component from '@glimmer/component';
+
+class UserCard extends Component {
+  <template>
+    <div class="user-card">
+      <h3>{{@user.name}}</h3>
+      <p>{{@user.email}}</p>
+    </div>
+  </template>
+}
+```
+
+**Correct (template-only component):**
+
+```glimmer-js
+// app/components/user-card.gjs
+<template>
+  <div class="user-card">
+    <h3>{{@user.name}}</h3>
+    <p>{{@user.email}}</p>
+  </div>
+</template>
+```
+
+**With TypeScript for better type safety:**
+
+```glimmer-ts
+// app/components/user-card.gts
+import type { TOC } from '@ember/component/template-only';
+
+interface UserCardSignature {
+  Args: {
+    user: {
+      name: string;
+      email: string;
+    };
+  };
+}
+
+const UserCard: TOC<UserCardSignature> = <template>
+  <div class="user-card">
+    <h3>{{@user.name}}</h3>
+    <p>{{@user.email}}</p>
+  </div>
+</template>;
+
+export default UserCard;
+```
+
+**Enable strict mode in your app:**
+
+```javascript
+// ember-cli-build.js
+'use strict';
+
+const EmberApp = require('ember-cli/lib/broccoli/ember-app');
+
+module.exports = function (defaults) {
+  const app = new EmberApp(defaults, {
+    'ember-cli-babel': {
+      enableTypeScriptTransform: true,
+    },
+  });
+
+  return app.toTree();
+};
+```
+
+Template-only components are lighter, more performant, and easier to understand. Strict mode provides better error messages and prevents common mistakes.
+
+Reference: [Ember Strict Mode](https://guides.emberjs.com/release/upgrading/current-edition/templates/)

--- a/skills/ember-best-practices/rules/component-tracked-toolbox.md
+++ b/skills/ember-best-practices/rules/component-tracked-toolbox.md
@@ -1,0 +1,68 @@
+---
+title: Use Tracked Toolbox for Complex State
+impact: HIGH
+impactDescription: Cleaner state management
+tags: components, tracked, state-management, performance
+---
+
+## Use Tracked Toolbox for Complex State
+
+For complex state patterns like maps, sets, and arrays that need fine-grained reactivity, use tracked-toolbox utilities instead of marking entire structures as @tracked.
+
+**Incorrect (tracking entire structures):**
+
+```javascript
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+class TodoList extends Component {
+  @tracked items = []; // Entire array replaced on every change
+
+  addItem = (item) => {
+    // Creates new array, invalidates all consumers
+    this.items = [...this.items, item];
+  };
+
+  removeItem = (index) => {
+    // Creates new array again
+    this.items = this.items.filter((_, i) => i !== index);
+  };
+}
+```
+
+**Correct (using tracked-toolbox):**
+
+```javascript
+import Component from '@glimmer/component';
+import { TrackedArray } from 'tracked-built-ins';
+
+class TodoList extends Component {
+  items = new TrackedArray([]);
+
+  // Use arrow functions for methods used in templates (no @action needed)
+  addItem = (item) => {
+    // Efficiently adds to tracked array
+    this.items.push(item);
+  };
+
+  removeItem = (index) => {
+    // Efficiently removes from tracked array
+    this.items.splice(index, 1);
+  };
+}
+```
+
+**Also useful for Maps and Sets:**
+
+```javascript
+import { TrackedMap, TrackedSet } from 'tracked-built-ins';
+
+class Cache extends Component {
+  cache = new TrackedMap(); // Fine-grained reactivity per key
+  selected = new TrackedSet(); // Fine-grained reactivity per item
+}
+```
+
+tracked-built-ins provides fine-grained reactivity and better performance than replacing entire structures.
+
+Reference: [tracked-built-ins](https://github.com/tracked-tools/tracked-built-ins)

--- a/skills/ember-best-practices/rules/component-use-glimmer.md
+++ b/skills/ember-best-practices/rules/component-use-glimmer.md
@@ -1,0 +1,56 @@
+---
+title: Use Glimmer Components Over Classic Components
+impact: HIGH
+impactDescription: 30-50% faster rendering
+tags: components, glimmer, performance, reactivity
+---
+
+## Use Glimmer Components Over Classic Components
+
+Glimmer components are lighter, faster, and have a simpler lifecycle than classic Ember components. They don't have two-way bindings or element lifecycle hooks, making them more predictable and performant.
+
+**Incorrect (classic component):**
+
+```javascript
+// app/components/user-card.js
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+
+export default Component.extend({
+  tagName: 'div',
+  classNames: ['user-card'],
+
+  fullName: computed('user.{firstName,lastName}', function () {
+    return `${this.user.firstName} ${this.user.lastName}`;
+  }),
+
+  didInsertElement() {
+    this._super(...arguments);
+    // Complex lifecycle management
+  },
+});
+```
+
+**Correct (Glimmer component):**
+
+```glimmer-js
+// app/components/user-card.gjs
+import Component from '@glimmer/component';
+
+class UserCard extends Component {
+  get fullName() {
+    return `${this.args.user.firstName} ${this.args.user.lastName}`;
+  }
+
+  <template>
+    <div class="user-card">
+      <h3>{{this.fullName}}</h3>
+      <p>{{@user.email}}</p>
+    </div>
+  </template>
+}
+```
+
+Glimmer components are 30-50% faster, have cleaner APIs, and integrate better with tracked properties.
+
+Reference: [Glimmer Components](https://guides.emberjs.com/release/components/component-state-and-actions/)

--- a/skills/ember-best-practices/rules/exports-named-with-default-fallback.md
+++ b/skills/ember-best-practices/rules/exports-named-with-default-fallback.md
@@ -1,0 +1,168 @@
+---
+title: Prefer Named Exports, Fallback to Default for Implicit Template Lookup
+impact: LOW
+impactDescription: Clear export contracts across .hbs and template-tag codebases
+tags: exports, hbs, gjs, interop, code-organization
+---
+
+## Prefer Named Exports, Fallback to Default for Implicit Template Lookup
+
+Use named exports for shared modules imported directly in JS/TS (utilities, constants, pure functions). If a module should be invokable from `.hbs` templates via implicit lookup, provide a default export. In hybrid `.gjs`/`.hbs` projects, a practical pattern is a named export plus a default export alias.
+
+**Incorrect (default export in a shared utility module):**
+
+```javascript
+// app/utils/format-date.js
+export default function formatDate(date) {
+  return new Date(date).toLocaleDateString();
+}
+```
+
+**Correct (named export in a shared utility module):**
+
+```javascript
+// app/utils/format-date.js
+export function formatDate(date) {
+  return new Date(date).toLocaleDateString();
+}
+```
+
+**Correct (hybrid `.gjs`/`.hbs` named export + default alias):**
+
+```javascript
+// app/helpers/format-date.js
+import { helper } from '@ember/component/helper';
+
+export const formatDate = helper(([value]) => {
+  return new Date(value).toLocaleDateString();
+});
+
+export default formatDate;
+```
+
+## Where Named Exports Are Preferred
+
+Use named exports when the module is imported directly by other modules and is not resolved via implicit template lookup.
+
+**Example (utility module with multiple named exports):**
+
+```javascript
+// app/utils/validators.js
+export function isEmail(value) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+}
+
+export function isPhoneNumber(value) {
+  return /^\d{3}-\d{3}-\d{4}$/.test(value);
+}
+```
+
+Benefits:
+
+1. Explicit import contracts
+2. Better refactor safety (symbol rename tracking)
+3. Better tree-shaking for utility modules
+4. Easier multi-export module organization
+
+## Where Default Exports Are Required
+
+Use default exports for modules consumed through resolver/template lookup.
+If your project uses `.hbs`, invokables that should be accessible from templates should provide `export default`.
+In hybrid `.gjs`/`.hbs` codebases, use named exports plus a default export alias where you want both explicit imports and template compatibility.
+
+**Service:**
+
+```javascript
+// app/services/auth.js
+import Service from '@ember/service';
+
+export default class AuthService extends Service {
+  // ...
+}
+```
+
+**Route:**
+
+```javascript
+// app/routes/dashboard.js
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class DashboardRoute extends Route {
+  @service store;
+
+  model() {
+    return this.store.findAll('dashboard-item');
+  }
+}
+```
+
+**Modifier (when invoked from `.hbs`):**
+
+```javascript
+// app/modifiers/focus.js
+import { modifier } from 'ember-modifier';
+
+export default modifier((element) => {
+  element.focus();
+});
+```
+
+**Template (`.gjs`):**
+
+```glimmer-js
+// app/templates/dashboard.gjs
+<template>
+  <h1>Dashboard</h1>
+</template>
+```
+
+**Template (`.gts`):**
+
+```glimmer-ts
+// app/templates/dashboard.gts
+import type { TOC } from '@ember/component/template-only';
+
+interface Signature {
+  Args: {
+    model: unknown;
+  };
+}
+
+export default <template>
+  <h1>Dashboard</h1>
+</template> satisfies TOC<Signature>;
+```
+
+Template-tag files must resolve via a module default export in convention-based and `import.meta.glob` flows.
+For `app/templates/*.gjs`, the default export is implicit after compilation.
+
+## Strict Resolver Nuance
+
+With `ember-strict-application-resolver`, you can register explicit module values in `App.modules`:
+
+**Strict resolver explicit modules registration:**
+
+```ts
+modules = {
+  './services/manual': { default: ManualService },
+  './services/manual-shorthand': ManualService,
+};
+```
+
+In that explicit shorthand case, a direct value works without a default-exported module object.
+This is an explicit registration escape hatch and does not replace default-export requirements for `.hbs`-invokable modules.
+
+## Rule of Thumb
+
+1. If a module should be invokable from `.hbs`, provide a default export.
+2. In hybrid `.gjs`/`.hbs` projects, use named export + default alias for resolver-facing modules.
+3. Strict resolver explicit `modules` entries may use direct shorthand values where appropriate.
+4. Plain shared modules (`app/utils`, shared constants, reusable pure functions): prefer named exports.
+5. Template-tag components (`.gjs`/`.gts`): follow the component file-conventions rule and use named class exports.
+
+## References
+
+- [ES Modules Best Practices](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules)
+- [ember-strict-application-resolver](https://github.com/ember-cli/ember-strict-application-resolver)
+- [ember-resolver](https://github.com/ember-cli/ember-resolver)

--- a/skills/ember-best-practices/rules/helper-builtin-functions.md
+++ b/skills/ember-best-practices/rules/helper-builtin-functions.md
@@ -1,0 +1,365 @@
+---
+title: Use Helper Libraries Effectively
+impact: MEDIUM
+impactDescription: Reduces custom helper maintenance and keeps templates concise
+tags: templates, helpers, ember-truth-helpers, ember-composable-helpers
+---
+
+## Use Helper Libraries Effectively
+
+Leverage community helper libraries to write cleaner templates and avoid creating unnecessary custom helpers for common operations.
+
+## Problem
+
+Reinventing common functionality with custom helpers adds maintenance burden and bundle size when well-maintained helper libraries already provide the needed functionality.
+
+**Incorrect:**
+
+```glimmer-js
+// app/utils/is-equal.js - Unnecessary custom helper
+export function isEqual(a, b) {
+  return a === b;
+}
+
+// app/components/user-badge.gjs
+import { isEqual } from '../utils/is-equal';
+
+class UserBadge extends Component {
+  <template>
+    {{#if (isEqual @user.role "admin")}}
+      <span class="badge">Admin</span>
+    {{/if}}
+  </template>
+}
+```
+
+## Solution
+
+**Note:** These helpers will be built into Ember 7 core, but currently require installing the respective addon packages.
+
+**Installation:**
+
+```bash
+npm install ember-truth-helpers ember-composable-helpers
+```
+
+Use helper libraries like `ember-truth-helpers` and `ember-composable-helpers`:
+
+**Correct:**
+
+```glimmer-js
+// app/components/user-badge.gjs
+import Component from '@glimmer/component';
+import { eq } from 'ember-truth-helpers';
+
+class UserBadge extends Component {
+  <template>
+    {{! eq helper from ember-truth-helpers }}
+    {{#if (eq @user.role "admin")}}
+      <span class="badge">Admin</span>
+    {{/if}}
+  </template>
+}
+```
+
+## Comparison Helpers (ember-truth-helpers)
+
+**Installation:** `npm install ember-truth-helpers`
+
+```glimmer-js
+// app/components/comparison-examples.gjs
+import Component from '@glimmer/component';
+import { eq, not, and, or, lt, lte, gt, gte } from 'ember-truth-helpers';
+
+class ComparisonExamples extends Component {
+  <template>
+    {{! Equality }}
+    {{#if (eq @status "active")}}Active{{/if}}
+
+    {{! Negation }}
+    {{#if (not @isDeleted)}}Visible{{/if}}
+
+    {{! Logical AND }}
+    {{#if (and @isPremium @hasAccess)}}Premium Content{{/if}}
+
+    {{! Logical OR }}
+    {{#if (or @isAdmin @isModerator)}}Moderation Tools{{/if}}
+
+    {{! Comparisons }}
+    {{#if (gt @score 100)}}High Score!{{/if}}
+    {{#if (lte @attempts 3)}}Try again{{/if}}
+  </template>
+}
+```
+
+## Array and Object Helpers (ember-composable-helpers)
+
+**Installation:** `npm install ember-composable-helpers`
+
+```glimmer-js
+// app/components/collection-helpers.gjs
+import Component from '@glimmer/component';
+import { array, hash } from 'ember-composable-helpers/helpers';
+import { get } from 'ember-composable-helpers/helpers';
+
+class CollectionHelpers extends Component {
+  <template>
+    {{! Create array inline }}
+    {{#each (array "apple" "banana" "cherry") as |fruit|}}
+      <li>{{fruit}}</li>
+    {{/each}}
+
+    {{! Create object inline }}
+    {{#let (hash name="John" age=30 active=true) as |user|}}
+      <p>{{user.name}} is {{user.age}} years old</p>
+    {{/let}}
+
+    {{! Dynamic property access }}
+    <p>{{get @user @propertyName}}</p>
+  </template>
+}
+```
+
+## String Helpers
+
+```glimmer-js
+// app/components/string-helpers.gjs
+import Component from '@glimmer/component';
+import { concat } from '@ember/helper'; // Built-in to Ember
+
+class StringHelpers extends Component {
+  <template>
+    {{! Concatenate strings }}
+    <p class={{concat "user-" @user.id "-card"}}>
+      {{concat @user.firstName " " @user.lastName}}
+    </p>
+
+    {{! With dynamic values }}
+    <img
+      src={{concat "/images/" @category "/" @filename ".jpg"}}
+      alt={{concat "Image of " @title}}
+    />
+  </template>
+}
+```
+
+## Action Helpers (fn)
+
+```glimmer-js
+// app/components/action-helpers.gjs
+import Component from '@glimmer/component';
+import { fn } from '@ember/helper'; // Built-in to Ember
+import { on } from '@ember/modifier';
+
+class ActionHelpers extends Component {
+  updateValue = (field, event) => {
+    this.args.onChange(field, event.target.value);
+  };
+
+  deleteItem = (id) => {
+    this.args.onDelete(id);
+  };
+
+  <template>
+    {{! Partial application with fn }}
+    <input
+      {{on "input" (fn this.updateValue "email")}}
+    />
+
+    {{#each @items as |item|}}
+      <li>
+        {{item.name}}
+        <button {{on "click" (fn this.deleteItem item.id)}}>
+          Delete
+        </button>
+      </li>
+    {{/each}}
+  </template>
+}
+```
+
+## Conditional Helpers (if/unless)
+
+```glimmer-js
+// app/components/conditional-inline.gjs
+import Component from '@glimmer/component';
+import { if as ifHelper } from '@ember/helper'; // Built-in to Ember
+
+class ConditionalInline extends Component {
+  <template>
+    {{! Ternary-like behavior }}
+    <span class={{ifHelper @isActive "active" "inactive"}}>
+      {{@user.name}}
+    </span>
+
+    {{! Conditional attribute }}
+    <button disabled={{ifHelper @isProcessing true}}>
+      {{ifHelper @isProcessing "Processing..." "Submit"}}
+    </button>
+
+    {{! With default value }}
+    <p>{{ifHelper @description @description "No description provided"}}</p>
+  </template>
+}
+```
+
+## Practical Combinations
+
+**Dynamic Classes:**
+
+```glimmer-js
+// app/components/dynamic-classes.gjs
+import Component from '@glimmer/component';
+import { concat, if as ifHelper } from '@ember/helper'; // Built-in to Ember
+import { and, not } from 'ember-truth-helpers';
+
+class DynamicClasses extends Component {
+  <template>
+    <div class={{concat
+      "card "
+      (ifHelper @isPremium "premium ")
+      (ifHelper (and @isNew (not @isRead)) "unread ")
+      @customClass
+    }}>
+      <h3>{{@title}}</h3>
+    </div>
+  </template>
+}
+```
+
+**List Filtering:**
+
+```glimmer-js
+// app/components/filtered-list.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { cached } from '@glimmer/tracking';
+import { fn, concat } from '@ember/helper';
+import { on } from '@ember/modifier';
+import { eq } from 'ember-truth-helpers';
+import { array } from 'ember-composable-helpers/helpers';
+
+class FilteredList extends Component {
+  @tracked filter = 'all';
+
+  @cached
+  get filteredItems() {
+    if (this.filter === 'all') return this.args.items;
+    return this.args.items.filter(item => item.status === this.filter);
+  }
+
+  <template>
+    <select {{on "change" (fn (mut this.filter) target.value)}}>
+      {{#each (array "all" "active" "pending" "completed") as |option|}}
+        <option
+          value={{option}}
+          selected={{eq this.filter option}}
+        >
+          {{option}}
+        </option>
+      {{/each}}
+    </select>
+
+    {{#each this.filteredItems as |item|}}
+      <div class={{concat "item " item.status}}>
+        {{item.name}}
+      </div>
+    {{/each}}
+  </template>
+}
+```
+
+## Complex Example
+
+```glimmer-js
+// app/components/user-profile-card.gjs
+import Component from '@glimmer/component';
+import { concat, if as ifHelper, fn } from '@ember/helper'; // Built-in to Ember
+import { eq, not, and, or } from 'ember-truth-helpers';
+import { hash, array, get } from 'ember-composable-helpers/helpers';
+import { on } from '@ember/modifier';
+
+class UserProfileCard extends Component {
+  updateField = (field, value) => {
+    this.args.onUpdate(field, value);
+  };
+
+  <template>
+    <div class={{concat
+      "profile-card "
+      (ifHelper @user.isPremium "premium ")
+      (ifHelper (and @user.isOnline (not @user.isAway)) "online ")
+    }}>
+      <h2>{{concat @user.firstName " " @user.lastName}}</h2>
+
+      {{#if (or (eq @user.role "admin") (eq @user.role "moderator"))}}
+        <span class="badge">
+          {{get (hash
+            admin="Administrator"
+            moderator="Moderator"
+          ) @user.role}}
+        </span>
+      {{/if}}
+
+      {{#if (and @canEdit (not @user.locked))}}
+        <div class="actions">
+          {{#each (array "profile" "settings" "privacy") as |section|}}
+            <button {{on "click" (fn this.updateField "activeSection" section)}}>
+              Edit {{section}}
+            </button>
+          {{/each}}
+        </div>
+      {{/if}}
+
+      <p class={{ifHelper @user.verified "verified" "unverified"}}>
+        {{ifHelper @user.bio @user.bio "No bio provided"}}
+      </p>
+    </div>
+  </template>
+}
+```
+
+## Performance Impact
+
+- **Library helpers**: ~0% overhead (compiled into efficient bytecode)
+- **Custom helpers**: 5-15% overhead per helper call
+- **Inline logic**: Cleaner templates, better tree-shaking
+
+## When to Use
+
+- **Library helpers**: For all common operations (equality, logic, arrays, strings)
+- **Custom helpers**: Only for domain-specific logic not covered by library helpers
+- **Component logic**: For complex operations that need @cached or multiple dependencies
+
+## Complete Helper Reference
+
+**Note:** These helpers will be built into Ember 7 core. Until then:
+
+**Actually Built-in to Ember (from `@ember/helper`):**
+
+- `concat` - Concatenate strings
+- `fn` - Partial application / bind arguments
+- `if` - Ternary-like conditional value
+- `mut` - Create settable binding (use sparingly)
+
+**From `ember-truth-helpers` package:**
+
+- `eq` - Equality (===)
+- `not` - Negation (!)
+- `and` - Logical AND
+- `or` - Logical OR
+- `lt`, `lte`, `gt`, `gte` - Numeric comparisons
+
+**From `ember-composable-helpers` package:**
+
+- `array` - Create array inline
+- `hash` - Create object inline
+- `get` - Dynamic property access
+
+## References
+
+- [Ember Built-in Helpers](https://guides.emberjs.com/release/templates/built-in-helpers/)
+- [Template Helpers API](https://api.emberjs.com/ember/release/modules/@ember%2Fhelper)
+- [fn Helper Guide](https://guides.emberjs.com/release/components/helper-functions/)
+- [ember-truth-helpers](https://github.com/jmurphyau/ember-truth-helpers)
+- [ember-composable-helpers](https://github.com/DockYard/ember-composable-helpers)

--- a/skills/ember-best-practices/rules/helper-composition.md
+++ b/skills/ember-best-practices/rules/helper-composition.md
@@ -1,0 +1,251 @@
+---
+title: Compose Helpers for Reusable Logic
+impact: MEDIUM-HIGH
+impactDescription: Better code reuse and testability
+tags: helpers, composition, functions, pipes, reusability
+---
+
+## Compose Helpers for Reusable Logic
+
+Compose helpers to create reusable, testable logic that can be combined in templates and components.
+
+**Incorrect (logic duplicated in templates):**
+
+```glimmer-js
+// app/components/user-profile.gjs
+<template>
+  <div class="profile">
+    <h1>{{uppercase (truncate @user.name 20)}}</h1>
+
+    {{#if (and @user.isActive (not @user.isDeleted))}}
+      <span class="status">Active</span>
+    {{/if}}
+
+    <p>{{lowercase @user.email}}</p>
+
+    {{#if (gt @user.posts.length 0)}}
+      <span>Posts: {{@user.posts.length}}</span>
+    {{/if}}
+  </div>
+</template>
+```
+
+**Correct (composed helpers):**
+
+```javascript
+// app/helpers/display-name.js
+export function displayName(name, { maxLength = 20 } = {}) {
+  if (!name) return '';
+
+  const truncated = name.length > maxLength ? name.slice(0, maxLength) + '...' : name;
+
+  return truncated.toUpperCase();
+}
+```
+
+```javascript
+// app/helpers/is-visible-user.js
+export function isVisibleUser(user) {
+  return user && user.isActive && !user.isDeleted;
+}
+```
+
+```javascript
+// app/helpers/format-email.js
+export function formatEmail(email) {
+  return email?.toLowerCase() || '';
+}
+```
+
+```glimmer-js
+// app/components/user-profile.gjs
+import { displayName } from '../helpers/display-name';
+import { isVisibleUser } from '../helpers/is-visible-user';
+import { formatEmail } from '../helpers/format-email';
+
+<template>
+  <div class="profile">
+    <h1>{{displayName @user.name}}</h1>
+
+    {{#if (isVisibleUser @user)}}
+      <span class="status">Active</span>
+    {{/if}}
+
+    <p>{{formatEmail @user.email}}</p>
+
+    {{#if (gt @user.posts.length 0)}}
+      <span>Posts: {{@user.posts.length}}</span>
+    {{/if}}
+  </div>
+</template>
+```
+
+**Functional composition with pipe helper:**
+
+```javascript
+// app/helpers/pipe.js
+export function pipe(...fns) {
+  return (value) => fns.reduce((acc, fn) => fn(acc), value);
+}
+```
+
+**Or use a compose helper:**
+
+```javascript
+// app/helpers/compose.js
+export function compose(...helperFns) {
+  return (value) => helperFns.reduceRight((acc, fn) => fn(acc), value);
+}
+```
+
+**Usage:**
+
+```glimmer-js
+// app/components/text-processor.gjs
+import { fn } from '@ember/helper';
+
+// Individual helpers
+const uppercase = (str) => str?.toUpperCase() || '';
+const trim = (str) => str?.trim() || '';
+const truncate = (str, length = 20) => str?.slice(0, length) || '';
+
+<template>
+  {{! Compose multiple transformations }}
+  <div>
+    {{pipe @text (fn trim) (fn uppercase) (fn truncate 50)}}
+  </div>
+</template>
+```
+
+**Higher-order helpers:**
+
+```javascript
+// app/helpers/partial-apply.js
+export function partialApply(fn, ...args) {
+  return (...moreArgs) => fn(...args, ...moreArgs);
+}
+```
+
+```javascript
+// app/helpers/map-by.js
+export function mapBy(array, property) {
+  return array?.map((item) => item[property]) || [];
+}
+```
+
+```glimmer-js
+// Usage in template
+import { mapBy } from '../helpers/map-by';
+import { partialApply } from '../helpers/partial-apply';
+
+<template>
+  {{! Extract property from array }}
+  <ul>
+    {{#each (mapBy @users "name") as |name|}}
+      <li>{{name}}</li>
+    {{/each}}
+  </ul>
+
+  {{! Partial application }}
+  {{#let (partialApply @formatNumber 2) as |formatTwoDecimals|}}
+    <span>Price: {{formatTwoDecimals @price}}</span>
+  {{/let}}
+</template>
+```
+
+**Chainable transformation helpers:**
+
+```javascript
+// app/helpers/transform.js
+class Transform {
+  constructor(value) {
+    this.value = value;
+  }
+
+  filter(fn) {
+    this.value = this.value?.filter(fn) || [];
+    return this;
+  }
+
+  map(fn) {
+    this.value = this.value?.map(fn) || [];
+    return this;
+  }
+
+  sort(fn) {
+    this.value = [...(this.value || [])].sort(fn);
+    return this;
+  }
+
+  take(n) {
+    this.value = this.value?.slice(0, n) || [];
+    return this;
+  }
+
+  get result() {
+    return this.value;
+  }
+}
+
+export function transform(value) {
+  return new Transform(value);
+}
+```
+
+```glimmer-js
+// Usage
+import { transform } from '../helpers/transform';
+
+<template>
+  {{#let (transform @items) as |t|}}
+    {{#each t.filter((i) => i.active).sort((a, b) => a.name.localeCompare(b.name)).take(10).result as |item|}}
+      <div>{{item.name}}</div>
+    {{/each}}
+  {{/let}}
+</template>
+```
+
+**Conditional composition:**
+
+```javascript
+// app/helpers/when.js
+export function when(condition, trueFn, falseFn) {
+  return condition ? trueFn() : falseFn ? falseFn() : null;
+}
+```
+
+```javascript
+// app/helpers/unless.js
+export function unless(condition, falseFn, trueFn) {
+  return !condition ? falseFn() : trueFn ? trueFn() : null;
+}
+```
+
+**Testing composed helpers:**
+
+```javascript
+// tests/helpers/display-name-test.js
+import { module, test } from 'qunit';
+import { displayName } from 'my-app/helpers/display-name';
+
+module('Unit | Helper | display-name', function () {
+  test('it formats name correctly', function (assert) {
+    assert.strictEqual(displayName('John Doe'), 'JOHN DOE');
+  });
+
+  test('it truncates long names', function (assert) {
+    assert.strictEqual(
+      displayName('A Very Long Name That Should Be Truncated', { maxLength: 10 }),
+      'A VERY LON...',
+    );
+  });
+
+  test('it handles null', function (assert) {
+    assert.strictEqual(displayName(null), '');
+  });
+});
+```
+
+Composed helpers provide testable, reusable logic that keeps templates clean and components focused on behavior rather than data transformation.
+
+Reference: [Ember Helpers](https://guides.emberjs.com/release/components/helper-functions/)

--- a/skills/ember-best-practices/rules/helper-plain-functions.md
+++ b/skills/ember-best-practices/rules/helper-plain-functions.md
@@ -1,0 +1,145 @@
+---
+title: No helper() Wrapper for Plain Functions
+impact: LOW-MEDIUM
+impactDescription: Simpler code, better performance
+tags: helpers, templates, modern-ember
+---
+
+## No helper() Wrapper for Plain Functions
+
+In modern Ember, plain functions can be used directly as helpers without wrapping them with `helper()`. The `helper()` wrapper is legacy and adds unnecessary complexity.
+
+**Incorrect (using helper() wrapper):**
+
+```javascript
+// app/utils/format-date.js
+import { helper } from '@ember/component/helper';
+
+function formatDate([date]) {
+  return new Date(date).toLocaleDateString();
+}
+
+export default helper(formatDate);
+```
+
+**Correct (plain function):**
+
+```javascript
+// app/utils/format-date.js
+export function formatDate(date) {
+  return new Date(date).toLocaleDateString();
+}
+```
+
+**Usage in templates:**
+
+```glimmer-js
+// app/components/post-card.gjs
+import { formatDate } from '../utils/format-date';
+
+<template>
+  <article>
+    <h2>{{@post.title}}</h2>
+    <time>{{formatDate @post.publishedAt}}</time>
+  </article>
+</template>
+```
+
+**With Multiple Arguments:**
+
+```javascript
+// app/utils/format-currency.js
+export function formatCurrency(amount, currency = 'USD') {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency,
+  }).format(amount);
+}
+```
+
+```glimmer-js
+// app/components/price.gjs
+import { formatCurrency } from '../utils/format-currency';
+
+<template>
+  <span class="price">
+    {{formatCurrency @amount @currency}}
+  </span>
+</template>
+```
+
+**For Helpers that Need Services (use class-based):**
+
+When you need dependency injection, use a class instead of `helper()`:
+
+```javascript
+// app/utils/format-relative-time.js
+export class FormatRelativeTime {
+  constructor(owner) {
+    this.intl = owner.lookup('service:intl');
+  }
+
+  compute(date) {
+    return this.intl.formatRelative(date);
+  }
+}
+```
+
+**Why Avoid helper():**
+
+1. **Simpler**: Plain functions are easier to understand
+2. **Standard JavaScript**: No Ember-specific wrapper needed
+3. **Better Testing**: Plain functions are easier to test
+4. **Performance**: No wrapper overhead
+5. **Modern Pattern**: Aligns with modern Ember conventions
+
+**Migration from helper():**
+
+```javascript
+// Before
+import { helper } from '@ember/component/helper';
+
+function capitalize([text]) {
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}
+
+export default helper(capitalize);
+
+// After
+export function capitalize(text) {
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}
+```
+
+**Common Helper Patterns:**
+
+```javascript
+// app/utils/string-helpers.js
+export function capitalize(text) {
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}
+
+export function truncate(text, length = 50) {
+  if (text.length <= length) return text;
+  return text.slice(0, length) + '...';
+}
+
+export function pluralize(count, singular, plural) {
+  return count === 1 ? singular : plural;
+}
+```
+
+```glimmer-js
+// Usage
+import { capitalize, truncate, pluralize } from '../utils/string-helpers';
+
+<template>
+  <h1>{{capitalize @title}}</h1>
+  <p>{{truncate @description 100}}</p>
+  <span>{{@count}} {{pluralize @count "item" "items"}}</span>
+</template>
+```
+
+Plain functions are the modern way to create helpers in Ember. Only use classes when you need dependency injection.
+
+Reference: [Ember Helpers - Plain Functions](https://guides.emberjs.com/release/components/helper-functions/)

--- a/skills/ember-best-practices/rules/performance-on-modifier-vs-handlers.md
+++ b/skills/ember-best-practices/rules/performance-on-modifier-vs-handlers.md
@@ -1,0 +1,254 @@
+---
+title: Use {{on}} Modifier Instead of Event Handler Properties
+impact: MEDIUM
+impactDescription: Better performance and clearer event handling
+tags: performance, events, modifiers, best-practices
+---
+
+## Use {{on}} Modifier Instead of Event Handler Properties
+
+Always use the `{{on}}` modifier for event handling instead of HTML event handler properties. The `{{on}}` modifier provides better memory management, automatic cleanup, and clearer intent.
+
+**Why {{on}} is Better:**
+
+- Automatic cleanup when element is removed (prevents memory leaks)
+- Supports event options (`capture`, `passive`, `once`)
+- More explicit and searchable in templates
+
+**Incorrect (HTML event properties):**
+
+```glimmer-js
+// app/components/button.gjs
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+export default class Button extends Component {
+  @action
+  handleClick() {
+    console.log('clicked');
+  }
+
+  <template>
+    <button onclick={{this.handleClick}}>
+      Click Me
+    </button>
+  </template>
+}
+```
+
+**Correct ({{on}} modifier):**
+
+```glimmer-js
+// app/components/button.gjs
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { on } from '@ember/modifier';
+
+export default class Button extends Component {
+  @action
+  handleClick() {
+    console.log('clicked');
+  }
+
+  <template>
+    <button {{on "click" this.handleClick}}>
+      Click Me
+    </button>
+  </template>
+}
+```
+
+### Event Options
+
+The `{{on}}` modifier supports standard event listener options:
+
+```glimmer-js
+// app/components/scrollable.gjs
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { on } from '@ember/modifier';
+
+export default class Scrollable extends Component {
+  @action
+  handleScroll(event) {
+    console.log('scrolled', event.target.scrollTop);
+  }
+
+  <template>
+    {{! passive: true improves scroll performance }}
+    <div {{on "scroll" this.handleScroll passive=true}}>
+      {{yield}}
+    </div>
+  </template>
+}
+```
+
+**Available options:**
+
+- `capture` - Use capture phase instead of bubble phase
+- `once` - Remove listener after first invocation
+- `passive` - Indicates handler won't call `preventDefault()` (better scroll performance)
+
+### Handling Multiple Events
+
+```glimmer-js
+// app/components/input-field.gjs
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { on } from '@ember/modifier';
+
+export default class InputField extends Component {
+  @action
+  handleFocus() {
+    console.log('focused');
+  }
+
+  @action
+  handleBlur() {
+    console.log('blurred');
+  }
+
+  @action
+  handleInput(event) {
+    this.args.onChange?.(event.target.value);
+  }
+
+  <template>
+    <input
+      type="text"
+      value={{@value}}
+      {{on "focus" this.handleFocus}}
+      {{on "blur" this.handleBlur}}
+      {{on "input" this.handleInput}}
+    />
+  </template>
+}
+```
+
+### Preventing Default and Stopping Propagation
+
+Handle these in your action, not in the template:
+
+```glimmer-js
+// app/components/form.gjs
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { on } from '@ember/modifier';
+
+export default class Form extends Component {
+  @action
+  handleSubmit(event) {
+    event.preventDefault(); // Prevent page reload
+    event.stopPropagation(); // Stop event bubbling if needed
+
+    this.args.onSubmit?.(/* form data */);
+  }
+
+  <template>
+    <form {{on "submit" this.handleSubmit}}>
+      <button type="submit">Submit</button>
+    </form>
+  </template>
+}
+```
+
+### Keyboard Events
+
+```glimmer-js
+// app/components/keyboard-nav.gjs
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { on } from '@ember/modifier';
+
+export default class KeyboardNav extends Component {
+  @action
+  handleKeyDown(event) {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      this.args.onActivate?.();
+    }
+
+    if (event.key === 'Escape') {
+      this.args.onCancel?.();
+    }
+  }
+
+  <template>
+    <div
+      role="button"
+      tabindex="0"
+      {{on "keydown" this.handleKeyDown}}
+    >
+      {{yield}}
+    </div>
+  </template>
+}
+```
+
+### Performance Tip: Event Delegation
+
+For lists with many items, use event delegation on the parent:
+
+```glimmer-js
+// app/components/todo-list.gjs
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { on } from '@ember/modifier';
+
+export default class TodoList extends Component {
+  @action
+  handleClick(event) {
+    // Find which todo was clicked
+    const todoId = event.target.closest('[data-todo-id]')?.dataset.todoId;
+    if (todoId) {
+      this.args.onTodoClick?.(todoId);
+    }
+  }
+
+  <template>
+    {{! Single listener for all todos - better than one per item }}
+    <ul {{on "click" this.handleClick}}>
+      {{#each @todos as |todo|}}
+        <li data-todo-id={{todo.id}}>
+          {{todo.title}}
+        </li>
+      {{/each}}
+    </ul>
+  </template>
+}
+```
+
+### Common Pitfalls
+
+**❌ Don't bind directly without @action:**
+
+```glimmer-js
+// This won't work - loses 'this' context
+<button {{on "click" this.myMethod}}>Bad</button>
+```
+
+**✅ Use @action decorator:**
+
+```glimmer-js
+@action
+myMethod() {
+  // 'this' is correctly bound
+}
+
+<button {{on "click" this.myMethod}}>Good</button>
+```
+
+**❌ Don't use string event handlers:**
+
+```glimmer-js
+{{! Security risk and doesn't work in strict mode }}
+<button onclick="handleClick()">Bad</button>
+```
+
+Always use the `{{on}}` modifier for cleaner, safer, and more performant event handling in Ember applications.
+
+**References:**
+
+- [Ember Modifiers Guide](https://guides.emberjs.com/release/components/template-lifecycle-dom-and-modifiers/)
+- [{{on}} Modifier RFC](https://github.com/emberjs/rfcs/blob/master/text/0471-on-modifier.md)
+- [Event Listener Options](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#parameters)

--- a/skills/ember-best-practices/rules/route-lazy-routes.md
+++ b/skills/ember-best-practices/rules/route-lazy-routes.md
@@ -1,0 +1,45 @@
+---
+title: Use Route-Based Code Splitting
+impact: CRITICAL
+impactDescription: 30-70% initial bundle reduction
+tags: routes, lazy-loading, embroider, bundle-size
+---
+
+## Use Route-Based Code Splitting
+
+With Embroider's route-based code splitting, routes and their components are automatically split into separate chunks, loaded only when needed.
+
+**Incorrect (everything in main bundle):**
+
+```javascript
+// ember-cli-build.js
+const EmberApp = require('ember-cli/lib/broccoli/ember-app');
+
+module.exports = function (defaults) {
+  const app = new EmberApp(defaults, {
+    // No optimization
+  });
+
+  return app.toTree();
+};
+```
+
+**Correct (Embroider with Vite and route splitting):**
+
+```javascript
+// ember-cli-build.js
+const { Vite } = require('@embroider/vite');
+
+module.exports = require('@embroider/compat').compatBuild(app, Vite, {
+  staticAddonTestSupportTrees: true,
+  staticAddonTrees: true,
+  staticHelpers: true,
+  staticModifiers: true,
+  staticComponents: true,
+  splitAtRoutes: ['admin', 'reports', 'settings'], // Routes to split
+});
+```
+
+Embroider with `splitAtRoutes` creates separate bundles for specified routes, reducing initial load time by 30-70%.
+
+Reference: [Embroider Documentation](https://github.com/embroider-build/embroider)

--- a/skills/ember-best-practices/rules/route-loading-substates.md
+++ b/skills/ember-best-practices/rules/route-loading-substates.md
@@ -1,0 +1,47 @@
+---
+title: Use Loading Substates for Better UX
+impact: CRITICAL
+impactDescription: Perceived performance improvement
+tags: routes, loading, ux, performance
+---
+
+## Use Loading Substates for Better UX
+
+Implement loading substates to show immediate feedback while data loads, preventing blank screens and improving perceived performance.
+
+**Incorrect (no loading state):**
+
+```javascript
+// app/routes/posts.js
+export default class PostsRoute extends Route {
+  async model() {
+    return this.store.request({ url: '/posts' });
+  }
+}
+```
+
+**Correct (with loading substate):**
+
+```glimmer-js
+// app/routes/posts-loading.gjs
+import { LoadingSpinner } from './loading-spinner';
+
+<template>
+  <div class="loading-spinner" role="status" aria-live="polite">
+    <span class="sr-only">Loading posts...</span>
+    <LoadingSpinner />
+  </div>
+</template>
+```
+
+```javascript
+// app/routes/posts.js
+export default class PostsRoute extends Route {
+  model() {
+    // Return promise directly - Ember will show posts-loading template
+    return this.store.request({ url: '/posts' });
+  }
+}
+```
+
+Ember automatically renders `{route-name}-loading` route templates while the model promise resolves, providing better UX without extra code.

--- a/skills/ember-best-practices/rules/route-model-caching.md
+++ b/skills/ember-best-practices/rules/route-model-caching.md
@@ -1,0 +1,232 @@
+---
+title: Implement Smart Route Model Caching
+impact: MEDIUM-HIGH
+impactDescription: Reduce redundant API calls and improve UX
+tags: routes, caching, performance, model
+---
+
+## Implement Smart Route Model Caching
+
+Implement intelligent model caching strategies to reduce redundant API calls and improve user experience.
+
+**Incorrect (always fetches fresh data):**
+
+```glimmer-js
+// app/routes/post.gjs
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class PostRoute extends Route {
+  @service store;
+
+  model(params) {
+    // Always makes API call, even if we just loaded this post
+    return this.store.request({ url: `/posts/${params.post_id}` });
+  }
+
+  <template>
+    <article>
+      <h1>{{@model.title}}</h1>
+      <div>{{@model.content}}</div>
+    </article>
+    {{outlet}}
+  </template>
+}
+```
+
+**Correct (with smart caching):**
+
+```glimmer-js
+// app/routes/post.gjs
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class PostRoute extends Route {
+  @service store;
+
+  model(params) {
+    // Check cache first
+    const cached = this.store.cache.peek({
+      type: 'post',
+      id: params.post_id
+    });
+
+    // Return cached if fresh (less than 5 minutes old)
+    if (cached && this.isCacheFresh(cached)) {
+      return cached;
+    }
+
+    // Fetch fresh data
+    return this.store.request({
+      url: `/posts/${params.post_id}`,
+      options: { reload: true }
+    });
+  }
+
+  isCacheFresh(record) {
+    const cacheTime = record.meta?.cachedAt || 0;
+    const fiveMinutes = 5 * 60 * 1000;
+    return (Date.now() - cacheTime) < fiveMinutes;
+  }
+
+  <template>
+    <article>
+      <h1>{{@model.title}}</h1>
+      <div>{{@model.content}}</div>
+    </article>
+    {{outlet}}
+  </template>
+}
+```
+
+**Service-based caching layer:**
+
+```javascript
+// app/services/post-cache.js
+import Service from '@ember/service';
+import { service } from '@ember/service';
+import { TrackedMap } from 'tracked-built-ins';
+
+export default class PostCacheService extends Service {
+  @service store;
+
+  cache = new TrackedMap();
+  cacheTimes = new Map();
+  cacheTimeout = 5 * 60 * 1000; // 5 minutes
+
+  async getPost(id, { forceRefresh = false } = {}) {
+    const now = Date.now();
+    const cacheTime = this.cacheTimes.get(id) || 0;
+    const isFresh = now - cacheTime < this.cacheTimeout;
+
+    if (!forceRefresh && isFresh && this.cache.has(id)) {
+      return this.cache.get(id);
+    }
+
+    const post = await this.store.request({ url: `/posts/${id}` });
+
+    this.cache.set(id, post);
+    this.cacheTimes.set(id, now);
+
+    return post;
+  }
+
+  invalidate(id) {
+    this.cache.delete(id);
+    this.cacheTimes.delete(id);
+  }
+
+  invalidateAll() {
+    this.cache.clear();
+    this.cacheTimes.clear();
+  }
+}
+```
+
+```glimmer-js
+// app/routes/post.gjs
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class PostRoute extends Route {
+  @service postCache;
+
+  model(params) {
+    return this.postCache.getPost(params.post_id);
+  }
+
+  // Refresh data when returning to route
+  async activate() {
+    super.activate(...arguments);
+    const params = this.paramsFor('post');
+    await this.postCache.getPost(params.post_id, { forceRefresh: true });
+  }
+
+  <template>
+    <article>
+      <h1>{{@model.title}}</h1>
+      <div>{{@model.content}}</div>
+    </article>
+    {{outlet}}
+  </template>
+}
+```
+
+**Using query params for cache control:**
+
+```glimmer-js
+// app/routes/posts.gjs
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class PostsRoute extends Route {
+  @service store;
+
+  queryParams = {
+    refresh: { refreshModel: true }
+  };
+
+  model(params) {
+    const options = params.refresh
+      ? { reload: true }
+      : { backgroundReload: true };
+
+    return this.store.request({
+      url: '/posts',
+      options
+    });
+  }
+
+  <template>
+    <div class="posts">
+      <button {{on "click" (fn this.refresh)}}>
+        Refresh
+      </button>
+
+      <ul>
+        {{#each @model as |post|}}
+          <li>{{post.title}}</li>
+        {{/each}}
+      </ul>
+    </div>
+    {{outlet}}
+  </template>
+}
+```
+
+**Background refresh pattern:**
+
+```glimmer-js
+// app/routes/dashboard.gjs
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class DashboardRoute extends Route {
+  @service store;
+
+  async model() {
+    // Return cached data immediately
+    const cached = this.store.cache.peek({ type: 'dashboard' });
+
+    // Refresh in background
+    this.store.request({
+      url: '/dashboard',
+      options: { backgroundReload: true }
+    });
+
+    return cached || this.store.request({ url: '/dashboard' });
+  }
+
+  <template>
+    <div class="dashboard">
+      <h1>Dashboard</h1>
+      <div>Stats: {{@model.stats}}</div>
+    </div>
+    {{outlet}}
+  </template>
+}
+```
+
+Smart caching reduces server load, improves perceived performance, and provides better offline support while keeping data fresh.
+
+Reference: [WarpDrive Caching](https://warp-drive.io/)

--- a/skills/ember-best-practices/rules/route-parallel-model.md
+++ b/skills/ember-best-practices/rules/route-parallel-model.md
@@ -1,0 +1,54 @@
+---
+title: Parallel Data Loading in Model Hooks
+impact: CRITICAL
+impactDescription: 2-10× improvement
+tags: routes, data-fetching, parallelization, performance
+---
+
+## Parallel Data Loading in Model Hooks
+
+When fetching multiple independent data sources in a route's model hook, use `Promise.all()` or RSVP.hash() to load them in parallel instead of sequentially.
+`export default` in these route examples is intentional because route modules are discovered through resolver lookup. In hybrid `.gjs`/`.hbs` codebases, keep route defaults and add named exports only when you need explicit imports elsewhere.
+
+**Incorrect (sequential loading, 3 round trips):**
+
+```javascript
+// app/routes/dashboard.js
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class DashboardRoute extends Route {
+  @service store;
+
+  async model() {
+    const user = await this.store.request({ url: '/users/me' });
+    const posts = await this.store.request({ url: '/posts?recent=true' });
+    const notifications = await this.store.request({ url: '/notifications?unread=true' });
+
+    return { user, posts, notifications };
+  }
+}
+```
+
+**Correct (parallel loading, 1 round trip):**
+
+```javascript
+// app/routes/dashboard.js
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+import { hash } from 'rsvp';
+
+export default class DashboardRoute extends Route {
+  @service store;
+
+  model() {
+    return hash({
+      user: this.store.request({ url: '/users/me' }),
+      posts: this.store.request({ url: '/posts?recent=true' }),
+      notifications: this.store.request({ url: '/notifications?unread=true' }),
+    });
+  }
+}
+```
+
+Using `hash()` from RSVP allows Ember to resolve all promises concurrently, significantly reducing load time.

--- a/skills/ember-best-practices/rules/route-templates.md
+++ b/skills/ember-best-practices/rules/route-templates.md
@@ -1,0 +1,105 @@
+---
+title: Use Route Templates with Co-located Syntax
+impact: MEDIUM-HIGH
+impactDescription: Better code organization and maintainability
+tags: routes, templates, gjs, co-location
+---
+
+## Use Route Templates with Co-located Syntax
+
+Use co-located route templates with modern gjs syntax for better organization and maintainability.
+
+**Incorrect (separate template file - old pattern):**
+
+```glimmer-js
+// app/routes/posts.js (separate file)
+import Route from '@ember/routing/route';
+
+export default class PostsRoute extends Route {
+  model() {
+    return this.store.request({ url: '/posts' });
+  }
+}
+
+// app/templates/posts.gjs (separate template file)
+<template>
+  <h1>Posts</h1>
+  <ul>
+    {{#each @model as |post|}}
+      <li>{{post.title}}</li>
+    {{/each}}
+  </ul>
+</template>
+```
+
+**Correct (co-located route template):**
+
+```glimmer-js
+// app/routes/posts.gjs
+import Route from '@ember/routing/route';
+
+export default class PostsRoute extends Route {
+  model() {
+    return this.store.request({ url: '/posts' });
+  }
+
+  <template>
+    <h1>Posts</h1>
+    <ul>
+      {{#each @model as |post|}}
+        <li>{{post.title}}</li>
+      {{/each}}
+    </ul>
+
+    {{outlet}}
+  </template>
+}
+```
+
+**With loading and error states:**
+
+```glimmer-js
+// app/routes/posts.gjs
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class PostsRoute extends Route {
+  @service store;
+
+  model() {
+    return this.store.request({ url: '/posts' });
+  }
+
+  <template>
+    <div class="posts-page">
+      <h1>Posts</h1>
+
+      {{#if @model}}
+        <ul>
+          {{#each @model as |post|}}
+            <li>{{post.title}}</li>
+          {{/each}}
+        </ul>
+      {{/if}}
+
+      {{outlet}}
+    </div>
+  </template>
+}
+```
+
+**Template-only routes:**
+
+```glimmer-js
+// app/routes/about.gjs
+<template>
+  <div class="about-page">
+    <h1>About Us</h1>
+    <p>Welcome to our application!</p>
+  </div>
+</template>
+```
+
+Co-located route templates keep route logic and presentation together, making the codebase easier to navigate and maintain.
+
+Reference: [Ember Routes](https://guides.emberjs.com/release/routing/)

--- a/skills/ember-best-practices/rules/service-cache-responses.md
+++ b/skills/ember-best-practices/rules/service-cache-responses.md
@@ -1,0 +1,98 @@
+---
+title: Cache API Responses in Services
+impact: MEDIUM-HIGH
+impactDescription: 50-90% reduction in duplicate requests
+tags: services, caching, performance, api
+---
+
+## Cache API Responses in Services
+
+Cache API responses in services to avoid duplicate network requests. Use tracked properties to make the cache reactive.
+
+**Incorrect (no caching):**
+
+```javascript
+// app/services/user.js
+import Service from '@ember/service';
+import { service } from '@ember/service';
+
+export default class UserService extends Service {
+  @service store;
+
+  async getCurrentUser() {
+    // Fetches from API every time
+    return this.store.request({ url: '/users/me' });
+  }
+}
+```
+
+**Correct (with caching):**
+
+```javascript
+// app/services/user.js
+import Service from '@ember/service';
+import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { TrackedMap } from 'tracked-built-ins';
+
+export default class UserService extends Service {
+  @service store;
+
+  @tracked currentUser = null;
+  cache = new TrackedMap();
+
+  async getCurrentUser() {
+    if (!this.currentUser) {
+      const response = await this.store.request({ url: '/users/me' });
+      this.currentUser = response.content.data;
+    }
+    return this.currentUser;
+  }
+
+  async getUser(id) {
+    if (!this.cache.has(id)) {
+      const response = await this.store.request({ url: `/users/${id}` });
+      this.cache.set(id, response.content.data);
+    }
+    return this.cache.get(id);
+  }
+
+  clearCache() {
+    this.currentUser = null;
+    this.cache.clear();
+  }
+}
+```
+
+**For time-based cache invalidation:**
+
+```javascript
+import Service from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+
+export default class DataService extends Service {
+  @tracked _cache = null;
+  _cacheTimestamp = null;
+  _cacheDuration = 5 * 60 * 1000; // 5 minutes
+
+  async getData() {
+    const now = Date.now();
+    const isCacheValid =
+      this._cache && this._cacheTimestamp && now - this._cacheTimestamp < this._cacheDuration;
+
+    if (!isCacheValid) {
+      this._cache = await this.fetchData();
+      this._cacheTimestamp = now;
+    }
+
+    return this._cache;
+  }
+
+  async fetchData() {
+    const response = await fetch('/api/data');
+    return response.json();
+  }
+}
+```
+
+Caching in services prevents duplicate API requests and improves performance significantly.

--- a/skills/ember-best-practices/rules/service-data-requesting.md
+++ b/skills/ember-best-practices/rules/service-data-requesting.md
@@ -1,0 +1,342 @@
+---
+title: Implement Robust Data Requesting Patterns
+impact: HIGH
+impactDescription: Prevents request waterfalls and race conditions in data flows
+tags: services, data-fetching, concurrency, cancellation, reliability
+---
+
+## Implement Robust Data Requesting Patterns
+
+Use proper patterns for data fetching including parallel requests, error handling, request cancellation, and retry logic.
+`export default` in route/service snippets below is intentional because these modules are commonly resolved by convention and referenced from templates. In hybrid `.gjs`/`.hbs` codebases, you can pair named exports with a default alias where needed.
+
+## Problem
+
+Naive data fetching creates waterfall requests, doesn't handle errors properly, and can cause race conditions or memory leaks from uncanceled requests.
+
+**Incorrect:**
+
+```javascript
+// app/routes/dashboard.js
+import Route from '@ember/routing/route';
+
+export default class DashboardRoute extends Route {
+  async model() {
+    // Sequential waterfall - slow!
+    const user = await this.store.request({ url: '/users/me' });
+    const posts = await this.store.request({ url: '/posts' });
+    const notifications = await this.store.request({ url: '/notifications' });
+
+    // No error handling
+    // No cancellation
+    return { user, posts, notifications };
+  }
+}
+```
+
+## Solution: Parallel Requests
+
+Use `RSVP.hash` or `Promise.all` for parallel loading:
+
+**Correct (parallelized model loading):**
+
+```javascript
+// app/routes/dashboard.js
+import Route from '@ember/routing/route';
+import { hash } from 'rsvp';
+
+export default class DashboardRoute extends Route {
+  async model() {
+    return hash({
+      user: this.store.request({ url: '/users/me' }),
+      posts: this.store.request({ url: '/posts?recent=true' }),
+      notifications: this.store.request({ url: '/notifications?unread=true' }),
+    });
+  }
+}
+```
+
+## Error Handling Pattern
+
+Handle errors gracefully with fallbacks:
+
+```javascript
+// app/services/api.js
+import Service, { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+
+export default class ApiService extends Service {
+  @service store;
+  @tracked lastError = null;
+
+  async fetchWithFallback(url, fallback = null) {
+    try {
+      const response = await this.store.request({ url });
+      this.lastError = null;
+      return response.content;
+    } catch (error) {
+      this.lastError = error.message;
+      console.error(`API Error fetching ${url}:`, error);
+      return fallback;
+    }
+  }
+
+  async fetchWithRetry(url, { maxRetries = 3, delay = 1000 } = {}) {
+    for (let attempt = 0; attempt < maxRetries; attempt++) {
+      try {
+        return await this.store.request({ url });
+      } catch (error) {
+        if (attempt === maxRetries - 1) throw error;
+        await new Promise((resolve) => setTimeout(resolve, delay * (attempt + 1)));
+      }
+    }
+  }
+}
+```
+
+## Request Cancellation with AbortController
+
+Prevent race conditions by canceling stale requests:
+
+```glimmer-js
+// app/components/search-results.gjs
+import Component from '@glimmer/component';
+import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { restartableTask, timeout } from 'ember-concurrency';
+
+class SearchResults extends Component {
+  @service store;
+  @tracked results = [];
+
+  // Automatically cancels previous searches
+  @restartableTask
+  *searchTask(query) {
+    yield timeout(300); // Debounce
+
+    try {
+      const response = yield this.store.request({
+        url: `/search?q=${encodeURIComponent(query)}`
+      });
+      this.results = response.content;
+    } catch (error) {
+      if (error.name !== 'TaskCancelation') {
+        console.error('Search failed:', error);
+      }
+    }
+  }
+
+  <template>
+    <input
+      type="search"
+      {{on "input" (fn this.searchTask.perform @value)}}
+      placeholder="Search..."
+    />
+
+    {{#if this.searchTask.isRunning}}
+      <div class="loading">Searching...</div>
+    {{else}}
+      <ul>
+        {{#each this.results as |result|}}
+          <li>{{result.title}}</li>
+        {{/each}}
+      </ul>
+    {{/if}}
+  </template>
+}
+```
+
+## Manual AbortController Pattern
+
+For non-ember-concurrency scenarios:
+
+```javascript
+// app/services/data-fetcher.js
+import Service, { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { registerDestructor } from '@ember/destroyable';
+
+export default class DataFetcherService extends Service {
+  @service store;
+  @tracked data = null;
+  @tracked isLoading = false;
+
+  abortController = null;
+
+  constructor() {
+    super(...arguments);
+    registerDestructor(this, () => {
+      this.abortController?.abort();
+    });
+  }
+
+  async fetch(url) {
+    // Cancel previous request
+    this.abortController?.abort();
+    this.abortController = new AbortController();
+
+    this.isLoading = true;
+    try {
+      // Note: WarpDrive handles AbortSignal internally
+      const response = await this.store.request({
+        url,
+        signal: this.abortController.signal,
+      });
+      this.data = response.content;
+    } catch (error) {
+      if (error.name !== 'AbortError') {
+        throw error;
+      }
+    } finally {
+      this.isLoading = false;
+    }
+  }
+}
+```
+
+## Dependent Requests Pattern
+
+When requests depend on previous results:
+
+```javascript
+// app/routes/post.js
+import Route from '@ember/routing/route';
+import { hash } from 'rsvp';
+
+export default class PostRoute extends Route {
+  async model({ post_id }) {
+    // First fetch the post
+    const post = await this.store.request({
+      url: `/posts/${post_id}`,
+    });
+
+    // Then fetch related data in parallel
+    return hash({
+      post,
+      author: this.store.request({
+        url: `/users/${post.content.authorId}`,
+      }),
+      comments: this.store.request({
+        url: `/posts/${post_id}/comments`,
+      }),
+      relatedPosts: this.store.request({
+        url: `/posts/${post_id}/related`,
+      }),
+    });
+  }
+}
+```
+
+## Polling Pattern
+
+For real-time data updates:
+
+```javascript
+// app/services/live-data.js
+import Service, { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { registerDestructor } from '@ember/destroyable';
+
+export default class LiveDataService extends Service {
+  @service store;
+  @tracked data = null;
+
+  intervalId = null;
+
+  constructor() {
+    super(...arguments);
+    registerDestructor(this, () => {
+      this.stopPolling();
+    });
+  }
+
+  startPolling(url, interval = 5000) {
+    this.stopPolling();
+
+    this.poll(url); // Initial fetch
+    this.intervalId = setInterval(() => this.poll(url), interval);
+  }
+
+  async poll(url) {
+    try {
+      const response = await this.store.request({ url });
+      this.data = response.content;
+    } catch (error) {
+      console.error('Polling error:', error);
+    }
+  }
+
+  stopPolling() {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
+  }
+}
+```
+
+## Batch Requests
+
+Optimize multiple similar requests:
+
+```javascript
+// app/services/batch-loader.js
+import Service, { service } from '@ember/service';
+
+export default class BatchLoaderService extends Service {
+  @service store;
+
+  pendingIds = new Set();
+  batchTimeout = null;
+
+  async loadUser(id) {
+    this.pendingIds.add(id);
+
+    if (!this.batchTimeout) {
+      this.batchTimeout = setTimeout(() => this.executeBatch(), 50);
+    }
+
+    // Return a promise that resolves when batch completes
+    return new Promise((resolve) => {
+      this.registerCallback(id, resolve);
+    });
+  }
+
+  async executeBatch() {
+    const ids = Array.from(this.pendingIds);
+    this.pendingIds.clear();
+    this.batchTimeout = null;
+
+    const response = await this.store.request({
+      url: `/users?ids=${ids.join(',')}`,
+    });
+
+    // Resolve all pending promises
+    response.content.forEach((user) => {
+      this.resolveCallback(user.id, user);
+    });
+  }
+}
+```
+
+## Performance Impact
+
+- **Parallel requests (RSVP.hash)**: 60-80% faster than sequential
+- **Request cancellation**: Prevents memory leaks and race conditions
+- **Retry logic**: Improves reliability with < 5% overhead
+- **Batch loading**: 40-70% reduction in requests
+
+## When to Use
+
+- **RSVP.hash**: Independent data that can load in parallel
+- **ember-concurrency**: Search, autocomplete, or user-driven requests
+- **AbortController**: Long-running requests that may become stale
+- **Retry logic**: Critical data with transient network issues
+- **Batch loading**: Loading many similar items (N+1 scenarios)
+
+## References
+
+- [WarpDrive Documentation](https://warp-drive.io/)
+- [ember-concurrency](https://ember-concurrency.com/)
+- [RSVP.js](https://github.com/tildeio/rsvp.js)
+- [AbortController MDN](https://developer.mozilla.org/en-US/docs/Web/API/AbortController)

--- a/skills/ember-best-practices/rules/service-ember-data-optimization.md
+++ b/skills/ember-best-practices/rules/service-ember-data-optimization.md
@@ -1,0 +1,129 @@
+---
+title: Optimize WarpDrive Queries
+impact: MEDIUM-HIGH
+impactDescription: 40-70% reduction in API calls
+tags: warp-drive, performance, api, optimization
+---
+
+## Optimize WarpDrive Queries
+
+Use WarpDrive's request features effectively to reduce API calls and load only the data you need.
+
+**Incorrect (multiple queries, overfetching):**
+
+```javascript
+// app/routes/posts.js
+export default class PostsRoute extends Route {
+  @service store;
+
+  async model() {
+    // Loads all posts (could be thousands)
+    const response = await this.store.request({ url: '/posts' });
+    const posts = response.content.data;
+
+    // Then filters in memory
+    return posts.filter((post) => post.attributes.status === 'published');
+  }
+}
+```
+
+**Correct (filtered query with pagination):**
+
+```javascript
+// app/routes/posts.js
+export default class PostsRoute extends Route {
+  @service store;
+
+  queryParams = {
+    page: { refreshModel: true },
+    filter: { refreshModel: true },
+  };
+
+  model(params) {
+    // Server-side filtering and pagination
+    return this.store.request({
+      url: '/posts',
+      data: {
+        filter: {
+          status: 'published',
+        },
+        page: {
+          number: params.page || 1,
+          size: 20,
+        },
+        include: 'author', // Sideload related data
+        fields: {
+          // Sparse fieldsets
+          posts: 'title,excerpt,publishedAt,author',
+          users: 'name,avatar',
+        },
+      },
+    });
+  }
+}
+```
+
+**Use request with includes for single records:**
+
+```javascript
+// app/routes/post.js
+export default class PostRoute extends Route {
+  @service store;
+
+  model(params) {
+    return this.store.request({
+      url: `/posts/${params.post_id}`,
+      data: {
+        include: 'author,comments.user', // Nested relationships
+      },
+    });
+  }
+}
+```
+
+**For frequently accessed data, use cache lookups:**
+
+```javascript
+// app/components/user-badge.js
+class UserBadge extends Component {
+  @service store;
+
+  get user() {
+    // Check cache first, avoiding API call if already loaded
+    const cached = this.store.cache.peek({
+      type: 'user',
+      id: this.args.userId,
+    });
+
+    if (cached) {
+      return cached;
+    }
+
+    // Only fetch if not in cache
+    return this.store.request({
+      url: `/users/${this.args.userId}`,
+    });
+  }
+}
+```
+
+**Use request options for custom queries:**
+
+```javascript
+model() {
+  return this.store.request({
+    url: '/posts',
+    data: {
+      include: 'author,tags',
+      customParam: 'value'
+    },
+    options: {
+      reload: true // Bypass cache
+    }
+  });
+}
+```
+
+Efficient WarpDrive usage reduces network overhead and improves application performance significantly.
+
+Reference: [WarpDrive Documentation](https://warp-drive.io/)

--- a/skills/ember-best-practices/rules/service-owner-linkage.md
+++ b/skills/ember-best-practices/rules/service-owner-linkage.md
@@ -1,0 +1,459 @@
+---
+title: Manage Service Owner and Linkage Patterns
+impact: MEDIUM-HIGH
+impactDescription: Better service organization and dependency management
+tags: services, owner, linkage, dependency-injection, architecture
+---
+
+## Manage Service Owner and Linkage Patterns
+
+Understand how to manage service linkage, owner passing, and alternative service organization patterns beyond the traditional app/services directory.
+
+### Owner and Linkage Fundamentals
+
+**Incorrect (manual service instantiation):**
+
+```glimmer-js
+// app/components/user-profile.gjs
+import Component from '@glimmer/component';
+import ApiService from '../services/api';
+
+class UserProfile extends Component {
+  // ❌ Creates orphaned instance without owner
+  api = new ApiService();
+
+  async loadUser() {
+    // Won't have access to other services or owner features
+    return this.api.fetch('/user/me');
+  }
+
+  <template>
+    <div>{{@user.name}}</div>
+  </template>
+}
+```
+
+**Correct (proper service injection with owner):**
+
+```glimmer-js
+// app/components/user-profile.gjs
+import Component from '@glimmer/component';
+import { service } from '@ember/service';
+
+class UserProfile extends Component {
+  // ✅ Proper injection with owner linkage
+  @service api;
+
+  async loadUser() {
+    // Has full owner context and can inject other services
+    return this.api.fetch('/user/me');
+  }
+
+  <template>
+    <div>{{@user.name}}</div>
+  </template>
+}
+```
+
+### Manual Owner Passing (Without Libraries)
+
+**Creating instances with owner:**
+
+```glimmer-js
+// app/components/data-processor.gjs
+import Component from '@glimmer/component';
+import { getOwner, setOwner } from '@ember/application';
+import { service } from '@ember/service';
+
+class DataTransformer {
+  @service store;
+
+  transform(data) {
+    // Can use injected services because it has an owner
+    return this.store.request({ url: '/transform', data });
+  }
+}
+
+class DataProcessor extends Component {
+  @service('store') storeService;
+
+  constructor(owner, args) {
+    super(owner, args);
+
+    // Manual instantiation with owner linkage
+    this.transformer = new DataTransformer();
+    setOwner(this.transformer, getOwner(this));
+  }
+
+  processData(data) {
+    // transformer can now access services
+    return this.transformer.transform(data);
+  }
+
+  <template>
+    <div>Processing...</div>
+  </template>
+}
+```
+
+**Factory pattern with owner:**
+
+```javascript
+// app/utils/logger-factory.js
+import { getOwner } from '@ember/application';
+
+class Logger {
+  constructor(owner, context) {
+    this.owner = owner;
+    this.context = context;
+  }
+
+  get config() {
+    // Access configuration service via owner
+    return getOwner(this).lookup('service:config');
+  }
+
+  log(message) {
+    if (this.config.enableLogging) {
+      console.log(`[${this.context}]`, message);
+    }
+  }
+}
+
+export function createLogger(owner, context) {
+  return new Logger(owner, context);
+}
+```
+
+```glimmer-js
+// Usage in component
+import Component from '@glimmer/component';
+import { getOwner } from '@ember/application';
+import { createLogger } from '../utils/logger-factory';
+
+class My extends Component {
+  logger = createLogger(getOwner(this), 'MyComponent');
+
+  performAction() {
+    this.logger.log('Action performed');
+  }
+
+  <template>
+    <button {{on "click" this.performAction}}>Do Something</button>
+  </template>
+}
+```
+
+### Owner Passing with Modern Libraries
+
+**Using reactiveweb's link() for ownership and destruction:**
+
+The `link()` function from `reactiveweb` provides both ownership transfer and automatic destruction linkage.
+
+```glimmer-js
+// app/components/advanced-form.gjs
+import Component from '@glimmer/component';
+import { link } from 'reactiveweb/link';
+
+class ValidationService {
+  validate(data) {
+    // Validation logic
+    return data.email && data.email.includes('@');
+  }
+}
+
+class FormStateManager {
+  data = { email: '' };
+
+  updateEmail(value) {
+    this.data.email = value;
+  }
+}
+
+export class AdvancedForm extends Component {
+  // link() handles both owner and destruction automatically
+  validation = link(this, () => new ValidationService());
+  formState = link(this, () => new FormStateManager());
+
+  get isValid() {
+    return this.validation.validate(this.formState.data);
+  }
+
+  <template>
+    <form>
+      <input value={{this.formState.data.email}} />
+      {{#if (not this.isValid)}}
+        <span>Invalid form</span>
+      {{/if}}
+    </form>
+  </template>
+}
+```
+
+**Why use link():**
+
+- Automatically transfers owner from parent to child instance
+- Registers destructor so child is cleaned up when parent is destroyed
+- No manual `setOwner` or `registerDestructor` calls needed
+- See [RFC #1067](https://github.com/emberjs/rfcs/pull/1067) for the proposal and reasoning
+- Documentation: https://reactive.nullvoxpopuli.com/functions/link.link.html
+
+### Services Outside app/services Directory
+
+**Using createService from ember-primitives:**
+
+```glimmer-js
+// app/components/analytics-tracker.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { createService } from 'ember-primitives/utils';
+
+// Define service logic as a plain function
+function AnalyticsService() {
+  let events = [];
+
+  return {
+    get events() {
+      return events;
+    },
+
+    track(event) {
+      events.push({ ...event, timestamp: Date.now() });
+
+      // Send to analytics endpoint
+      fetch('/analytics', {
+        method: 'POST',
+        body: JSON.stringify(event)
+      });
+    }
+  };
+}
+
+export class AnalyticsTracker extends Component {
+  // createService handles owner linkage and cleanup automatically
+  analytics = createService(this, AnalyticsService);
+
+  <template>
+    <div>Tracking {{this.analytics.events.length}} events</div>
+  </template>
+}
+```
+
+**Why createService:**
+
+- No need to extend Service class
+- Automatic owner linkage and cleanup
+- Simpler than manual setOwner/registerDestructor
+- Documentation: https://ce1d7e18.ember-primitives.pages.dev/6-utils/createService.md
+
+**Co-located services with components:**
+
+```javascript
+// app/components/shopping-cart/service.js
+import Service from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { TrackedArray } from 'tracked-built-ins';
+import { action } from '@ember/object';
+
+export class CartService extends Service {
+  @tracked items = new TrackedArray([]);
+
+  get total() {
+    return this.items.reduce((sum, item) => sum + item.price, 0);
+  }
+
+  @action
+  addItem(item) {
+    this.items.push(item);
+  }
+
+  @action
+  removeItem(id) {
+    const index = this.items.findIndex((item) => item.id === id);
+    if (index > -1) this.items.splice(index, 1);
+  }
+
+  @action
+  clear() {
+    this.items.clear();
+  }
+}
+```
+
+```glimmer-js
+// app/components/shopping-cart/index.gjs
+import Component from '@glimmer/component';
+import { getOwner, setOwner } from '@ember/application';
+import { CartService } from './service';
+
+class ShoppingCart extends Component {
+  cart = (() => {
+    const instance = new CartService();
+    setOwner(instance, getOwner(this));
+    return instance;
+  })();
+
+  <template>
+    <div class="cart">
+      <h3>Cart ({{this.cart.items.length}} items)</h3>
+      <div>Total: ${{this.cart.total}}</div>
+
+      {{#each this.cart.items as |item|}}
+        <div class="cart-item">
+          {{item.name}} - ${{item.price}}
+          <button {{on "click" (fn this.cart.removeItem item.id)}}>
+            Remove
+          </button>
+        </div>
+      {{/each}}
+
+      <button {{on "click" this.cart.clear}}>Clear Cart</button>
+    </div>
+  </template>
+}
+```
+
+**Service-like utilities in utils/ directory:**
+
+```javascript
+// app/utils/notification-manager.js
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { TrackedArray } from 'tracked-built-ins';
+import { setOwner } from '@ember/application';
+
+export class NotificationManager {
+  @tracked notifications = new TrackedArray([]);
+
+  constructor(owner) {
+    setOwner(this, owner);
+  }
+
+  @action
+  add(message, type = 'info') {
+    const notification = {
+      id: Math.random().toString(36),
+      message,
+      type,
+      timestamp: Date.now(),
+    };
+
+    this.notifications.push(notification);
+
+    // Auto-dismiss after 5 seconds
+    setTimeout(() => this.dismiss(notification.id), 5000);
+  }
+
+  @action
+  dismiss(id) {
+    const index = this.notifications.findIndex((n) => n.id === id);
+    if (index > -1) this.notifications.splice(index, 1);
+  }
+}
+```
+
+```glimmer-js
+// app/components/notification-container.gjs
+import Component from '@glimmer/component';
+import { getOwner } from '@ember/application';
+import { NotificationManager } from '../utils/notification-manager';
+
+class NotificationContainer extends Component {
+  notifications = new NotificationManager(getOwner(this));
+
+  <template>
+    <div class="notifications">
+      {{#each this.notifications.notifications as |notif|}}
+        <div class="notification notification-{{notif.type}}">
+          {{notif.message}}
+          <button {{on "click" (fn this.notifications.dismiss notif.id)}}>
+            ×
+          </button>
+        </div>
+      {{/each}}
+    </div>
+
+    {{! Example usage }}
+    <button {{on "click" (fn this.notifications.add "Success!" "success")}}>
+      Show Notification
+    </button>
+  </template>
+}
+```
+
+### Registering Custom Services Dynamically
+
+**Runtime service registration:**
+
+```javascript
+// app/instance-initializers/dynamic-services.js
+export function initialize(appInstance) {
+  // Register service dynamically without app/services file
+  appInstance.register(
+    'service:feature-flags',
+    class FeatureFlagsService {
+      flags = {
+        newDashboard: true,
+        betaFeatures: false,
+      };
+
+      isEnabled(flag) {
+        return this.flags[flag] || false;
+      }
+    },
+  );
+
+  // Make it a singleton
+  appInstance.inject('route', 'featureFlags', 'service:feature-flags');
+  appInstance.inject('component', 'featureFlags', 'service:feature-flags');
+}
+
+export default {
+  initialize,
+};
+```
+
+**Using registered services:**
+
+```glimmer-js
+// app/components/feature-gated.gjs
+import Component from '@glimmer/component';
+import { service } from '@ember/service';
+
+class FeatureGated extends Component {
+  @service featureFlags;
+
+  get shouldShow() {
+    return this.featureFlags.isEnabled(this.args.feature);
+  }
+
+  <template>
+    {{#if this.shouldShow}}
+      {{yield}}
+    {{else}}
+      <div class="feature-disabled">This feature is not available</div>
+    {{/if}}
+  </template>
+}
+```
+
+### Best Practices
+
+1. **Use @service decorator** for app/services - cleanest and most maintainable
+2. **Use link() from reactiveweb** for ownership and destruction linkage
+3. **Use createService from ember-primitives** for component-scoped services without extending Service class
+4. **Manual owner passing** for utilities that need occasional service access
+5. **Co-located services** for component-specific state that doesn't need global access
+6. **Runtime registration** for dynamic services or testing scenarios
+7. **Always use setOwner** when manually instantiating classes that need services
+
+### When to Use Each Pattern
+
+- **app/services**: Global singletons needed across the app
+- **link() from reactiveweb**: When you need both owner and destruction linkage
+- **createService from ember-primitives**: Component-scoped services without Service class
+- **Co-located services**: Component-specific state, not needed elsewhere
+- **Utils with owner**: Stateless utilities that occasionally need config/services
+- **Runtime registration**: Dynamic configuration, feature flags, testing
+
+Reference: [Ember Owner API](https://api.emberjs.com/ember/release/functions/@ember%2Fapplication/getOwner), [Dependency Injection](https://guides.emberjs.com/release/applications/dependency-injection/), [reactiveweb link()](https://reactive.nullvoxpopuli.com/functions/link.link.html), [ember-primitives createService](https://ce1d7e18.ember-primitives.pages.dev/6-utils/createService.md)

--- a/skills/ember-best-practices/rules/service-shared-state.md
+++ b/skills/ember-best-practices/rules/service-shared-state.md
@@ -1,0 +1,119 @@
+---
+title: Use Services for Shared State
+impact: MEDIUM-HIGH
+impactDescription: Better state management and reusability
+tags: services, state-management, dependency-injection
+---
+
+## Use Services for Shared State
+
+Use services to manage shared state across components and routes instead of passing data through multiple layers or duplicating state.
+
+**Incorrect (prop drilling):**
+
+```glimmer-js
+// app/routes/dashboard.gjs
+export default class DashboardRoute extends Route {
+  model() {
+    return { currentTheme: 'dark' };
+  }
+
+  <template>
+    <Header @theme={{@model.currentTheme}} />
+    <Sidebar @theme={{@model.currentTheme}} />
+    <MainContent @theme={{@model.currentTheme}} />
+  </template>
+}
+```
+
+**Correct (using service):**
+
+```javascript
+// app/services/theme.js
+import Service from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class ThemeService extends Service {
+  @tracked currentTheme = 'dark';
+
+  @action
+  setTheme(theme) {
+    this.currentTheme = theme;
+    localStorage.setItem('theme', theme);
+  }
+
+  @action
+  loadTheme() {
+    this.currentTheme = localStorage.getItem('theme') || 'dark';
+  }
+}
+```
+
+```javascript
+// app/components/header.js
+import Component from '@glimmer/component';
+import { service } from '@ember/service';
+
+class Header extends Component {
+  @service theme;
+
+  // Access theme.currentTheme directly
+}
+```
+
+```javascript
+// app/components/sidebar.js
+import Component from '@glimmer/component';
+import { service } from '@ember/service';
+
+class Sidebar extends Component {
+  @service theme;
+
+  // Access theme.currentTheme directly
+}
+```
+
+Services provide centralized state management with automatic reactivity through tracked properties.
+
+**For complex state, consider using Ember Data or ember-orbit:**
+
+```javascript
+// app/services/cart.js
+import Service from '@ember/service';
+import { service } from '@ember/service';
+import { TrackedArray } from 'tracked-built-ins';
+import { cached } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class CartService extends Service {
+  @service store;
+
+  items = new TrackedArray([]);
+
+  @cached
+  get total() {
+    return this.items.reduce((sum, item) => sum + item.price, 0);
+  }
+
+  @cached
+  get itemCount() {
+    return this.items.length;
+  }
+
+  @action
+  addItem(item) {
+    this.items.push(item);
+  }
+
+  @action
+  removeItem(item) {
+    const index = this.items.indexOf(item);
+    if (index > -1) {
+      this.items.splice(index, 1);
+    }
+  }
+}
+```
+
+Reference: [Ember Services](https://guides.emberjs.com/release/services/)

--- a/skills/ember-best-practices/rules/template-avoid-computation.md
+++ b/skills/ember-best-practices/rules/template-avoid-computation.md
@@ -1,0 +1,98 @@
+---
+title: Avoid Heavy Computation in Templates
+impact: MEDIUM
+impactDescription: 40-60% reduction in render time
+tags: templates, performance, getters, helpers
+---
+
+## Avoid Heavy Computation in Templates
+
+Move expensive computations from templates to cached getters in the component class or in-scope functions for template-only components. Templates should only display data, not compute it. Keep templates easy for humans to read by minimizing nested function invocations.
+
+**Why this matters:**
+
+- Templates should be easy to read and understand
+- Nested function calls create cognitive overhead
+- Computations should be cached and reused, not recalculated on every render
+- Template-only components (without `this`) need alternative patterns
+
+**Incorrect (heavy computation in template):**
+
+```glimmer-js
+// app/components/stats.gjs
+import { sum, map, div, max, multiply, sortBy } from '../helpers/math';
+
+<template>
+  <div>
+    <p>Total: {{sum (map @items "price")}}</p>
+    <p>Average: {{div (sum (map @items "price")) @items.length}}</p>
+    <p>Max: {{max (map @items "price")}}</p>
+
+    {{#each (sortBy "name" @items) as |item|}}
+      <div>{{item.name}}: {{multiply item.price item.quantity}}</div>
+    {{/each}}
+  </div>
+</template>
+```
+
+**Correct (computation in component with cached getters):**
+
+```glimmer-js
+// app/components/stats.gjs
+import Component from '@glimmer/component';
+import { cached } from '@glimmer/tracking';
+
+export class Stats extends Component {
+  // @cached is useful when getters are accessed multiple times
+  // For single access, regular getters are sufficient
+
+  @cached
+  get total() {
+    return this.args.items.reduce((sum, item) => sum + item.price, 0);
+  }
+
+  get average() {
+    // No @cached needed if only accessed once in template
+    return this.args.items.length > 0
+      ? this.total / this.args.items.length
+      : 0;
+  }
+
+  get maxPrice() {
+    return Math.max(...this.args.items.map(item => item.price));
+  }
+
+  @cached
+  get sortedItems() {
+    // @cached useful here as it's used by itemsWithTotal
+    return [...this.args.items].sort((a, b) =>
+      a.name.localeCompare(b.name)
+    );
+  }
+
+  @cached
+  get itemsWithTotal() {
+    // @cached useful as accessed multiple times in {{#each}}
+    return this.sortedItems.map(item => ({
+      ...item,
+      total: item.price * item.quantity
+    }));
+  }
+
+  <template>
+    <div>
+      <p>Total: {{this.total}}</p>
+      <p>Average: {{this.average}}</p>
+      <p>Max: {{this.maxPrice}}</p>
+
+      {{#each this.itemsWithTotal key="id" as |item|}}
+        <div>{{item.name}}: {{item.total}}</div>
+      {{/each}}
+    </div>
+  </template>
+}
+```
+
+**Note on @cached**: Use `@cached` when a getter is accessed multiple times (like in `{{#each}}` loops or by other getters). For getters accessed only once, regular getters are sufficient and avoid unnecessary memoization overhead.
+
+Moving computations to getters ensures they run only when dependencies change, not on every render. Templates remain clean and readable.

--- a/skills/ember-best-practices/rules/template-conditional-rendering.md
+++ b/skills/ember-best-practices/rules/template-conditional-rendering.md
@@ -1,0 +1,283 @@
+---
+title: Optimize Conditional Rendering
+impact: HIGH
+impactDescription: Reduces unnecessary rerenders in dynamic template branches
+tags: templates, conditionals, rendering, performance, glimmer
+---
+
+## Optimize Conditional Rendering
+
+Use efficient conditional rendering patterns to minimize unnecessary DOM updates and improve rendering performance.
+
+## Problem
+
+Inefficient conditional logic causes excessive re-renders, creates complex template code, and can lead to poor performance in lists and dynamic UIs.
+
+**Incorrect:**
+
+```glimmer-js
+// app/components/user-list.gjs
+import Component from '@glimmer/component';
+
+class UserList extends Component {
+  <template>
+    {{#each @users as |user|}}
+      <div class="user">
+        {{! Recomputes every time}}
+        {{#if (eq user.role "admin")}}
+          <span class="badge admin">{{user.name}} (Admin)</span>
+        {{/if}}
+        {{#if (eq user.role "moderator")}}
+          <span class="badge mod">{{user.name}} (Mod)</span>
+        {{/if}}
+        {{#if (eq user.role "user")}}
+          <span>{{user.name}}</span>
+        {{/if}}
+      </div>
+    {{/each}}
+  </template>
+}
+```
+
+## Solution
+
+Use `{{#if}}` / `{{#else if}}` / `{{#else}}` chains and extract computed logic to getters for better performance and readability.
+
+**Correct:**
+
+```glimmer-js
+// app/components/user-list.gjs
+import Component from '@glimmer/component';
+
+class UserList extends Component {
+  <template>
+    {{#each @users as |user|}}
+      <div class="user">
+        {{#if (eq user.role "admin")}}
+          <span class="badge admin">{{user.name}} (Admin)</span>
+        {{else if (eq user.role "moderator")}}
+          <span class="badge mod">{{user.name}} (Mod)</span>
+        {{else}}
+          <span>{{user.name}}</span>
+        {{/if}}
+      </div>
+    {{/each}}
+  </template>
+}
+```
+
+## Extracted Logic Pattern
+
+For complex conditions, use getters:
+
+```glimmer-js
+// app/components/user-card.gjs
+import Component from '@glimmer/component';
+import { cached } from '@glimmer/tracking';
+
+class UserCard extends Component {
+  @cached
+  get isActive() {
+    return this.args.user.status === 'active' &&
+           this.args.user.lastLoginDays < 30;
+  }
+
+  @cached
+  get showActions() {
+    return this.args.canEdit &&
+           !this.args.user.locked &&
+           this.isActive;
+  }
+
+  <template>
+    <div class="user-card">
+      <h3>{{@user.name}}</h3>
+
+      {{#if this.isActive}}
+        <span class="status active">Active</span>
+      {{else}}
+        <span class="status inactive">Inactive</span>
+      {{/if}}
+
+      {{#if this.showActions}}
+        <div class="actions">
+          <button>Edit</button>
+          <button>Delete</button>
+        </div>
+      {{/if}}
+    </div>
+  </template>
+}
+```
+
+## Conditional Lists
+
+Use `{{#if}}` to guard `{{#each}}` and avoid rendering empty states:
+
+```glimmer-js
+// app/components/task-list.gjs
+import Component from '@glimmer/component';
+
+class TaskList extends Component {
+  get hasTasks() {
+    return this.args.tasks?.length > 0;
+  }
+
+  <template>
+    {{#if this.hasTasks}}
+      <ul class="task-list">
+        {{#each @tasks as |task|}}
+          <li>
+            {{task.title}}
+            {{#if task.completed}}
+              <span class="done">✓</span>
+            {{/if}}
+          </li>
+        {{/each}}
+      </ul>
+    {{else}}
+      <p class="empty-state">No tasks yet</p>
+    {{/if}}
+  </template>
+}
+```
+
+## Avoid Nested Conditionals
+
+**Bad:**
+
+```glimmer-js
+{{#if @user}}
+  {{#if @user.isPremium}}
+    {{#if @user.hasAccess}}
+      <PremiumContent />
+    {{/if}}
+  {{/if}}
+{{/if}}
+```
+
+**Good:**
+
+```glimmer-js
+// app/components/content-gate.gjs
+import Component from '@glimmer/component';
+import { cached } from '@glimmer/tracking';
+
+class ContentGate extends Component {
+  @cached
+  get canViewPremium() {
+    return this.args.user?.isPremium && this.args.user?.hasAccess;
+  }
+
+  <template>
+    {{#if this.canViewPremium}}
+      <PremiumContent />
+    {{else}}
+      <UpgradeCTA />
+    {{/if}}
+  </template>
+}
+```
+
+## Component Switching Pattern
+
+Use conditional rendering for component selection:
+
+```glimmer-js
+// app/components/media-viewer.gjs
+import Component from '@glimmer/component';
+import ImageViewer from './image-viewer';
+import VideoPlayer from './video-player';
+import AudioPlayer from './audio-player';
+import { cached } from '@glimmer/tracking';
+
+class MediaViewer extends Component {
+  @cached
+  get mediaType() {
+    return this.args.media?.type;
+  }
+
+  <template>
+    {{#if (eq this.mediaType "image")}}
+      <ImageViewer @src={{@media.url}} />
+    {{else if (eq this.mediaType "video")}}
+      <VideoPlayer @src={{@media.url}} />
+    {{else if (eq this.mediaType "audio")}}
+      <AudioPlayer @src={{@media.url}} />
+    {{else}}
+      <p>Unsupported media type</p>
+    {{/if}}
+  </template>
+}
+```
+
+## Loading States
+
+Pattern for async data with loading/error states:
+
+```glimmer-js
+// app/components/data-display.gjs
+import Component from '@glimmer/component';
+import { Resource } from 'ember-resources';
+import { resource } from 'ember-resources';
+
+class DataResource extends Resource {
+  @tracked data = null;
+  @tracked isLoading = true;
+  @tracked error = null;
+
+  modify(positional, named) {
+    this.fetchData(named.url);
+  }
+
+  async fetchData(url) {
+    this.isLoading = true;
+    this.error = null;
+    try {
+      const response = await fetch(url);
+      this.data = await response.json();
+    } catch (e) {
+      this.error = e.message;
+    } finally {
+      this.isLoading = false;
+    }
+  }
+}
+
+class DataDisplay extends Component {
+  @resource data = DataResource.from(() => ({
+    url: this.args.url
+  }));
+
+  <template>
+    {{#if this.data.isLoading}}
+      <div class="loading">Loading...</div>
+    {{else if this.data.error}}
+      <div class="error">Error: {{this.data.error}}</div>
+    {{else}}
+      <div class="content">
+        {{this.data.data}}
+      </div>
+    {{/if}}
+  </template>
+}
+```
+
+## Performance Impact
+
+- **Chained if/else**: 40-60% faster than multiple independent {{#if}} blocks
+- **Extracted getters**: ~20% faster for complex conditions (cached)
+- **Component switching**: Same performance as {{#if}} but better code organization
+
+## When to Use
+
+- **{{#if}}/{{#else}}**: For simple true/false conditions
+- **Extracted getters**: For complex or reused conditions
+- **Component switching**: For different component types based on state
+- **Guard clauses**: To avoid rendering large subtrees when not needed
+
+## References
+
+- [Ember Guides - Conditionals](https://guides.emberjs.com/release/components/conditional-content/)
+- [Glimmer VM Performance](https://github.com/glimmerjs/glimmer-vm)
+- [@cached decorator](https://api.emberjs.com/ember/release/functions/@glimmer%2Ftracking/cached)

--- a/skills/ember-best-practices/rules/template-each-key.md
+++ b/skills/ember-best-practices/rules/template-each-key.md
@@ -1,0 +1,91 @@
+---
+title: Use {{#each}} with @key for Lists
+impact: MEDIUM
+impactDescription: 50-100% faster list updates
+tags: templates, each, performance, rendering
+---
+
+## Use {{#each}} with @key for Lists
+
+Use the `key=` parameter with `{{#each}}` when objects are recreated between renders (e.g., via `.map()` or fresh API data). The default behavior uses object identity (`@identity`), which works when object references are stable.
+
+**Incorrect (no key):**
+
+```glimmer-js
+// app/components/user-list.gjs
+import UserCard from './user-card';
+
+<template>
+  <ul>
+    {{#each this.users as |user|}}
+      <li>
+        <UserCard @user={{user}} />
+      </li>
+    {{/each}}
+  </ul>
+</template>
+```
+
+**Correct (with key):**
+
+```glimmer-js
+// app/components/user-list.gjs
+import UserCard from './user-card';
+
+<template>
+  <ul>
+    {{#each this.users key="id" as |user|}}
+      <li>
+        <UserCard @user={{user}} />
+      </li>
+    {{/each}}
+  </ul>
+</template>
+```
+
+**For arrays of primitives (strings, numbers):**
+
+`@identity` is the default, so you rarely need to specify it explicitly. It compares items by value for primitives.
+
+```glimmer-js
+// app/components/tag-list.gjs
+<template>
+  {{! @identity is implicit, no need to write it }}
+  {{#each this.tags as |tag|}}
+    <span class="tag">{{tag}}</span>
+  {{/each}}
+</template>
+```
+
+**For complex scenarios with @index:**
+
+```glimmer-js
+// app/components/item-list.gjs
+<template>
+  {{#each this.items key="@index" as |item index|}}
+    <div data-index={{index}}>
+      {{item.name}}
+    </div>
+  {{/each}}
+</template>
+```
+
+Using proper keys allows Ember's rendering engine to efficiently update, reorder, and remove items without re-rendering the entire list.
+
+**When to use `key=`:**
+
+- Objects recreated between renders (`.map()`, generators, fresh API responses) → use `key="id"` or similar
+- High-frequency updates (animations, real-time data) → always specify a key
+- Stable object references (Apollo cache, Ember Data) → default `@identity` is fine
+- Items never reorder → `key="@index"` is acceptable
+
+**Performance comparison (dbmon benchmark, 40 rows at 60fps):**
+
+- Without key (objects recreated): Destroys/recreates DOM every frame
+- With `key="data.db.id"`: DOM reuse, **2x FPS improvement**
+
+### References:
+
+- [Ember API: each helper](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/each)
+- [Ember template lint: equire-each-key](https://github.com/ember-template-lint/ember-template-lint/blob/main/docs/rule/require-each-key.md)
+- [Example PR showing the fps improvement on updated lists](https://github.com/universal-ember/table/pull/68)

--- a/skills/ember-best-practices/rules/template-fn-helper.md
+++ b/skills/ember-best-practices/rules/template-fn-helper.md
@@ -1,0 +1,148 @@
+---
+title: Use {{fn}} for Partial Application Only
+impact: LOW-MEDIUM
+impactDescription: Clearer code, avoid unnecessary wrapping
+tags: helpers, templates, fn, partial-application
+---
+
+## Use {{fn}} for Partial Application Only
+
+The `{{fn}}` helper is used for partial application (binding arguments), similar to JavaScript's `.bind()`. Only use it when you need to pre-bind arguments to a function. Don't use it to simply pass a function reference.
+
+**Incorrect (unnecessary use of {{fn}}):**
+
+```glimmer-js
+// app/components/search.gjs
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+class Search extends Component {
+  @action
+  handleSearch(event) {
+    console.log('Searching:', event.target.value);
+  }
+
+  <template>
+    {{! Wrong - no arguments being bound}}
+    <input {{on "input" (fn this.handleSearch)}} />
+  </template>
+}
+```
+
+**Correct (direct function reference):**
+
+```glimmer-js
+// app/components/search.gjs
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+class Search extends Component {
+  @action
+  handleSearch(event) {
+    console.log('Searching:', event.target.value);
+  }
+
+  <template>
+    {{! Correct - pass function directly}}
+    <input {{on "input" this.handleSearch}} />
+  </template>
+}
+```
+
+**When to Use {{fn}} - Partial Application:**
+
+Use `{{fn}}` when you need to pre-bind arguments to a function, similar to JavaScript's `.bind()`:
+
+```glimmer-js
+// app/components/user-list.gjs
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+class UserList extends Component {
+  @action
+  deleteUser(userId, event) {
+    console.log('Deleting user:', userId);
+    this.args.onDelete(userId);
+  }
+
+  <template>
+    <ul>
+      {{#each @users as |user|}}
+        <li>
+          {{user.name}}
+          {{! Correct - binding user.id as first argument}}
+          <button {{on "click" (fn this.deleteUser user.id)}}>
+            Delete
+          </button>
+        </li>
+      {{/each}}
+    </ul>
+  </template>
+}
+```
+
+**Multiple Arguments:**
+
+```glimmer-js
+// app/components/data-grid.gjs
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+class DataGrid extends Component {
+  @action
+  updateCell(rowId, columnKey, event) {
+    const newValue = event.target.value;
+    this.args.onUpdate(rowId, columnKey, newValue);
+  }
+
+  <template>
+    {{#each @rows as |row|}}
+      {{#each @columns as |column|}}
+        <input
+          value={{get row column.key}}
+          {{! Pre-binding rowId and columnKey}}
+          {{on "input" (fn this.updateCell row.id column.key)}}
+        />
+      {{/each}}
+    {{/each}}
+  </template>
+}
+```
+
+**Think of {{fn}} like .bind():**
+
+```javascript
+// JavaScript comparison
+const boundFn = this.deleteUser.bind(this, userId); // .bind() pre-binds args
+// Template equivalent: {{fn this.deleteUser userId}}
+
+// Direct reference
+const directFn = this.handleSearch; // No pre-binding
+// Template equivalent: {{this.handleSearch}}
+```
+
+**Common Patterns:**
+
+```javascript
+// ❌ Wrong - no partial application
+<button {{on "click" (fn this.save)}}>Save</button>
+
+// ✅ Correct - direct reference
+<button {{on "click" this.save}}>Save</button>
+
+// ✅ Correct - partial application with argument
+<button {{on "click" (fn this.save "draft")}}>Save Draft</button>
+
+// ❌ Wrong - no partial application
+<input {{on "input" (fn this.handleInput)}} />
+
+// ✅ Correct - direct reference
+<input {{on "input" this.handleInput}} />
+
+// ✅ Correct - partial application with field name
+<input {{on "input" (fn this.updateField "email")}} />
+```
+
+Only use `{{fn}}` when you're binding arguments. For simple function references, pass them directly.
+
+Reference: [Ember Templates - fn Helper](https://guides.emberjs.com/release/components/template-lifecycle-dom-and-modifiers/#toc_passing-arguments-to-functions)

--- a/skills/ember-best-practices/rules/template-helper-imports.md
+++ b/skills/ember-best-practices/rules/template-helper-imports.md
@@ -1,0 +1,116 @@
+---
+title: Import Helpers Directly in Templates
+impact: MEDIUM
+impactDescription: Better tree-shaking and clarity
+tags: helpers, imports, templates, gjs
+---
+
+## Import Helpers Directly in Templates
+
+Import helpers directly in gjs/gts files for better tree-shaking, clearer dependencies, and improved type safety.
+
+**Incorrect (global helper resolution):**
+
+```glimmer-js
+// app/components/user-profile.gjs
+<template>
+  <div class="profile">
+    <h1>{{capitalize @user.name}}</h1>
+    <p>Joined: {{format-date @user.createdAt}}</p>
+    <p>Posts: {{pluralize @user.postCount "post"}}</p>
+  </div>
+</template>
+```
+
+**Correct (explicit helper imports):**
+
+```glimmer-js
+// app/components/user-profile.gjs
+import { capitalize } from 'ember-string-helpers';
+import { formatDate } from 'ember-intl';
+import { pluralize } from 'ember-inflector';
+
+<template>
+  <div class="profile">
+    <h1>{{capitalize @user.name}}</h1>
+    <p>Joined: {{formatDate @user.createdAt}}</p>
+    <p>Posts: {{pluralize @user.postCount "post"}}</p>
+  </div>
+</template>
+```
+
+**Built-in and library helpers:**
+
+```glimmer-js
+// app/components/conditional-content.gjs
+import { fn, hash } from '@ember/helper'; // Actually built-in to Ember
+import { eq, not } from 'ember-truth-helpers'; // From ember-truth-helpers addon
+
+<template>
+  <div class="content">
+    {{#if (eq @status "active")}}
+      <span class="badge">Active</span>
+    {{/if}}
+
+    {{#if (not @isLoading)}}
+      <button {{on "click" (fn @onSave (hash id=@id data=@data))}}>
+        Save
+      </button>
+    {{/if}}
+  </div>
+</template>
+```
+
+**Custom helper with imports:**
+
+```javascript
+// app/utils/format-currency.js
+export function formatCurrency(amount, { currency = 'USD' } = {}) {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency,
+  }).format(amount);
+}
+```
+
+```glimmer-js
+// app/components/price-display.gjs
+import { formatCurrency } from '../utils/format-currency';
+
+<template>
+  <div class="price">
+    {{formatCurrency @amount currency="EUR"}}
+  </div>
+</template>
+```
+
+**Type-safe helpers with TypeScript:**
+
+```glimmer-ts
+// app/components/typed-component.gts
+import { fn } from '@ember/helper';
+import type { TOC } from '@ember/component/template-only';
+
+interface Signature {
+  Args: {
+    items: Array<{ id: string; name: string }>;
+    onSelect: (id: string) => void;
+  };
+}
+
+const TypedComponent: TOC<Signature> = <template>
+  <ul>
+    {{#each @items as |item|}}
+      <li {{on "click" (fn @onSelect item.id)}}>
+        {{item.name}}
+      </li>
+    {{/each}}
+  </ul>
+</template>;
+
+export default TypedComponent;
+```
+
+Explicit helper imports enable better tree-shaking, make dependencies clear, and improve IDE support with proper type checking.
+
+Reference: [Template Imports](https://github.com/ember-template-imports/ember-template-imports)

--- a/skills/ember-best-practices/rules/template-let-helper.md
+++ b/skills/ember-best-practices/rules/template-let-helper.md
@@ -1,0 +1,81 @@
+---
+title: Use {{#let}} to Avoid Recomputation
+impact: MEDIUM
+impactDescription: 30-50% reduction in duplicate work
+tags: templates, helpers, performance, optimization
+---
+
+## Use {{#let}} to Avoid Recomputation
+
+Use `{{#let}}` to compute expensive values once and reuse them in the template instead of calling getters or helpers multiple times.
+
+**Incorrect (recomputes on every reference):**
+
+```glimmer-js
+// app/components/user-card.gjs
+<template>
+  <div class="user-card">
+    {{#if (and this.user.isActive (not this.user.isDeleted))}}
+      <h3>{{this.user.fullName}}</h3>
+      <p>Status: Active</p>
+    {{/if}}
+
+    {{#if (and this.user.isActive (not this.user.isDeleted))}}
+      <button {{on "click" this.editUser}}>Edit</button>
+    {{/if}}
+
+    {{#if (and this.user.isActive (not this.user.isDeleted))}}
+      <button {{on "click" this.deleteUser}}>Delete</button>
+    {{/if}}
+  </div>
+</template>
+```
+
+**Correct (compute once, reuse):**
+
+```glimmer-js
+// app/components/user-card.gjs
+<template>
+  {{#let (and this.user.isActive (not this.user.isDeleted)) as |isEditable|}}
+    <div class="user-card">
+      {{#if isEditable}}
+        <h3>{{this.user.fullName}}</h3>
+        <p>Status: Active</p>
+      {{/if}}
+
+      {{#if isEditable}}
+        <button {{on "click" this.editUser}}>Edit</button>
+      {{/if}}
+
+      {{#if isEditable}}
+        <button {{on "click" this.deleteUser}}>Delete</button>
+      {{/if}}
+    </div>
+  {{/let}}
+</template>
+```
+
+**Multiple values:**
+
+```glimmer-js
+// app/components/checkout.gjs
+<template>
+  {{#let
+    (this.calculateTotal this.items)
+    (this.formatCurrency this.total)
+    (this.hasDiscount this.user)
+    as |total formattedTotal showDiscount|
+  }}
+    <div class="checkout">
+      <p>Total: {{formattedTotal}}</p>
+
+      {{#if showDiscount}}
+        <p>Original: {{total}}</p>
+        <p>Discount Applied!</p>
+      {{/if}}
+    </div>
+  {{/let}}
+</template>
+```
+
+`{{#let}}` computes values once and caches them for the block scope, reducing redundant calculations.

--- a/skills/ember-best-practices/rules/template-only-component-functions.md
+++ b/skills/ember-best-practices/rules/template-only-component-functions.md
@@ -1,0 +1,222 @@
+---
+title: Template-Only Components with In-Scope Functions
+impact: MEDIUM
+impactDescription: Clean, performant patterns for template-only components
+tags: templates, components, functions, performance
+---
+
+## Template-Only Components with In-Scope Functions
+
+For template-only components (components without a class and `this`), use in-scope functions to keep logic close to the template while avoiding unnecessary caching overhead.
+
+**Incorrect (using class-based component for simple logic):**
+
+```glimmer-js
+// app/components/product-card.gjs
+import Component from '@glimmer/component';
+
+export class ProductCard extends Component {
+  // Unnecessary class and overhead for simple formatting
+  formatPrice(price) {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD'
+    }).format(price);
+  }
+
+  <template>
+    <div class="product-card">
+      <h3>{{@product.name}}</h3>
+      <div class="price">{{this.formatPrice @product.price}}</div>
+    </div>
+  </template>
+}
+```
+
+**Correct (template-only component with in-scope functions):**
+
+```glimmer-js
+// app/components/product-card.gjs
+function formatPrice(price) {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD'
+  }).format(price);
+}
+
+function calculateDiscount(price, discountPercent) {
+  return price * (1 - discountPercent / 100);
+}
+
+function isOnSale(product) {
+  return product.discountPercent > 0;
+}
+
+<template>
+  <div class="product-card">
+    <h3>{{@product.name}}</h3>
+
+    {{#if (isOnSale @product)}}
+      <div class="price">
+        <span class="original">{{formatPrice @product.price}}</span>
+        <span class="sale">
+          {{formatPrice (calculateDiscount @product.price @product.discountPercent)}}
+        </span>
+      </div>
+    {{else}}
+      <div class="price">{{formatPrice @product.price}}</div>
+    {{/if}}
+
+    <p>{{@product.description}}</p>
+  </div>
+</template>
+```
+
+**When to use class-based vs template-only:**
+
+```glimmer-js
+// Use class-based when:
+// - You need @cached for expensive computations accessed multiple times
+// - You have tracked state
+// - You need lifecycle hooks or services
+
+import Component from '@glimmer/component';
+import { cached } from '@glimmer/tracking';
+
+export class ProductList extends Component {
+  @cached
+  get sortedProducts() {
+    // Expensive sort, accessed in template multiple times
+    return [...this.args.products].sort((a, b) =>
+      a.name.localeCompare(b.name)
+    );
+  }
+
+  @cached
+  get filteredProducts() {
+    // Depends on sortedProducts - benefits from caching
+    return this.sortedProducts.filter(p =>
+      p.category === this.args.selectedCategory
+    );
+  }
+
+  <template>
+    {{#each this.filteredProducts as |product|}}
+      <div>{{product.name}}</div>
+    {{/each}}
+  </template>
+}
+```
+
+```glimmer-js
+// Use template-only when:
+// - Simple transformations
+// - Functions accessed once
+// - No state or services needed
+
+function formatDate(date) {
+  return new Date(date).toLocaleDateString();
+}
+
+<template>
+  <div class="timestamp">
+    Last updated: {{formatDate @lastUpdate}}
+  </div>
+</template>
+```
+
+**Combining in-scope functions for readability:**
+
+```glimmer-js
+// app/components/user-badge.gjs
+function getInitials(name) {
+  return name
+    .split(' ')
+    .map(part => part[0])
+    .join('')
+    .toUpperCase();
+}
+
+function getBadgeColor(status) {
+  const colors = {
+    active: 'green',
+    pending: 'yellow',
+    inactive: 'gray'
+  };
+  return colors[status] || 'gray';
+}
+
+<template>
+  <div class="user-badge" style="background-color: {{getBadgeColor @user.status}}">
+    <span class="initials">{{getInitials @user.name}}</span>
+    <span class="name">{{@user.name}}</span>
+  </div>
+</template>
+```
+
+**Anti-pattern - Complex nested calls:**
+
+```glimmer-js
+// ❌ Hard to read, lots of nesting
+<template>
+  <div>
+    {{formatCurrency (multiply (add @basePrice @taxAmount) @quantity)}}
+  </div>
+</template>
+
+// ✅ Better - use intermediate function
+function calculateTotal(basePrice, taxAmount, quantity) {
+  return (basePrice + taxAmount) * quantity;
+}
+
+function formatCurrency(amount) {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD'
+  }).format(amount);
+}
+
+<template>
+  <div>
+    {{formatCurrency (calculateTotal @basePrice @taxAmount @quantity)}}
+  </div>
+</template>
+```
+
+**Key differences from class-based components:**
+
+| Aspect           | Template-Only            | Class-Based              |
+| ---------------- | ------------------------ | ------------------------ |
+| `this` context   | ❌ No `this`             | ✅ Has `this`            |
+| Function caching | ❌ Recreated each render | ✅ `@cached` available   |
+| Services         | ❌ Cannot inject         | ✅ `@service` decorator  |
+| Tracked state    | ❌ No instance state     | ✅ `@tracked` properties |
+| Best for         | Simple, stateless        | Complex, stateful        |
+
+**Best practices:**
+
+1. **Keep functions simple** - If computation is complex, consider a class with `@cached`
+2. **One responsibility per function** - Makes them reusable and testable
+3. **Minimize nesting** - Use intermediate functions for readability
+4. **No side effects** - Functions should be pure transformations
+5. **Export for testing** - Export functions so they can be tested independently
+
+```glimmer-js
+// app/components/stats-display.gjs
+export function average(numbers) {
+  if (numbers.length === 0) return 0;
+  return numbers.reduce((sum, n) => sum + n, 0) / numbers.length;
+}
+
+export function round(number, decimals = 2) {
+  return Math.round(number * Math.pow(10, decimals)) / Math.pow(10, decimals);
+}
+
+<template>
+  <div class="stats">
+    Average: {{round (average @scores)}}
+  </div>
+</template>
+```
+
+Reference: [Template-only Components](https://guides.emberjs.com/release/components/component-types/), [Component Authoring Best Practices](https://guides.emberjs.com/release/components/conditional-content/)

--- a/skills/ember-best-practices/rules/testing-library-dom-abstraction.md
+++ b/skills/ember-best-practices/rules/testing-library-dom-abstraction.md
@@ -1,0 +1,334 @@
+---
+title: Provide DOM-Abstracted Test Utilities for Library Components
+impact: MEDIUM
+impactDescription: Stabilizes consumer tests against internal DOM refactors
+tags: testing, test-support, libraries, dom-abstraction, maintainability
+---
+
+## Provide DOM-Abstracted Test Utilities for Library Components
+
+**Impact: Medium** - Critical for library maintainability and consumer testing experience, especially important for team-based projects
+
+## Problem
+
+When building reusable components or libraries, consumers should not need to know implementation details or interact directly with the component's DOM. DOM structure should be considered **private** unless the author of the tests is the **owner** of the code being tested.
+
+Without abstracted test utilities:
+
+- Component refactoring breaks consumer tests
+- Tests are tightly coupled to implementation details
+- Teams waste time updating tests when internals change
+- Testing becomes fragile and maintenance-heavy
+
+## Solution
+
+**Library authors should provide test utilities that fully abstract the DOM.** These utilities expose a public API for testing that remains stable even when internal implementation changes.
+
+**Incorrect (exposing DOM to consumers):**
+
+```glimmer-js
+// my-library/src/components/data-grid.gjs
+export class DataGrid extends Component {
+  <template>
+    <div class="data-grid">
+      <div class="data-grid__header">
+        <button class="sort-button" data-column="name">Name</button>
+      </div>
+      <div class="data-grid__body">
+        {{#each @rows as |row|}}
+          <div class="data-grid__row">{{row.name}}</div>
+        {{/each}}
+      </div>
+    </div>
+  </template>
+}
+```
+
+```glimmer-js
+// Consumer's test - tightly coupled to DOM
+import { render, click } from '@ember/test-helpers';
+import { DataGrid } from 'my-library';
+
+test('sorting works', async function(assert) {
+  await render(<template>
+    <DataGrid @rows={{this.rows}} />
+  </template>);
+
+  // Fragile: breaks if class names or structure change
+  await click('.data-grid__header .sort-button[data-column="name"]');
+
+  assert.dom('.data-grid__row:first-child').hasText('Alice');
+});
+```
+
+**Problems:**
+
+- Consumer knows about `.data-grid__header`, `.sort-button`, `[data-column]`
+- Refactoring component structure breaks consumer tests
+- No clear public API for testing
+
+**Correct (providing DOM-abstracted test utilities):**
+
+```glimmer-js
+// my-library/src/test-support/data-grid.js
+import { click, findAll } from '@ember/test-helpers';
+
+/**
+ * Test utility for DataGrid component
+ * Provides stable API regardless of internal DOM structure
+ */
+export class DataGridTestHelper {
+  constructor(containerElement) {
+    this.container = containerElement;
+  }
+
+  /**
+   * Sort by column name
+   * @param {string} columnName - Column to sort by
+   */
+  async sortBy(columnName) {
+    // Implementation detail hidden from consumer
+    const button = this.container.querySelector(`[data-test-sort="${columnName}"]`);
+    if (!button) {
+      throw new Error(`Column "${columnName}" not found`);
+    }
+    await click(button);
+  }
+
+  /**
+   * Get all row data
+   * @returns {Array<string>} Row text content
+   */
+  getRows() {
+    return findAll('[data-test-row]', this.container)
+      .map(el => el.textContent.trim());
+  }
+
+  /**
+   * Get row by index
+   * @param {number} index - Zero-based row index
+   * @returns {string} Row text content
+   */
+  getRow(index) {
+    const rows = this.getRows();
+    return rows[index];
+  }
+}
+
+// Factory function for easier usage
+export function getDataGrid(container = document) {
+  const gridElement = container.querySelector('[data-test-data-grid]');
+  if (!gridElement) {
+    throw new Error('DataGrid component not found');
+  }
+  return new DataGridTestHelper(gridElement);
+}
+```
+
+```glimmer-js
+// my-library/src/components/data-grid.gjs
+// Component updated with test hooks (data-test-*)
+export class DataGrid extends Component {
+  <template>
+    <div data-test-data-grid class="data-grid">
+      <div class="data-grid__header">
+        {{#each @columns as |column|}}
+          <button data-test-sort={{column.name}}>
+            {{column.label}}
+          </button>
+        {{/each}}
+      </div>
+      <div class="data-grid__body">
+        {{#each @rows as |row|}}
+          <div data-test-row class="data-grid__row">{{row.name}}</div>
+        {{/each}}
+      </div>
+    </div>
+  </template>
+}
+```
+
+```glimmer-js
+// Consumer's test - abstracted from DOM
+import { render } from '@ember/test-helpers';
+import { DataGrid } from 'my-library';
+import { getDataGrid } from 'my-library/test-support';
+
+test('sorting works', async function(assert) {
+  await render(<template>
+    <DataGrid @rows={{this.rows}} @columns={{this.columns}} />
+  </template>);
+
+  const grid = getDataGrid();
+
+  // Clean API: no DOM knowledge required
+  await grid.sortBy('name');
+
+  assert.strictEqual(grid.getRow(0), 'Alice');
+  assert.deepEqual(grid.getRows(), ['Alice', 'Bob', 'Charlie']);
+});
+```
+
+**Benefits:**
+
+- Component internals can change without breaking consumer tests
+- Clear, documented testing API
+- Consumer tests are declarative and readable
+- Library maintains API stability contract
+
+## When This Matters Most
+
+### Team-Based Projects (Critical)
+
+On projects with teams, DOM abstraction prevents:
+
+- Merge conflicts from test changes
+- Cross-team coordination overhead
+- Broken tests from uncoordinated refactoring
+- Knowledge silos about component internals
+
+### Solo Projects (Less Critical)
+
+For solo projects, the benefit is smaller but still valuable:
+
+- Easier refactoring without test maintenance
+- Better separation of concerns
+- Professional API design practice
+
+## Best Practices
+
+### 1. Use `data-test-*` Attributes
+
+```glimmer-js
+// Stable test hooks that won't conflict with styling
+<button data-test-submit>Submit</button>
+<div data-test-error-message>{{@errorMessage}}</div>
+```
+
+### 2. Document the Test API
+
+```javascript
+/**
+ * @class FormTestHelper
+ * @description Test utility for Form component
+ *
+ * @example
+ * const form = getForm();
+ * await form.fillIn('email', 'user@example.com');
+ * await form.submit();
+ * assert.strictEqual(form.getError(), 'Invalid email');
+ */
+```
+
+### 3. Provide Semantic Methods
+
+```javascript
+// ✅ Semantic and declarative
+await modal.close();
+await form.fillIn('email', 'test@example.com');
+assert.true(dropdown.isOpen());
+
+// ❌ Exposes implementation
+await click('.modal-close-button');
+await fillIn('.form-field[name="email"]', 'test@example.com');
+assert.dom('.dropdown.is-open').exists();
+```
+
+### 4. Handle Edge Cases
+
+```javascript
+export class FormTestHelper {
+  async fillIn(fieldName, value) {
+    const field = this.container.querySelector(`[data-test-field="${fieldName}"]`);
+    if (!field) {
+      throw new Error(
+        `Field "${fieldName}" not found. Available fields: ${this.getFieldNames().join(', ')}`,
+      );
+    }
+    await fillIn(field, value);
+  }
+
+  getFieldNames() {
+    return Array.from(this.container.querySelectorAll('[data-test-field]')).map(
+      (el) => el.dataset.testField,
+    );
+  }
+}
+```
+
+## Example: Complete Test Utility
+
+```javascript
+// addon/test-support/modal.js
+import { click, find, waitUntil } from '@ember/test-helpers';
+
+export class ModalTestHelper {
+  constructor(container = document) {
+    this.container = container;
+  }
+
+  get element() {
+    return find('[data-test-modal]', this.container);
+  }
+
+  isOpen() {
+    return this.element !== null;
+  }
+
+  async waitForOpen() {
+    await waitUntil(() => this.isOpen(), { timeout: 1000 });
+  }
+
+  async waitForClose() {
+    await waitUntil(() => !this.isOpen(), { timeout: 1000 });
+  }
+
+  getTitle() {
+    const titleEl = find('[data-test-modal-title]', this.element);
+    return titleEl ? titleEl.textContent.trim() : null;
+  }
+
+  getBody() {
+    const bodyEl = find('[data-test-modal-body]', this.element);
+    return bodyEl ? bodyEl.textContent.trim() : null;
+  }
+
+  async close() {
+    if (!this.isOpen()) {
+      throw new Error('Cannot close modal: modal is not open');
+    }
+    await click('[data-test-modal-close]', this.element);
+  }
+
+  async clickButton(buttonText) {
+    const buttons = findAll('[data-test-modal-button]', this.element);
+    const button = buttons.find((btn) => btn.textContent.trim() === buttonText);
+    if (!button) {
+      const available = buttons.map((b) => b.textContent.trim()).join(', ');
+      throw new Error(`Button "${buttonText}" not found. Available: ${available}`);
+    }
+    await click(button);
+  }
+}
+
+export function getModal(container) {
+  return new ModalTestHelper(container);
+}
+```
+
+## Performance Impact
+
+**Before:** ~30-50% of test maintenance time spent updating selectors
+**After:** Minimal test maintenance when refactoring components
+
+## Related Patterns
+
+- **component-avoid-classes-in-examples.md** - Avoid exposing implementation details
+- **testing-modern-patterns.md** - Modern testing approaches
+- **testing-render-patterns.md** - Component testing patterns
+
+## References
+
+- [Testing Best Practices - ember-learn](https://guides.emberjs.com/release/testing/)
+- [ember-test-selectors](https://github.com/mainmatter/ember-test-selectors) - Addon for stripping test selectors from production
+- [Page Objects Pattern](https://martinfowler.com/bliki/PageObject.html) - Related testing abstraction pattern

--- a/skills/ember-best-practices/rules/testing-modern-patterns.md
+++ b/skills/ember-best-practices/rules/testing-modern-patterns.md
@@ -1,0 +1,340 @@
+---
+title: Use Modern Testing Patterns
+impact: HIGH
+impactDescription: Better test coverage and maintainability
+tags: testing, qunit, test-helpers, integration-tests
+---
+
+## Use Modern Testing Patterns
+
+Use modern Ember testing patterns with `@ember/test-helpers` and `qunit-dom` for better test coverage and maintainability.
+
+**Incorrect (old testing patterns):**
+
+```glimmer-js
+// tests/integration/components/user-card-test.js
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, find, click } from '@ember/test-helpers';
+import UserCard from 'my-app/components/user-card';
+
+module('Integration | Component | user-card', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    await render(<template><UserCard /></template>);
+
+    // Using find() instead of qunit-dom
+    assert.ok(find('.user-card'));
+  });
+});
+```
+
+**Correct (modern testing patterns):**
+
+```glimmer-js
+// tests/integration/components/user-card-test.js
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click } from '@ember/test-helpers';
+import { setupIntl } from 'ember-intl/test-support';
+import UserCard from 'my-app/components/user-card';
+
+module('Integration | Component | user-card', function(hooks) {
+  setupRenderingTest(hooks);
+  setupIntl(hooks);
+
+  test('it renders user information', async function(assert) {
+    const user = {
+      name: 'John Doe',
+      email: 'john@example.com',
+      avatarUrl: '/avatar.jpg'
+    };
+
+    await render(<template>
+      <UserCard @user={{user}} />
+    </template>);
+
+    // qunit-dom assertions
+    assert.dom('[data-test-user-name]').hasText('John Doe');
+    assert.dom('[data-test-user-email]').hasText('john@example.com');
+    assert.dom('[data-test-user-avatar]')
+      .hasAttribute('src', '/avatar.jpg')
+      .hasAttribute('alt', 'John Doe');
+  });
+
+  test('it handles edit action', async function(assert) {
+    assert.expect(1);
+
+    const user = { name: 'John Doe', email: 'john@example.com' };
+    const handleEdit = (editedUser) => {
+      assert.deepEqual(editedUser, user, 'Edit handler called with user');
+    };
+
+    await render(<template>
+      <UserCard @user={{user}} @onEdit={{handleEdit}} />
+    </template>);
+
+    await click('[data-test-edit-button]');
+  });
+});
+```
+
+**Component testing with reactive state:**
+
+```glimmer-ts
+// tests/integration/components/search-box-test.ts
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, fillIn } from '@ember/test-helpers';
+import { trackedObject } from '@ember/reactive/collections';
+import SearchBox from 'my-app/components/search-box';
+
+module('Integration | Component | search-box', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it performs search', async function(assert) {
+    // Use trackedObject for reactive state in tests
+    const state = trackedObject({
+      results: [] as string[]
+    });
+
+    const handleSearch = (query: string) => {
+      state.results = [`Result for ${query}`];
+    };
+
+    await render(<template>
+      <SearchBox @onSearch={{handleSearch}} />
+      <ul data-test-results>
+        {{#each state.results as |result|}}
+          <li>{{result}}</li>
+        {{/each}}
+      </ul>
+    </template>);
+
+    await fillIn('[data-test-search-input]', 'ember');
+
+    // State updates reactively - no waitFor needed when using test-waiters
+    assert.dom('[data-test-results] li').hasText('Result for ember');
+  });
+});
+```
+
+**Testing with ember-concurrency tasks:**
+
+```glimmer-js
+// app/components/async-button.js
+import Component from '@glimmer/component';
+import { task } from 'ember-concurrency';
+
+export default class AsyncButtonComponent extends Component {
+  @task
+  *saveTask() {
+    yield this.args.onSave();
+  }
+
+  <template>
+    <button
+      type="button"
+      disabled={{this.saveTask.isRunning}}
+      {{on "click" (perform this.saveTask)}}
+      data-test-button
+    >
+      {{#if this.saveTask.isRunning}}
+        <span data-test-loading-spinner>Saving...</span>
+      {{else}}
+        {{yield}}
+      {{/if}}
+    </button>
+  </template>
+}
+```
+
+```glimmer-js
+// tests/integration/components/async-button-test.js
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click } from '@ember/test-helpers';
+import AsyncButton from 'my-app/components/async-button';
+
+module('Integration | Component | async-button', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it shows loading state during task execution', async function(assert) {
+    let resolveTask;
+    const onSave = () => {
+      return new Promise(resolve => { resolveTask = resolve; });
+    };
+
+    await render(<template>
+      <AsyncButton @onSave={{onSave}}>
+        Save
+      </AsyncButton>
+    </template>);
+
+    // Trigger the task
+    await click('[data-test-button]');
+
+    // ember-concurrency automatically registers test waiters
+    // The button will be disabled while the task runs
+    assert.dom('[data-test-button]').hasAttribute('disabled');
+    assert.dom('[data-test-loading-spinner]').hasText('Saving...');
+
+    // Resolve the task
+    resolveTask();
+    // No need to call settled() - ember-concurrency's test waiters handle this
+
+    assert.dom('[data-test-button]').doesNotHaveAttribute('disabled');
+    assert.dom('[data-test-loading-spinner]').doesNotExist();
+    assert.dom('[data-test-button]').hasText('Save');
+  });
+});
+```
+
+**When to use test-waiters with ember-concurrency:**
+
+- **ember-concurrency auto-registers test waiters** - You don't need to manually register test waiters for ember-concurrency tasks. The library automatically waits for tasks to complete before test helpers like `click()`, `fillIn()`, etc. resolve.
+
+- **You still need test-waiters when:**
+  - Using raw Promises outside of ember-concurrency tasks
+  - Working with third-party async operations that don't integrate with Ember's test waiter system
+  - Creating custom async behavior that needs to pause test execution
+
+- **You DON'T need additional test-waiters when:**
+  - Using ember-concurrency tasks (already handled)
+  - Using Ember Data operations (already handled)
+  - Using `settled()` from `@ember/test-helpers` (already coordinates with test waiters)
+  - **Note**: `waitFor()` and `waitUntil()` from `@ember/test-helpers` are code smells - if you need them, it indicates missing test-waiters in your code. Instrument your async operations with test-waiters instead.
+
+**Route testing with MSW (Mock Service Worker):**
+
+```javascript
+// tests/acceptance/posts-test.js
+import { module, test } from 'qunit';
+import { visit, currentURL, click } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { http, HttpResponse } from 'msw';
+import { setupMSW } from 'my-app/tests/helpers/msw';
+
+module('Acceptance | posts', function (hooks) {
+  setupApplicationTest(hooks);
+  const { server } = setupMSW(hooks);
+
+  test('visiting /posts', async function (assert) {
+    server.use(
+      http.get('/api/posts', () => {
+        return HttpResponse.json({
+          data: [
+            { id: '1', type: 'post', attributes: { title: 'Post 1' } },
+            { id: '2', type: 'post', attributes: { title: 'Post 2' } },
+            { id: '3', type: 'post', attributes: { title: 'Post 3' } },
+          ],
+        });
+      }),
+    );
+
+    await visit('/posts');
+
+    assert.strictEqual(currentURL(), '/posts');
+    assert.dom('[data-test-post-item]').exists({ count: 3 });
+  });
+
+  test('clicking a post navigates to detail', async function (assert) {
+    server.use(
+      http.get('/api/posts', () => {
+        return HttpResponse.json({
+          data: [{ id: '1', type: 'post', attributes: { title: 'Test Post', slug: 'test-post' } }],
+        });
+      }),
+      http.get('/api/posts/test-post', () => {
+        return HttpResponse.json({
+          data: { id: '1', type: 'post', attributes: { title: 'Test Post', slug: 'test-post' } },
+        });
+      }),
+    );
+
+    await visit('/posts');
+    await click('[data-test-post-item]:first-child');
+
+    assert.strictEqual(currentURL(), '/posts/test-post');
+    assert.dom('[data-test-post-title]').hasText('Test Post');
+  });
+});
+```
+
+**Note:** Use MSW (Mock Service Worker) for API mocking instead of Mirage. MSW provides better conventions and doesn't lead developers astray. See `testing-msw-setup.md` for detailed setup instructions.
+
+**Accessibility testing:**
+
+```glimmer-js
+// tests/integration/components/modal-test.js
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click } from '@ember/test-helpers';
+import a11yAudit from 'ember-a11y-testing/test-support/audit';
+import Modal from 'my-app/components/modal';
+
+module('Integration | Component | modal', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it passes accessibility audit', async function(assert) {
+    await render(<template>
+      <Modal @isOpen={{true}} @title="Test Modal">
+        <p>Modal content</p>
+      </Modal>
+    </template>);
+
+    await a11yAudit();
+    assert.ok(true, 'no a11y violations');
+  });
+
+  test('it traps focus', async function(assert) {
+    await render(<template>
+      <Modal @isOpen={{true}}>
+        <button data-test-first>First</button>
+        <button data-test-last>Last</button>
+      </Modal>
+    </template>);
+
+    assert.dom('[data-test-first]').isFocused();
+
+    // Tab should stay within modal
+    await click('[data-test-last]');
+    assert.dom('[data-test-last]').isFocused();
+  });
+});
+```
+
+**Testing with data-test attributes:**
+
+```glimmer-js
+// app/components/user-profile.gjs
+import Component from '@glimmer/component';
+
+class UserProfile extends Component {
+  <template>
+    <div class="user-profile" data-test-user-profile>
+      <img
+        src={{@user.avatar}}
+        alt={{@user.name}}
+        data-test-avatar
+      />
+      <h2 data-test-name>{{@user.name}}</h2>
+      <p data-test-email>{{@user.email}}</p>
+
+      {{#if @onEdit}}
+        <button
+          {{on "click" (fn @onEdit @user)}}
+          data-test-edit-button
+        >
+          Edit
+        </button>
+      {{/if}}
+    </div>
+  </template>
+}
+```
+
+Modern testing patterns with `@ember/test-helpers`, `qunit-dom`, and data-test attributes provide better test reliability, readability, and maintainability.
+
+Reference: [Ember Testing](https://guides.emberjs.com/release/testing/)

--- a/skills/ember-best-practices/rules/testing-msw-setup.md
+++ b/skills/ember-best-practices/rules/testing-msw-setup.md
@@ -1,0 +1,541 @@
+---
+title: MSW (Mock Service Worker) Setup for Testing
+impact: HIGH
+impactDescription: Proper API mocking without ORM complexity
+tags: testing, msw, api-mocking, mock-service-worker
+---
+
+## MSW (Mock Service Worker) Setup for Testing
+
+Use MSW (Mock Service Worker) for API mocking in tests. MSW provides a cleaner approach than Mirage by intercepting requests at the network level without introducing unnecessary ORM patterns or abstractions.
+
+**Incorrect (using Mirage with ORM complexity):**
+
+```javascript
+// mirage/config.js
+export default function () {
+  this.namespace = '/api';
+
+  // Complex schema and factories
+  this.get('/users', (schema) => {
+    return schema.users.all();
+  });
+
+  // Need to maintain schema, factories, serializers
+  this.post('/users', (schema, request) => {
+    let attrs = JSON.parse(request.requestBody);
+    return schema.users.create(attrs);
+  });
+}
+```
+
+**Correct (using MSW with simple network mocking):**
+
+```javascript
+// tests/helpers/msw.js
+import { http, HttpResponse } from 'msw';
+
+// Simple request/response mocking
+export const handlers = [
+  http.get('/api/users', () => {
+    return HttpResponse.json([
+      { id: 1, name: 'Alice' },
+      { id: 2, name: 'Bob' },
+    ]);
+  }),
+
+  http.post('/api/users', async ({ request }) => {
+    const user = await request.json();
+    return HttpResponse.json({ id: 3, ...user }, { status: 201 });
+  }),
+];
+```
+
+**Why MSW over Mirage:**
+
+- **Better conventions** - Mock at the network level, not with an ORM
+- **Simpler mental model** - Define request handlers, return responses
+- **Doesn't lead developers astray** - No schema migrations or factories to maintain
+- **Works everywhere** - Same mocks work in tests, Storybook, and development
+- **More realistic** - Actually intercepts fetch/XMLHttpRequest
+
+Reference: [Ember.js Community Discussion on MSW](https://discuss.emberjs.com/t/my-cookbook-for-various-emberjs-things/19679)
+
+### Installation
+
+```bash
+npm install --save-dev msw
+```
+
+### Setup Test Helper
+
+Create a test helper to set up MSW in your tests:
+
+```javascript
+// tests/helpers/msw.js
+import { setupServer } from 'msw/node';
+import { http, HttpResponse } from 'msw';
+
+// Define default handlers that apply to all tests
+const defaultHandlers = [
+  // Add default handlers here if needed
+];
+
+export function setupMSW(hooks, handlers = []) {
+  const server = setupServer(...defaultHandlers, ...handlers);
+
+  hooks.beforeEach(function () {
+    server.listen({ onUnhandledRequest: 'warn' });
+  });
+
+  hooks.afterEach(function () {
+    server.resetHandlers();
+  });
+
+  hooks.after(function () {
+    server.close();
+  });
+
+  return { server };
+}
+
+// Re-export for convenience
+export { http, HttpResponse };
+```
+
+### Basic Usage in Tests
+
+```javascript
+// tests/acceptance/users-test.js
+import { module, test } from 'qunit';
+import { visit, currentURL, click } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { setupMSW, http, HttpResponse } from 'my-app/tests/helpers/msw';
+
+module('Acceptance | users', function (hooks) {
+  setupApplicationTest(hooks);
+  const { server } = setupMSW(hooks);
+
+  test('displays list of users', async function (assert) {
+    server.use(
+      http.get('/api/users', () => {
+        return HttpResponse.json({
+          data: [
+            {
+              id: '1',
+              type: 'user',
+              attributes: { name: 'Alice', email: 'alice@example.com' },
+            },
+            {
+              id: '2',
+              type: 'user',
+              attributes: { name: 'Bob', email: 'bob@example.com' },
+            },
+          ],
+        });
+      }),
+    );
+
+    await visit('/users');
+
+    assert.strictEqual(currentURL(), '/users');
+    assert.dom('[data-test-user-item]').exists({ count: 2 });
+    assert.dom('[data-test-user-name]').hasText('Alice');
+  });
+
+  test('handles server errors gracefully', async function (assert) {
+    server.use(
+      http.get('/api/users', () => {
+        return HttpResponse.json({ errors: [{ title: 'Server Error' }] }, { status: 500 });
+      }),
+    );
+
+    await visit('/users');
+
+    assert.dom('[data-test-error-message]').exists();
+    assert.dom('[data-test-error-message]').containsText('Server Error');
+  });
+});
+```
+
+### Mocking POST/PUT/DELETE Requests
+
+```javascript
+import { visit, click, fillIn } from '@ember/test-helpers';
+
+test('creates a new user', async function (assert) {
+  let capturedRequest = null;
+
+  server.use(
+    http.post('/api/users', async ({ request }) => {
+      capturedRequest = await request.json();
+
+      return HttpResponse.json(
+        {
+          data: {
+            id: '3',
+            type: 'user',
+            attributes: capturedRequest.data.attributes,
+          },
+        },
+        { status: 201 },
+      );
+    }),
+  );
+
+  await visit('/users/new');
+  await fillIn('[data-test-name-input]', 'Charlie');
+  await fillIn('[data-test-email-input]', 'charlie@example.com');
+  await click('[data-test-submit-button]');
+
+  assert.strictEqual(currentURL(), '/users/3');
+  assert.deepEqual(capturedRequest.data.attributes, {
+    name: 'Charlie',
+    email: 'charlie@example.com',
+  });
+});
+
+test('updates an existing user', async function (assert) {
+  server.use(
+    http.get('/api/users/1', () => {
+      return HttpResponse.json({
+        data: {
+          id: '1',
+          type: 'user',
+          attributes: { name: 'Alice', email: 'alice@example.com' },
+        },
+      });
+    }),
+    http.patch('/api/users/1', async ({ request }) => {
+      const body = await request.json();
+      return HttpResponse.json({
+        data: {
+          id: '1',
+          type: 'user',
+          attributes: body.data.attributes,
+        },
+      });
+    }),
+  );
+
+  await visit('/users/1/edit');
+  await fillIn('[data-test-name-input]', 'Alice Updated');
+  await click('[data-test-submit-button]');
+
+  assert.dom('[data-test-user-name]').hasText('Alice Updated');
+});
+
+test('deletes a user', async function (assert) {
+  server.use(
+    http.get('/api/users', () => {
+      return HttpResponse.json({
+        data: [{ id: '1', type: 'user', attributes: { name: 'Alice' } }],
+      });
+    }),
+    http.delete('/api/users/1', () => {
+      return new HttpResponse(null, { status: 204 });
+    }),
+  );
+
+  await visit('/users');
+  await click('[data-test-delete-button]');
+
+  assert.dom('[data-test-user-item]').doesNotExist();
+});
+```
+
+### Query Parameters and Dynamic Routes
+
+```javascript
+test('filters users by query parameter', async function (assert) {
+  server.use(
+    http.get('/api/users', ({ request }) => {
+      const url = new URL(request.url);
+      const searchQuery = url.searchParams.get('filter[name]');
+
+      const users = [
+        { id: '1', type: 'user', attributes: { name: 'Alice' } },
+        { id: '2', type: 'user', attributes: { name: 'Bob' } },
+      ];
+
+      const filtered = searchQuery
+        ? users.filter((u) => u.attributes.name.includes(searchQuery))
+        : users;
+
+      return HttpResponse.json({ data: filtered });
+    }),
+  );
+
+  await visit('/users?filter[name]=Alice');
+
+  assert.dom('[data-test-user-item]').exists({ count: 1 });
+  assert.dom('[data-test-user-name]').hasText('Alice');
+});
+
+test('handles dynamic route segments', async function (assert) {
+  server.use(
+    http.get('/api/users/:id', ({ params }) => {
+      return HttpResponse.json({
+        data: {
+          id: params.id,
+          type: 'user',
+          attributes: { name: `User ${params.id}` },
+        },
+      });
+    }),
+  );
+
+  await visit('/users/42');
+
+  assert.dom('[data-test-user-name]').hasText('User 42');
+});
+```
+
+### Network Delays and Race Conditions
+
+```javascript
+test('handles slow network responses', async function (assert) {
+  server.use(
+    http.get('/api/users', async () => {
+      // Simulate network delay
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      return HttpResponse.json({
+        data: [{ id: '1', type: 'user', attributes: { name: 'Alice' } }],
+      });
+    }),
+  );
+
+  const visitPromise = visit('/users');
+
+  // Loading state should be visible
+  assert.dom('[data-test-loading-spinner]').exists();
+
+  await visitPromise;
+
+  assert.dom('[data-test-loading-spinner]').doesNotExist();
+  assert.dom('[data-test-user-item]').exists();
+});
+```
+
+### Shared Handlers with Reusable Fixtures
+
+```javascript
+// tests/helpers/msw-handlers.js
+import { http, HttpResponse } from 'msw';
+
+export const userHandlers = {
+  list: (users = []) => {
+    return http.get('/api/users', () => {
+      return HttpResponse.json({ data: users });
+    });
+  },
+
+  get: (user) => {
+    return http.get(`/api/users/${user.id}`, () => {
+      return HttpResponse.json({ data: user });
+    });
+  },
+
+  create: (attributes) => {
+    return http.post('/api/users', () => {
+      return HttpResponse.json(
+        {
+          data: {
+            id: String(Math.random()),
+            type: 'user',
+            attributes,
+          },
+        },
+        { status: 201 },
+      );
+    });
+  },
+};
+
+// Common fixtures
+export const fixtures = {
+  users: {
+    alice: {
+      id: '1',
+      type: 'user',
+      attributes: { name: 'Alice', email: 'alice@example.com' },
+    },
+    bob: {
+      id: '2',
+      type: 'user',
+      attributes: { name: 'Bob', email: 'bob@example.com' },
+    },
+  },
+};
+```
+
+```javascript
+// tests/acceptance/users-test.js
+import { userHandlers, fixtures } from 'my-app/tests/helpers/msw-handlers';
+
+test('displays list of users', async function (assert) {
+  server.use(userHandlers.list([fixtures.users.alice, fixtures.users.bob]));
+
+  await visit('/users');
+
+  assert.dom('[data-test-user-item]').exists({ count: 2 });
+});
+```
+
+### Integration Test Setup
+
+MSW works in integration tests too:
+
+```javascript
+// tests/integration/components/user-list-test.js
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, waitFor } from '@ember/test-helpers';
+import { setupMSW, http, HttpResponse } from 'my-app/tests/helpers/msw';
+import UserList from 'my-app/components/user-list';
+
+module('Integration | Component | user-list', function (hooks) {
+  setupRenderingTest(hooks);
+  const { server } = setupMSW(hooks);
+
+  test('fetches and displays users', async function (assert) {
+    server.use(
+      http.get('/api/users', () => {
+        return HttpResponse.json({
+          data: [{ id: '1', type: 'user', attributes: { name: 'Alice' } }],
+        });
+      }),
+    );
+
+    await render(
+      <template>
+        <UserList />
+      </template>,
+    );
+
+    // Wait for async data to load
+    await waitFor('[data-test-user-item]');
+
+    assert.dom('[data-test-user-item]').exists();
+    assert.dom('[data-test-user-name]').hasText('Alice');
+  });
+});
+```
+
+### Best Practices
+
+1. **Define handlers per test** - Use `server.use()` in individual tests rather than global handlers
+2. **Reset between tests** - The helper automatically resets handlers after each test
+3. **Use JSON:API format** - Keep responses consistent with your API format
+4. **Test error states** - Mock various HTTP error codes (400, 401, 403, 404, 500)
+5. **Capture requests** - Use the request object to verify what your app sent
+6. **Use fixtures** - Create reusable test data to keep tests DRY
+7. **Simulate delays** - Test loading states with artificial delays
+8. **Type-safe responses** - In TypeScript, type your response payloads
+
+### Common Patterns
+
+**Default handlers for all tests:**
+
+```javascript
+// tests/helpers/msw.js
+const defaultHandlers = [
+  // Always return current user
+  http.get('/api/current-user', () => {
+    return HttpResponse.json({
+      data: {
+        id: '1',
+        type: 'user',
+        attributes: { name: 'Test User', role: 'admin' },
+      },
+    });
+  }),
+];
+```
+
+**One-time handlers (don't persist):**
+
+```javascript
+// MSW handlers persist until resetHandlers() is called
+// The test helper automatically resets after each test
+// For a one-time handler within a test, manually reset:
+test('one-time response', async function (assert) {
+  server.use(
+    http.get('/api/special', () => {
+      return HttpResponse.json({ data: 'special' });
+    }),
+  );
+
+  // First request gets mocked response
+  await visit('/special');
+  assert.dom('[data-test-data]').hasText('special');
+
+  // Reset to remove this handler
+  server.resetHandlers();
+
+  // Subsequent requests will use default handlers or be unhandled
+});
+```
+
+**Conditional responses:**
+
+```javascript
+http.post('/api/login', async ({ request }) => {
+  const { email, password } = await request.json();
+
+  if (email === 'test@example.com' && password === 'password') {
+    return HttpResponse.json({
+      data: { token: 'abc123' },
+    });
+  }
+
+  return HttpResponse.json({ errors: [{ title: 'Invalid credentials' }] }, { status: 401 });
+});
+```
+
+### Migration from Mirage
+
+If migrating from Mirage:
+
+1. Remove `ember-cli-mirage` dependency
+2. Delete `mirage/` directory (models, factories, scenarios)
+3. Install MSW: `npm install --save-dev msw`
+4. Create the MSW test helper (see above)
+5. Replace `setupMirage(hooks)` with `setupMSW(hooks)`
+6. Convert Mirage handlers:
+   - `this.server.get()` → `http.get()`
+   - `this.server.create()` → Return inline JSON
+   - `this.server.createList()` → Return array of JSON objects
+
+**Before (Mirage):**
+
+```javascript
+test('lists posts', async function (assert) {
+  this.server.createList('post', 3);
+  await visit('/posts');
+  assert.dom('[data-test-post]').exists({ count: 3 });
+});
+```
+
+**After (MSW):**
+
+```javascript
+test('lists posts', async function (assert) {
+  server.use(
+    http.get('/api/posts', () => {
+      return HttpResponse.json({
+        data: [
+          { id: '1', type: 'post', attributes: { title: 'Post 1' } },
+          { id: '2', type: 'post', attributes: { title: 'Post 2' } },
+          { id: '3', type: 'post', attributes: { title: 'Post 3' } },
+        ],
+      });
+    }),
+  );
+  await visit('/posts');
+  assert.dom('[data-test-post]').exists({ count: 3 });
+});
+```
+
+Reference: [MSW Documentation](https://mswjs.io/docs/)

--- a/skills/ember-best-practices/rules/testing-no-raf-for-state.md
+++ b/skills/ember-best-practices/rules/testing-no-raf-for-state.md
@@ -1,0 +1,78 @@
+---
+title: Avoid requestAnimationFrame for State Changes in Ember Components
+impact: HIGH
+impactDescription: Prevents flaky tests caused by untracked async timing
+tags: testing, async, requestAnimationFrame, runloop, settled, flaky-tests
+---
+
+## Avoid requestAnimationFrame for State Changes in Ember Components
+
+Do not use `requestAnimationFrame` to defer tracked property changes or DOM mutations in Ember components. Use `scheduleOnce('afterRender', ...)` from `@ember/runloop` instead.
+
+**Why This Matters:**
+
+`requestAnimationFrame` runs outside the Ember runloop. Ember's test helpers (`settled()`, `click()`, `waitFor()`, etc.) do not wait for rAF callbacks. This means:
+
+- Tracked property changes inside rAF may not be reflected when test assertions run
+- Tests pass locally but fail intermittently on CI under load
+- The flakiness is extremely hard to reproduce and diagnose
+
+`scheduleOnce('afterRender', ...)` participates in the Ember runloop, so `settled()` properly waits for it.
+
+**Incorrect (causes flaky tests):**
+
+```glimmer-js
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+export default class MyComponent extends Component {
+  @tracked highlightedId = null;
+
+  constructor(owner, args) {
+    super(owner, args);
+    // BAD: settled() won't wait for this
+    requestAnimationFrame(() => this.activateFirstItem());
+  }
+
+  activateFirstItem() {
+    this.highlightedId = 'first-item';
+  }
+}
+```
+
+**Correct (test-friendly):**
+
+```glimmer-js
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { scheduleOnce } from '@ember/runloop';
+
+export default class MyComponent extends Component {
+  @tracked highlightedId = null;
+
+  constructor(owner, args) {
+    super(owner, args);
+    // GOOD: settled() waits for afterRender queue
+    scheduleOnce('afterRender', this, this.activateFirstItem);
+  }
+
+  activateFirstItem() {
+    this.highlightedId = 'first-item';
+  }
+}
+```
+
+**When requestAnimationFrame IS appropriate:**
+
+- Canvas/WebGL render loops (`requestAnimationFrame(this.animate)`)
+- Throttling visual updates (color pickers, drag handlers)
+- Measuring layout after browser paint (reading `getBoundingClientRect`)
+
+In these cases, disable the lint rule with an inline comment:
+
+```js
+// eslint-disable-next-line @cardstack/boxel/no-raf-for-state
+requestAnimationFrame(this.animate);
+```
+
+**Enforced by:** `@cardstack/boxel/no-raf-for-state` ESLint rule

--- a/skills/ember-best-practices/rules/testing-qunit-dom-assertions.md
+++ b/skills/ember-best-practices/rules/testing-qunit-dom-assertions.md
@@ -1,0 +1,323 @@
+---
+title: Use qunit-dom for Better Test Assertions
+impact: MEDIUM
+impactDescription: More readable and maintainable tests
+tags: testing, qunit-dom, assertions, best-practices
+---
+
+## Use qunit-dom for Better Test Assertions
+
+Use `qunit-dom` for DOM assertions in tests. It provides expressive, chainable assertions that make tests more readable and provide better error messages than raw QUnit assertions.
+
+**Why qunit-dom:**
+
+- More expressive and readable test assertions
+- Better error messages when tests fail
+- Type-safe with TypeScript
+- Reduces boilerplate in DOM testing
+
+### Basic DOM Assertions
+
+**Incorrect (verbose QUnit assertions):**
+
+```javascript
+// tests/integration/components/greeting-test.js
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+
+
+module('Integration | Component | greeting', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    await render(<template><Greeting @name="World" /></template>);
+
+    const element = this.element.querySelector('.greeting');
+    assert.ok(element, 'greeting element exists');
+    assert.equal(element.textContent.trim(), 'Hello, World!', 'shows greeting');
+    assert.ok(element.classList.contains('greeting'), 'has greeting class');
+  });
+});
+```
+
+**Correct (expressive qunit-dom):**
+
+```javascript
+// tests/integration/components/greeting-test.js
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+
+
+module('Integration | Component | greeting', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    await render(<template><Greeting @name="World" /></template>);
+
+    assert.dom('.greeting').exists('greeting element exists');
+    assert.dom('.greeting').hasText('Hello, World!', 'shows greeting');
+  });
+});
+```
+
+### Common Assertions
+
+**Existence and Visibility:**
+
+```javascript
+test('element visibility', async function (assert) {
+  await render(
+    <template>
+      <MyComponent />
+    </template>,
+  );
+
+  // Element exists in DOM
+  assert.dom('[data-test-output]').exists();
+
+  // Element doesn't exist
+  assert.dom('[data-test-deleted]').doesNotExist();
+
+  // Element is visible (not display: none or visibility: hidden)
+  assert.dom('[data-test-visible]').isVisible();
+
+  // Element is not visible
+  assert.dom('[data-test-hidden]').isNotVisible();
+
+  // Count elements
+  assert.dom('[data-test-item]').exists({ count: 3 });
+});
+```
+
+**Text Content:**
+
+```javascript
+test('text assertions', async function (assert) {
+  await render(<template><Article @title="Hello World" /></template>);
+
+  // Exact text match
+  assert.dom('h1').hasText('Hello World');
+
+  // Contains text (partial match)
+  assert.dom('p').containsText('Hello');
+
+  // Any text exists
+  assert.dom('h1').hasAnyText();
+
+  // No text
+  assert.dom('.empty').hasNoText();
+});
+```
+
+**Attributes:**
+
+```javascript
+test('attribute assertions', async function (assert) {
+  await render(<template><Button @disabled={{true}} /></template>);
+
+  // Has attribute (any value)
+  assert.dom('button').hasAttribute('disabled');
+
+  // Has specific attribute value
+  assert.dom('button').hasAttribute('type', 'submit');
+
+  // Attribute value matches regex
+  assert.dom('a').hasAttribute('href', /^https:\/\//);
+
+  // Doesn't have attribute
+  assert.dom('button').doesNotHaveAttribute('aria-hidden');
+
+  // Has ARIA attributes
+  assert.dom('[role="button"]').hasAttribute('aria-label', 'Close dialog');
+});
+```
+
+**Classes:**
+
+```javascript
+test('class assertions', async function (assert) {
+  await render(<template><Card @status="active" /></template>);
+
+  // Has single class
+  assert.dom('.card').hasClass('active');
+
+  // Doesn't have class
+  assert.dom('.card').doesNotHaveClass('disabled');
+
+  // Has no classes at all
+  assert.dom('.plain').hasNoClass();
+});
+```
+
+**Form Elements:**
+
+```javascript
+test('form assertions', async function (assert) {
+  await render(
+    <template>
+      <form>
+        <input type="text" value="hello" />
+        <input type="checkbox" checked />
+        <input type="radio" disabled />
+        <select>
+          <option selected>Option 1</option>
+        </select>
+      </form>
+    </template>,
+  );
+
+  // Input value
+  assert.dom('input[type="text"]').hasValue('hello');
+
+  // Checkbox/radio state
+  assert.dom('input[type="checkbox"]').isChecked();
+  assert.dom('input[type="checkbox"]').isNotChecked();
+
+  // Disabled state
+  assert.dom('input[type="radio"]').isDisabled();
+  assert.dom('input[type="text"]').isNotDisabled();
+
+  // Required state
+  assert.dom('input').isRequired();
+  assert.dom('input').isNotRequired();
+
+  // Focus state
+  assert.dom('input').isFocused();
+  assert.dom('input').isNotFocused();
+});
+```
+
+### Chaining Assertions
+
+You can chain multiple assertions on the same element:
+
+```javascript
+test('chained assertions', async function (assert) {
+  await render(<template><Button @variant="primary" @disabled={{false}} /></template>);
+
+  assert.dom('button')
+    .exists()
+    .hasClass('btn-primary')
+    .hasAttribute('type', 'button')
+    .isNotDisabled()
+    .hasText('Submit')
+    .isVisible();
+});
+```
+
+### Custom Error Messages
+
+Add custom messages to make failures clearer:
+
+```javascript
+test('custom messages', async function (assert) {
+  await render(<template><UserProfile @user={{this.user}} /></template>);
+
+  assert.dom('[data-test-username]')
+    .hasText(this.user.name, 'username is displayed correctly');
+
+  assert.dom('[data-test-avatar]')
+    .exists('user avatar should be visible');
+});
+```
+
+### Testing Counts
+
+```javascript
+test('list items', async function (assert) {
+  await render(<template>
+    <TodoList @todos={{this.todos}} />
+  </template>);
+
+  // Exact count
+  assert.dom('[data-test-todo]').exists({ count: 5 });
+
+  // At least one
+  assert.dom('[data-test-todo]').exists({ count: 1 });
+
+  // None
+  assert.dom('[data-test-todo]').doesNotExist();
+});
+```
+
+### Accessibility Testing
+
+Use qunit-dom for basic accessibility checks:
+
+```javascript
+test('accessibility', async function (assert) {
+  await render(<template><Modal @onClose={{this.close}} /></template>);
+
+  // ARIA roles
+  assert.dom('[role="dialog"]').exists();
+  assert.dom('[role="dialog"]').hasAttribute('aria-modal', 'true');
+
+  // Labels
+  assert.dom('[aria-label="Close modal"]').exists();
+
+  // Focus management
+  assert.dom('[data-test-close-button]').isFocused();
+
+  // Required fields
+  assert.dom('input[name="email"]').hasAttribute('aria-required', 'true');
+});
+```
+
+### Best Practices
+
+1. **Use data-test attributes** for test selectors instead of classes:
+
+   ```javascript
+   // Good
+   assert.dom('[data-test-submit-button]').exists();
+
+   // Avoid - classes can change
+   assert.dom('.btn.btn-primary').exists();
+   ```
+
+2. **Make assertions specific**:
+
+   ```javascript
+   // Better - exact match
+   assert.dom('h1').hasText('Welcome');
+
+   // Less specific - could miss issues
+   assert.dom('h1').containsText('Welc');
+   ```
+
+3. **Use meaningful custom messages**:
+
+   ```javascript
+   assert.dom('[data-test-error]').hasText('Invalid email', 'shows correct validation error');
+   ```
+
+4. **Combine with @ember/test-helpers**:
+
+   ```javascript
+   import { click, fillIn } from '@ember/test-helpers';
+
+   await fillIn('[data-test-email]', 'user@example.com');
+   await click('[data-test-submit]');
+
+   assert.dom('[data-test-success]').exists();
+   ```
+
+5. **Test user-visible behavior**, not implementation:
+
+   ```javascript
+   // Good - tests what user sees
+   assert.dom('[data-test-greeting]').hasText('Hello, Alice');
+
+   // Avoid - tests implementation details
+   assert.ok(this.component.internalState === 'ready');
+   ```
+
+qunit-dom makes your tests more maintainable and easier to understand. It comes pre-installed with `ember-qunit`, so you can start using it immediately.
+
+**References:**
+
+- [qunit-dom Documentation](https://github.com/mainmatter/qunit-dom)
+- [qunit-dom API](https://github.com/mainmatter/qunit-dom/blob/master/API.md)
+- [Ember Testing Guide](https://guides.emberjs.com/release/testing/)

--- a/skills/ember-best-practices/rules/testing-render-patterns.md
+++ b/skills/ember-best-practices/rules/testing-render-patterns.md
@@ -1,0 +1,251 @@
+---
+title: Use Appropriate Render Patterns in Tests
+impact: MEDIUM
+impactDescription: Simpler test code and better readability
+tags: testing, render, component-testing, test-helpers
+---
+
+## Use Appropriate Render Patterns in Tests
+
+Choose the right rendering pattern based on whether your component needs arguments, blocks, or attributes in the test.
+
+**Incorrect (using template tag unnecessarily):**
+
+```javascript
+// tests/integration/components/loading-spinner-test.js
+import { render } from '@ember/test-helpers';
+import LoadingSpinner from 'my-app/components/loading-spinner';
+
+test('it renders', async function (assert) {
+  // ❌ Unnecessary template wrapper for component with no args
+  await render(
+    <template>
+      <LoadingSpinner />
+    </template>,
+  );
+
+  assert.dom('[data-test-spinner]').exists();
+});
+```
+
+**Correct (direct component render when no args needed):**
+
+```javascript
+// tests/integration/components/loading-spinner-test.js
+import { render } from '@ember/test-helpers';
+import LoadingSpinner from 'my-app/components/loading-spinner';
+
+test('it renders', async function (assert) {
+  // ✅ Simple: pass component directly when no args needed
+  await render(LoadingSpinner);
+
+  assert.dom('[data-test-spinner]').exists();
+});
+```
+
+**Pattern 1: Direct component render (no args/blocks/attributes):**
+
+```javascript
+// tests/integration/components/loading-spinner-test.js
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import LoadingSpinner from 'my-app/components/loading-spinner';
+
+module('Integration | Component | loading-spinner', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders without arguments', async function (assert) {
+    // ✅ Simple: pass component directly when no args needed
+    await render(LoadingSpinner);
+
+    assert.dom('[data-test-spinner]').exists();
+    assert.dom('[data-test-spinner]').hasClass('loading');
+  });
+});
+```
+
+**Pattern 2: Template tag render (with args/blocks/attributes):**
+
+```glimmer-js
+// tests/integration/components/user-card-test.js
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import UserCard from 'my-app/components/user-card';
+
+module('Integration | Component | user-card', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders with arguments', async function(assert) {
+    const user = { name: 'John Doe', email: 'john@example.com' };
+
+    // ✅ Use template tag when passing arguments
+    await render(<template>
+      <UserCard @user={{user}} />
+    </template>);
+
+    assert.dom('[data-test-user-name]').hasText('John Doe');
+  });
+
+  test('it renders with block content', async function(assert) {
+    // ✅ Use template tag when providing blocks
+    await render(<template>
+      <UserCard>
+        <:header>Custom Header</:header>
+        <:body>Custom Content</:body>
+      </UserCard>
+    </template>);
+
+    assert.dom('[data-test-header]').hasText('Custom Header');
+    assert.dom('[data-test-body]').hasText('Custom Content');
+  });
+
+  test('it renders with HTML attributes', async function(assert) {
+    // ✅ Use template tag when passing HTML attributes
+    await render(<template>
+      <UserCard class="featured" data-test-featured />
+    </template>);
+
+    assert.dom('[data-test-featured]').exists();
+    assert.dom('[data-test-featured]').hasClass('featured');
+  });
+});
+```
+
+**Complete example showing both patterns:**
+
+```glimmer-js
+// tests/integration/components/button-test.js
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click } from '@ember/test-helpers';
+import Button from 'my-app/components/button';
+
+module('Integration | Component | button', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders default button', async function(assert) {
+    // ✅ No args needed - use direct render
+    await render(Button);
+
+    assert.dom('button').exists();
+    assert.dom('button').hasText('Click me');
+  });
+
+  test('it renders with custom text', async function(assert) {
+    // ✅ Needs block content - use template tag
+    await render(<template>
+      <Button>Submit Form</Button>
+    </template>);
+
+    assert.dom('button').hasText('Submit Form');
+  });
+
+  test('it handles click action', async function(assert) {
+    assert.expect(1);
+
+    const handleClick = () => {
+      assert.ok(true, 'Click handler called');
+    };
+
+    // ✅ Needs argument - use template tag
+    await render(<template>
+      <Button @onClick={{handleClick}}>Click me</Button>
+    </template>);
+
+    await click('button');
+  });
+
+  test('it applies variant styling', async function(assert) {
+    // ✅ Needs argument - use template tag
+    await render(<template>
+      <Button @variant="primary">Primary Button</Button>
+    </template>);
+
+    assert.dom('button').hasClass('btn-primary');
+  });
+});
+```
+
+**Testing template-only components:**
+
+```glimmer-js
+// tests/integration/components/icon-test.js
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import Icon from 'my-app/components/icon';
+
+module('Integration | Component | icon', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders default icon', async function(assert) {
+    // ✅ Template-only component with no args - use direct render
+    await render(Icon);
+
+    assert.dom('[data-test-icon]').exists();
+  });
+
+  test('it renders specific icon', async function(assert) {
+    // ✅ Needs @name argument - use template tag
+    await render(<template>
+      <Icon @name="check" @size="large" />
+    </template>);
+
+    assert.dom('[data-test-icon]').hasAttribute('data-icon', 'check');
+    assert.dom('[data-test-icon]').hasClass('icon-large');
+  });
+});
+```
+
+**Decision guide:**
+
+| Scenario                            | Pattern                            | Example                                                     |
+| ----------------------------------- | ---------------------------------- | ----------------------------------------------------------- |
+| No arguments, blocks, or attributes | `render(Component)`                | `render(LoadingSpinner)`                                    |
+| Component needs arguments           | `render(<template>...</template>)` | `render(<template><Card @title="Hello" /></template>)`      |
+| Component receives block content    | `render(<template>...</template>)` | `render(<template><Card>Content</Card></template>)`         |
+| Component needs HTML attributes     | `render(<template>...</template>)` | `render(<template><Card class="featured" /></template>)`    |
+| Multiple test context properties    | `render(<template>...</template>)` | `render(<template><Card @data={{this.data}} /></template>)` |
+
+**Why this matters:**
+
+- **Simplicity**: Direct render reduces boilerplate for simple cases
+- **Clarity**: Template syntax makes data flow explicit when needed
+- **Consistency**: Clear pattern helps teams write maintainable tests
+- **Type Safety**: Both patterns work with TypeScript for component types
+
+**Common patterns:**
+
+```glimmer-js
+// ✅ Simple component, no setup needed
+await render(LoadingSpinner);
+await render(Divider);
+await render(Logo);
+
+// ✅ Component with arguments from test context
+await render(<template>
+  <UserList @users={{this.users}} @onSelect={{this.handleSelect}} />
+</template>);
+
+// ✅ Component with named blocks
+await render(<template>
+  <Modal>
+    <:header>Title</:header>
+    <:body>Content</:body>
+    <:footer><button>Close</button></:footer>
+  </Modal>
+</template>);
+
+// ✅ Component with splattributes
+await render(<template>
+  <Card class="highlighted" data-test-card role="article">
+    Card content
+  </Card>
+</template>);
+```
+
+Using the appropriate render pattern keeps tests clean and expressive.
+
+Reference: [Ember Testing Guide](https://guides.emberjs.com/release/testing/)

--- a/skills/ember-best-practices/rules/testing-test-waiters.md
+++ b/skills/ember-best-practices/rules/testing-test-waiters.md
@@ -1,0 +1,309 @@
+---
+title: Use Test Waiters for Async Operations
+impact: HIGH
+impactDescription: Reliable tests that don't depend on implementation details
+tags: testing, async, test-waiters, waitFor, settled
+---
+
+## Use Test Waiters for Async Operations
+
+Instrument async code with test waiters instead of using `waitFor()` or `waitUntil()` in tests. Test waiters abstract async implementation details so tests focus on user behavior rather than timing.
+
+**Why Test Waiters Matter:**
+
+Test waiters allow `settled()` and other test helpers to automatically wait for your async operations. This means:
+
+- Tests don't need to know about implementation details (timeouts, polling intervals, etc.)
+- Tests are written from a user's perspective ("click button, see result")
+- Code refactoring doesn't break tests
+- Tests are more reliable and less flaky
+
+**Incorrect (testing implementation details):**
+
+```glimmer-js
+// tests/integration/components/data-loader-test.js
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click, waitFor } from '@ember/test-helpers';
+import DataLoader from 'my-app/components/data-loader';
+
+module('Integration | Component | data-loader', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it loads data', async function(assert) {
+    await render(<template><DataLoader /></template>);
+
+    await click('[data-test-load-button]');
+
+    // BAD: Test knows about implementation details
+    // If the component changes from polling every 100ms to 200ms, test breaks
+    await waitFor('[data-test-data]', { timeout: 5000 });
+
+    assert.dom('[data-test-data]').hasText('Loaded data');
+  });
+});
+```
+
+**Correct (using test waiters):**
+
+```glimmer-js
+// app/components/data-loader.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { registerDestructor } from '@ember/destroyable';
+import { buildWaiter } from '@ember/test-waiters';
+
+const waiter = buildWaiter('data-loader');
+
+export class DataLoader extends Component {
+  @tracked data = null;
+  @tracked isLoading = false;
+
+  loadData = async () => {
+    // Register the async operation with test waiter
+    const token = waiter.beginAsync();
+
+    try {
+      this.isLoading = true;
+
+      // Simulate async data loading
+      const response = await fetch('/api/data');
+      this.data = await response.json();
+    } finally {
+      this.isLoading = false;
+      // Always end the async operation, even on error
+      waiter.endAsync(token);
+    }
+  };
+
+  <template>
+    <div>
+      <button {{on "click" this.loadData}} data-test-load-button>
+        Load Data
+      </button>
+
+      {{#if this.isLoading}}
+        <div data-test-loading>Loading...</div>
+      {{/if}}
+
+      {{#if this.data}}
+        <div data-test-data>{{this.data}}</div>
+      {{/if}}
+    </div>
+  </template>
+}
+```
+
+```glimmer-js
+// tests/integration/components/data-loader-test.js
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click, settled } from '@ember/test-helpers';
+import DataLoader from 'my-app/components/data-loader';
+
+module('Integration | Component | data-loader', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it loads data', async function(assert) {
+    await render(<template><DataLoader /></template>);
+
+    await click('[data-test-load-button]');
+
+    // GOOD: settled() automatically waits for test waiters
+    // No knowledge of timing needed - tests from user's perspective
+    await settled();
+
+    assert.dom('[data-test-data]').hasText('Loaded data');
+  });
+});
+```
+
+**Test waiter with cleanup:**
+
+```glimmer-js
+// app/components/polling-widget.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { registerDestructor } from '@ember/destroyable';
+import { buildWaiter } from '@ember/test-waiters';
+
+const waiter = buildWaiter('polling-widget');
+
+export class PollingWidget extends Component {
+  @tracked status = 'idle';
+  intervalId = null;
+  token = null;
+
+  constructor(owner, args) {
+    super(owner, args);
+
+    registerDestructor(this, () => {
+      this.stopPolling();
+    });
+  }
+
+  startPolling = () => {
+    // Register async operation
+    this.token = waiter.beginAsync();
+
+    this.intervalId = setInterval(() => {
+      this.checkStatus();
+    }, 1000);
+  };
+
+  stopPolling = () => {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
+
+    // End async operation on cleanup
+    if (this.token) {
+      waiter.endAsync(this.token);
+      this.token = null;
+    }
+  };
+
+  checkStatus = async () => {
+    const response = await fetch('/api/status');
+    this.status = await response.text();
+
+    if (this.status === 'complete') {
+      this.stopPolling();
+    }
+  };
+
+  <template>
+    <div>
+      <button {{on "click" this.startPolling}} data-test-start>
+        Start Polling
+      </button>
+      <div data-test-status>{{this.status}}</div>
+    </div>
+  </template>
+}
+```
+
+**Test waiter with Services:**
+
+```glimmer-js
+// app/services/data-sync.js
+import Service from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { buildWaiter } from '@ember/test-waiters';
+
+const waiter = buildWaiter('data-sync-service');
+
+export class DataSyncService extends Service {
+  @tracked isSyncing = false;
+
+  async sync() {
+    const token = waiter.beginAsync();
+
+    try {
+      this.isSyncing = true;
+
+      const response = await fetch('/api/sync', { method: 'POST' });
+      const result = await response.json();
+
+      return result;
+    } finally {
+      this.isSyncing = false;
+      waiter.endAsync(token);
+    }
+  }
+}
+```
+
+```glimmer-js
+// tests/unit/services/data-sync-test.js
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { settled } from '@ember/test-helpers';
+
+module('Unit | Service | data-sync', function(hooks) {
+  setupTest(hooks);
+
+  test('it syncs data', async function(assert) {
+    const service = this.owner.lookup('service:data-sync');
+
+    // Start async operation
+    const syncPromise = service.sync();
+
+    // No need for manual waiting - settled() handles it
+    await settled();
+
+    const result = await syncPromise;
+    assert.ok(result, 'Sync completed successfully');
+  });
+});
+```
+
+**Multiple concurrent operations:**
+
+```glimmer-js
+// app/components/parallel-loader.gjs
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { buildWaiter } from '@ember/test-waiters';
+
+const waiter = buildWaiter('parallel-loader');
+
+export class ParallelLoader extends Component {
+  @tracked results = [];
+
+  loadAll = async () => {
+    const urls = ['/api/data1', '/api/data2', '/api/data3'];
+
+    // Each request gets its own token
+    const requests = urls.map(async (url) => {
+      const token = waiter.beginAsync();
+
+      try {
+        const response = await fetch(url);
+        return await response.json();
+      } finally {
+        waiter.endAsync(token);
+      }
+    });
+
+    this.results = await Promise.all(requests);
+  };
+
+  <template>
+    <button {{on "click" this.loadAll}} data-test-load-all>
+      Load All
+    </button>
+
+    {{#each this.results as |result|}}
+      <div data-test-result>{{result}}</div>
+    {{/each}}
+  </template>
+}
+```
+
+**Benefits:**
+
+1. **User-focused tests**: Tests describe user actions, not implementation
+2. **Resilient to refactoring**: Change timing/polling without breaking tests
+3. **No arbitrary timeouts**: Tests complete as soon as operations finish
+4. **Automatic waiting**: `settled()`, `click()`, etc. wait for all registered operations
+5. **Better debugging**: Test waiters show pending operations when tests hang
+
+**When to use test waiters:**
+
+- Network requests (fetch, XHR)
+- Timers and intervals (setTimeout, setInterval)
+- Animations and transitions
+- Polling operations
+- Any async operation that affects rendered output
+
+**When NOT needed:**
+
+- ember-concurrency already registers test waiters automatically
+- Promises that complete before render (data preparation in constructors)
+- Operations that don't affect the DOM or component state
+
+**Key principle:** If your code does something async that users care about, register it with a test waiter. Tests should never use `waitFor()` or `waitUntil()` - those are code smells indicating missing test waiters.
+
+Reference: [@ember/test-waiters](https://github.com/emberjs/ember-test-waiters)

--- a/skills/ember-best-practices/rules/vscode-setup-recommended.md
+++ b/skills/ember-best-practices/rules/vscode-setup-recommended.md
@@ -1,0 +1,210 @@
+---
+title: VSCode Extensions and MCP Configuration for Ember Projects
+impact: HIGH
+impactDescription: Improves editor consistency and AI-assisted debugging setup
+tags: tooling, vscode, mcp, glint, developer-experience
+---
+
+## VSCode Extensions and MCP Configuration for Ember Projects
+
+Set up recommended VSCode extensions and Model Context Protocol (MCP) servers for optimal Ember development experience.
+
+**Incorrect (no extension recommendations):**
+
+```json
+{
+  "recommendations": []
+}
+```
+
+**Correct (recommended extensions for Ember):**
+
+```json
+{
+  "recommendations": [
+    "emberjs.vscode-ember",
+    "vunguyentuan.vscode-glint",
+    "esbenp.prettier-vscode",
+    "dbaeumer.vscode-eslint"
+  ]
+}
+```
+
+## Recommended VSCode Extensions
+
+Create a `.vscode/extensions.json` file in your project root to recommend extensions to all team members:
+
+```json
+{
+  "recommendations": [
+    "emberjs.vscode-ember",
+    "vunguyentuan.vscode-glint",
+    "esbenp.prettier-vscode",
+    "dbaeumer.vscode-eslint"
+  ]
+}
+```
+
+### Core Ember Extensions
+
+**ember-extension-pack** (or individual extensions):
+
+- `emberjs.vscode-ember` - Ember.js language support
+- Syntax highlighting for `.hbs`, `.gjs`, `.gts` files
+- IntelliSense for Ember-specific patterns
+- Code snippets for common Ember patterns
+
+**Glint 2 Extension** (for TypeScript projects):
+
+- `vunguyentuan.vscode-glint` - Type checking for Glimmer templates
+- Real-time type errors in `.gts`/`.gjs` files
+- Template-aware autocomplete
+- Hover information for template helpers and components
+
+Install instructions:
+
+```bash
+# Via command palette
+# Press Cmd+Shift+P (Mac) or Ctrl+Shift+P (Windows/Linux)
+# Type: "Extensions: Install Extensions"
+# Search for "Ember" or "Glint"
+```
+
+## MCP (Model Context Protocol) Server Configuration
+
+Configure MCP servers in `.vscode/settings.json` to integrate AI coding assistants with Ember-specific context:
+
+```json
+{
+  "github.copilot.enable": {
+    "*": true,
+    "yaml": false,
+    "plaintext": false,
+    "markdown": false
+  },
+  "mcp.servers": {
+    "ember-mcp": {
+      "command": "npx",
+      "args": ["@ember/mcp-server"],
+      "description": "Ember.js MCP Server - Provides Ember-specific context"
+    },
+    "chrome-devtools": {
+      "command": "npx",
+      "args": ["@modelcontextprotocol/server-chrome-devtools"],
+      "description": "Chrome DevTools MCP Server - Browser debugging integration"
+    },
+    "playwright": {
+      "command": "npx",
+      "args": ["@playwright/mcp-server"],
+      "description": "Playwright MCP Server - Browser automation and testing"
+    }
+  }
+}
+```
+
+### MCP Server Benefits
+
+**Ember MCP Server** (`@ember/mcp-server`):
+
+- Ember API documentation lookup
+- Component and helper discovery
+- Addon documentation integration
+- Routing and data layer context
+
+**Chrome DevTools MCP** (`@modelcontextprotocol/server-chrome-devtools`):
+
+- Live browser inspection
+- Console debugging assistance
+- Network request analysis
+- Performance profiling integration
+
+**Playwright MCP** (optional, `@playwright/mcp-server`):
+
+- Test generation assistance
+- Browser automation context
+- E2E testing patterns
+- Debugging test failures
+
+## Complete VSCode Settings Example
+
+```json
+{
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  },
+
+  "[glimmer-js]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[glimmer-ts]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+
+  "files.associations": {
+    "*.gjs": "glimmer-js",
+    "*.gts": "glimmer-ts"
+  },
+
+  "glint.enabled": true,
+  "glint.configPath": "./tsconfig.json",
+
+  "github.copilot.enable": {
+    "*": true
+  },
+
+  "mcp.servers": {
+    "ember-mcp": {
+      "command": "npx",
+      "args": ["@ember/mcp-server"],
+      "description": "Ember.js MCP Server"
+    },
+    "chrome-devtools": {
+      "command": "npx",
+      "args": ["@modelcontextprotocol/server-chrome-devtools"],
+      "description": "Chrome DevTools MCP Server"
+    }
+  }
+}
+```
+
+## TypeScript Configuration (when using Glint)
+
+Ensure your `tsconfig.json` has Glint configuration:
+
+```json
+{
+  "compilerOptions": {
+    // ... standard TS options
+  },
+  "glint": {
+    "environment": ["ember-loose", "ember-template-imports"]
+  }
+}
+```
+
+## Installation Steps
+
+1. **Install extensions** (prompted automatically when opening project with `.vscode/extensions.json`)
+2. **Install Glint** (if using TypeScript):
+   ```bash
+   npm install --save-dev @glint/core @glint/environment-ember-loose @glint/environment-ember-template-imports
+   ```
+3. **Configure MCP servers** in `.vscode/settings.json`
+4. **Reload VSCode** to activate all extensions and MCP integrations
+
+## Benefits
+
+- **Consistent team setup**: All developers get same extensions
+- **Type safety**: Glint provides template type checking
+- **AI assistance**: MCP servers give AI tools Ember-specific context
+- **Better DX**: Autocomplete, debugging, and testing integration
+- **Reduced onboarding**: New team members get productive faster
+
+## References
+
+- [VSCode Ember Extension](https://marketplace.visualstudio.com/items?itemName=emberjs.vscode-ember)
+- [Glint Documentation](https://typed-ember.gitbook.io/glint/)
+- [MCP Protocol Specification](https://modelcontextprotocol.io/)
+- [Ember Primitives VSCode Setup Example](https://github.com/universal-ember/ember-primitives/tree/main/.vscode)


### PR DESCRIPTION
Makes this repo the source of truth for four skills that until now lived only in the boxel monorepo (three in its root `.agents/skills/`, one in the software-factory package). Once this lands in a tagged release and the boxel-cli plugin sync picks it up, the monorepo copies get deleted — a companion monorepo PR handles that side.

What each skill is and what changed on the way in:

- **boxel-development** — the distilled card-development essentials (`dev-*` references: fitted formats, enumerations, spec usage, template patterns, technical rules, …), designed for token-constrained agent contexts as a lean companion to the full `boxel` skill. Copied at its newest state, which is well ahead of the `Skill/dev-*` card content in this repo (the fitted-formats reference is 152 lines vs the 33-line Skill card) — reconciling those cards against these references is a follow-up for maintainers. Four references had wording tied to the software factory's tooling; they now speak in terms any consumer has (`boxel test`, `boxel parse`, reading the base-realm module for schemas).
- **boxel-workspace-cardinal-rules** — silent-failure traps that pass lint and often indexing before corrupting data with no error: DateField vs DateTimeField value formats, an external URL in a relationship link poisoning a realm's indexing transaction, and the rest. Previously marked "local-only" in the monorepo; these are platform truths every consumer should have.
- **ember-best-practices** — Ember performance and accessibility rules for card authoring, moved as-is.
- **boxel-ui-component-discovery** — search the catalog for a boxel-ui component Spec before hand-rolling any UI primitive. Generalized from its factory-specific phrasing (issue-comment bookkeeping, system-prompt realm lookup, `signal_done`), and the example catalog query was corrected to the search grammar the engine actually accepts (`item.on` type anchor with `item.`-prefixed field paths — the previous `filter.type` shape is rejected).

All four SKILL.md files carry the `boxel: kind: skill` frontmatter and follow the existing `skills/<name>/SKILL.md` + `references/` layout, so the plugin sync picks them up with no script changes.