### PR TITLE
Port stranded workspace distillations into the skill tree

### DIFF
--- a/index.md
+++ b/index.md
@@ -75,6 +75,7 @@ Commands route to these supporting skills. They're documented in `skills/` and a
 ### UI & content
 
 - **`boxel-ui-guidelines/`** — Template UI rules: theme tokens, `@fields` vs `@model`, container queries, layout safety.
+- **`boxel-card-interaction/`** — Decision tree for clicks on rendered child cards: `viewCard` vs `cardComponentModifier` vs anchor, the Interact/Host click inversion, child-owned pointer events, `@mode` hydration.
 - **`boxel-ui-component-discovery/`** — Mandatory catalog search for a boxel-ui component Spec before hand-rolling any UI primitive in a `.gts` template.
 - **`boxel-design/`** — Visual design language, mood, typography, asset direction.
 - **`boxel-file-def/`** — File-typed fields (FileDef, ImageDef, MarkdownDef, PngDef, CsvFileDef).
@@ -87,6 +88,7 @@ Commands route to these supporting skills. They're documented in `skills/` and a
 - **`boxel-environment/`** — Driving the live Boxel app: switch-submode, host commands, search-cards, indexing.
 - **`catalog-listing/`** — Catalog use / install / remix / update operations, plus submission through `SubmissionWorkflowCard`.
 - **`boxel-create-edit-cards/`** — Thin pointer to `boxel-environment/references/card-tool-selection.md` (host-command combos for card create/edit).
+- **`memory-leak/`** — Near-completion lifecycle/allocation audit for builds using timers, media, canvas/WebGL, observers, object URLs, or subscriptions; load on suspected leaks, not every turn.
 
 ### Patterns
 

--- a/skills/boxel-card-interaction/SKILL.md
+++ b/skills/boxel-card-interaction/SKILL.md
@@ -1,0 +1,357 @@
+---
+name: boxel-card-interaction
+description: Use when a card renders OTHER cards and a user will click them — tile grids, search-result lists, dashboards, feeds, embedded media, app-card homes. Decides the click mechanism (viewCard vs cardComponentModifier vs anchor), whether the child owns its own pointer events (audio/video/3D/forms), and the @mode hydration setting. Load before writing any template containing `entry.component`, `c.component`, or a stretched click overlay.
+---
+
+# Card Interaction Contract
+
+_One decision tree for "what happens when a user clicks a rendered card."_
+
+This skill supersedes the scattered click-through advice in
+`boxel/references/delegated-rendering.md`,
+`boxel-ui-guidelines/references/delegated-render-control.md`, and
+`boxel-patterns/patterns/app-card-home-with-search/README.md`. Those files
+now point here. If you find click guidance elsewhere that disagrees with this
+file, this file wins. The behavior below was measured empirically in a live
+app (the interaction-lab harness — see Verification), not just read from
+source.
+
+---
+
+## The organizing idea: click behavior INVERTS between Interact and Host
+
+In **Interact**, the host tracks rendered card elements and binds a bubbling
+`click` (plus `cursor: pointer` and the hover "adorn" chrome) directly onto
+them — so search-result entries AND `<@fields.X />` children are clickable
+**with no wiring at all**, whether you asked or not. In **Host** (published),
+nothing is tracked: zero adorn elements, every cursor `auto`, nothing
+clickable unless you wired it.
+
+Consequences, one per mode:
+
+- Diagnosing **"the tile doesn't open"** → almost always Host (you never
+  wired a click).
+- Diagnosing **"it opens when it shouldn't"** (audio plays → card opens
+  instead) → almost always Interact (the host's own listener fired).
+
+### What the host tracks
+
+| Field type | Tracked (auto-clickable in Interact)? |
+|---|---|
+| `linksTo` / `linksToMany`, any format | **Yes** — except the exact pair `linksTo` + `isolated` |
+| `linksToMany` + `isolated` | **Yes** (the carve-out is `linksTo`-only) |
+| `contains` / `containsMany` (FieldDef children) | Never |
+
+The `linksTo`+`isolated` carve-out exists in the source for index-card
+reasons, is undocumented, and does NOT extend to `linksToMany` — don't build
+on it. The inconsistency is filed as CS-12268.
+
+### Default child formats (when you don't pass `@format`)
+
+`defaultFieldFormats(containingFormat)` decides what a bare `<@fields.x />`
+renders as — and the defaults are asymmetric:
+
+| containing format | FieldDef child | CardDef child |
+|---|---|---|
+| `isolated` / `embedded` / `fitted` | `embedded` | **`fitted`** |
+| `edit` | `edit` | `edit` → rewritten to `fitted` |
+| `atom` | `atom` | `atom` |
+| `markdown` | `markdown` | `markdown` (recurses in-format on purpose) |
+
+Two consequences: a bare `<@fields.linkedCard />` in an isolated template
+gives **fitted, not embedded** — if the child should own its own height
+(list/feed rows), say `@format='embedded'` explicitly. And `getChildFormat`
+rewrites `edit` → `fitted` for CardDef/FileDef children, which is why a
+linked card in an edit form renders as a pill. Because `fitted` is a
+*tracked* format, the default wiring for a linked child is also the
+click-stealing one.
+
+---
+
+## 🚨 Rule 0 — `<a href>` to a card URL is almost always wrong
+
+An anchor whose `href` is a card URL triggers a **full document navigation**
+— verified in *both* modes (`navType: navigate`). The Boxel app — in
+Interact mode *and* on a published Host site — is a live Ember SPA. A
+document navigation tears it down and reboots it: the card stack is lost,
+in-flight edits are lost, and the user watches the whole app reload.
+
+This is the single most common defect in card grids, and it comes from a
+retired claim that "Host mode is a plain HTML/CSS render." **It is not.** The
+published site is the same SPA (`templates/index.gts`), with
+`hostModeService.isActive === true`. It hydrates, it runs JS, and it has a
+working card stack (`addToHostModeStack`).
+
+Use `<a href>` for a card only when leaving the app is the actual intent
+(cross-realm link, external site, "open in new tab" affordance with
+`target="_blank"`).
+
+---
+
+## The one primitive you need: `viewCard`
+
+`this.args.viewCard(cardOrURL, format, opts?)` is the only mechanism that
+works in **both** Interact and Host submodes and never reloads the app:
+
+| Submode | What `viewCard` does |
+|---|---|
+| `interact` | `operatorModeStateService.viewCardOnStack` — pushes a new pane |
+| `host` (published) | `operatorModeStateService.addToHostModeStack` — SPA push, `?hostModeStack=` URL update |
+| `code` | pushes into the preview/playground surface |
+
+It is the mechanism the base library itself uses — see `skill-reference.gts`,
+`skill-set.gts`, and `system-card.gts` in `packages/base`, which all guard on
+existence and call it:
+
+```gts
+private openCard = () => {
+  this.args.viewCard?.(new URL(this.entryId), 'isolated');
+};
+```
+
+Always guard with `?.` — `viewCard` is absent in the static prerender pass and
+in freestyle/test contexts.
+
+---
+
+## Decision tree
+
+Answer in order. Stop at the first match.
+
+```
+Is the child a LIVE surface — audio, video, 3D/model viewer, canvas,
+form, wizard, map, code editor, anything with its own controls?
+│
+├─ YES → The child must defend its own pointer events (see below).
+│        NO overlay, NO whole-card click target in the parent.
+│        Give the parent an explicit `Open ↗` button in parent-owned
+│        chrome (corner, header, or caption) wired to `viewCard`.
+│        Set @mode='none' so the tile is never swapped mid-interaction.
+│
+└─ NO → It is a read-only preview. Continue.
+   │
+   In Interact it is ALREADY clickable (tracked). The wiring below is
+   what makes it work in Host — and what makes the affordance explicit,
+   accessible, and consistent across modes.
+   │
+   Does the whole tile need to be the click target?
+   │
+   ├─ YES → Stretched transparent <button> overlay (inset: 0) on a
+   │        position: relative wrapper, calling `viewCard`.
+   │        NOT an <a href>. NOT a click handler on the <li>.
+   │        sr-only label inside; :focus-visible outline.
+   │
+   └─ NO → A real <button> or the card's own title link, calling `viewCard`.
+
+Then, independently: pick @mode (see hydration table below).
+```
+
+### Live children must stop propagation INSIDE themselves
+
+In Interact the host's click-to-open listener sits on the tracked
+`.field-component-card` element. A click on the child's own Play button,
+slider, or canvas **bubbles up to it** and opens the card. Three measured
+facts:
+
+1. Removing your own stretched overlay is **necessary but not sufficient** —
+   with no overlay at all, clicking Play still opened the card.
+2. The guard must live **inside the child card's template**. A wrapper in the
+   parent is an *ancestor* of the tracked element, so the host's listener has
+   already fired by the time the wrapper sees the event.
+3. `ember-template-lint`'s `no-invalid-interactive` rejects `{{on 'click'}}`
+   on a `<div>`, so route it through a modifier:
+
+```ts
+private containClicks = modifier((element: HTMLElement) => {
+  let swallow = (event: Event) => event.stopPropagation();
+  element.addEventListener('click', swallow);
+  return () => element.removeEventListener('click', swallow);
+});
+```
+
+(`packages/base/skill-set.gts` uses the same defense.) Consequence: a parent
+embedding a live card it does not own has **no remedy** — the fix belongs in
+the child CardDef. Any CardDef whose embedded/fitted template has real
+controls should ship this guard.
+
+### Why a `<button>` overlay, not an `<a>`, and not `<li {{on 'click'}}>`
+
+- `<a href>` → full app reload (Rule 0).
+- `{{on 'click'}}` on `<li>`/`<div>` → `ember-template-lint`
+  `no-invalid-interactive` rejects it.
+- `role="button"` on a wrapper containing `<entry.component />` →
+  `require-presentational-children` rejects it.
+- A transparent `<button>` is keyboard-reachable, screen-reader labelable,
+  and lint-clean.
+
+### Why overlay, not wrap
+
+Wrapping (`<button><entry.component /></button>`) breaks fitted cards: the
+`height: 100%` chain has to propagate through the host's
+`boxel-card-container` chrome, and it breaks silently — the tile collapses to
+zero height. Overlay leaves the card's own layout untouched.
+
+```hbs
+<li class='cell'>
+  <entry.component />
+  <button type='button' class='cell-open' {{on 'click' (fn this.open entry.id)}}>
+    <span class='sr-only'>Open {{entry.displayName}}</span>
+  </button>
+</li>
+```
+
+```css
+.cell { position: relative; }
+.cell-open {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+}
+.cell-open:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 3px;
+}
+.sr-only {
+  position: absolute;
+  width: 1px; height: 1px;
+  padding: 0; margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+```
+
+---
+
+## Detecting mode — `@context.submode`
+
+`CardContext` carries the runtime mode. This is the supported way to branch:
+
+```gts
+get isPublished() {
+  return this.args.context?.submode === 'host';
+}
+```
+
+| Provider | `mode` | `submode` |
+|---|---|---|
+| Operator container (in-app) | `'operator'` | `'interact'` \| `'code'` |
+| Published site (`templates/index.gts`, host active) | `'host'` | `'host'` |
+| Static prerender (`templates/render/html.gts`) | `'host'` | `'host'` |
+
+**🚨 Do NOT branch on `@context.cardComponentModifier` existence.** It is
+always truthy — `field-component.gts` supplies a `NoOpModifier` default when
+the real one isn't provided. `{{#if @context.cardComponentModifier}}` is
+always true and tells you nothing about the mode.
+
+In practice you rarely need to branch at all: `viewCard` covers every submode.
+Reach for `submode` only for genuinely mode-specific chrome (e.g. hiding an
+in-app-only edit affordance on the published site).
+
+---
+
+## `cardComponentModifier` — narrow purpose
+
+```hbs
+<CardContainer {{@context.cardComponentModifier
+  cardId=entry.id format='data' fieldType=undefined fieldName=undefined}}>
+```
+
+This registers the rendered element with the host's card tracker, which powers
+the **native overlay chrome** (hover outline, card menu, drag). Use it when you
+want the host's stock behavior instead of your own affordance. It is a no-op
+outside operator mode.
+
+Do not stack it with an overlay button on the same tile — you get two
+competing click targets and the hover chrome flickers against your own
+hover styles.
+
+---
+
+## Hydration — `@mode` on `searchResultsComponent`
+
+Each result renders as inert prerendered HTML and swaps to a live card
+component on the trigger you choose. **That swap is visible**: chrome and
+adornment fade in as the live component mounts, and out again if the entry
+re-renders. Symptoms of the wrong setting are cosmetic-looking but are
+hydration, not CSS.
+
+| `@mode` | Swaps on | Use for |
+|---|---|---|
+| `'none'` | never | Dense read-only sections; **any section containing live media**; anything where flicker is unacceptable |
+| `'hover'` (default) | mouseenter | Small in-app grids where hover chrome is wanted |
+| `'click'` | click | Rarely — delays the first interaction |
+| `'touch'` | touch | Touch-primary surfaces |
+
+**Two failure modes, opposite directions:**
+
+1. **Flicker** — `'hover'` on a dense grid means every mouse sweep hydrates a
+   row of tiles, each visibly acquiring chrome. Fix: `@mode='none'`.
+2. **Permanently blank tiles** — `'hover'` is the *only* hydration path, so a
+   result whose prerendered fitted HTML is missing or broken stays a white box
+   until someone happens to hover it. Fix: hydrate near-viewport with an
+   `IntersectionObserver` modifier (disconnect after first intersection), keep
+   mouseenter as a fast fallback. Verified in the catalog storefront: nine
+   near-viewport cards per tab hydrated without hover, and grid-cell/title
+   counts matched for the first time.
+
+If a section shows blank tiles, that's #2 — do not "fix" it with CSS.
+
+---
+
+## Cost note
+
+`searchResultsComponent` is live by construction: each section subscribes to
+realm change events, so any create/edit/delete in the realm re-fetches every
+section whose query might match. With autosave-per-keystroke, a Home with four
+live sections can make unrelated edit forms feel sluggish. Keep live sections
+modest; `@mode='none'` reduces per-result cost but not the subscription.
+
+---
+
+## Verification
+
+- **Click a tile in Interact mode.** The stack should gain a pane. If the
+  whole app white-flashes and reboots, you have an `<a href>`.
+- **Click a tile on the published site.** URL should update and a pane push;
+  same reload test applies.
+- **Inspect a media tile.** No absolutely-positioned element should sit above
+  the player. Play/scrub/orbit must work without navigating — in Interact,
+  which is where the host's own listener steals the click.
+- **Sweep the mouse across a grid.** Tiles should not visibly acquire chrome.
+  If they do, set `@mode='none'`.
+- **Load a long grid without touching the mouse.** No permanently blank tiles.
+
+### The live harness
+
+`https://realms-staging.stack.cards/ctse/interaction-lab/` (card
+`InteractionLab/lab`), published for Host-mode testing at
+`https://ctse.staging.boxel.dev/interaction-lab/`. Benches cover every
+mechanism above plus a per-cell format×fieldType tracking matrix, and the
+card prints a live readout of `context.mode` / `submode` / `viewCard`
+presence plus a **boot stamp** that only changes on a full app reload — the
+tell for distinguishing an SPA push from a document navigation. Re-run it
+after platform upgrades (CS-12268).
+
+**Browser-automation gotcha:** the Claude-in-Chrome `computer` tool's
+screenshot space can be **1.2× the page viewport** (e.g. 1301×924 vs
+1084×770). Coordinates from `getBoundingClientRect()` passed straight to
+`left_click` land ~20% off and silently hit nothing — which reads as "the
+bench is inert." Derive coordinates from a screenshot, or multiply page
+coords by `screenshotWidth / window.innerWidth`, and confirm any null result
+a second way (stack length, `elementFromPoint`, a DOM state change) before
+believing it.
+
+---
+
+## Related
+
+- `boxel-ui-guidelines/references/delegated-render-control.md` — how to style
+  the host's injected chrome around a child card (the CSS side).
+- `boxel-patterns/patterns/app-card-home-with-search/README.md` — the query
+  and layout side of result-list sections.
+- `boxel/references/query-systems.md` — building the `SearchEntryWireQuery`.

--- a/skills/boxel-environment/references/indexing-operations.md
+++ b/skills/boxel-environment/references/indexing-operations.md
@@ -318,3 +318,101 @@ Some host commands require a browser context with a Matrix client to persist the
 - Any command whose docstring mentions "saves the card" or "uploads to realm" with a browser-only auth dependency.
 
 CLI-friendly commands (no browser dependency): `get-card-type-schema`, `full-reindex-realm`, `invalidate-realm-identifiers`, `search-cards`, `instantiate-card` for read-only schema introspection.
+
+## The `/_atomic?waitForIndex=true` FieldDef strip (2026-07-16, prod)
+
+Any card instance pushed through `POST /_atomic?waitForIndex=true` — the
+path `realm sync` / workspace-sync and the software factory use — comes
+back with **every `containsMany(<FieldDef>)` entry emptied to `{}`**:
+array length, top-level primitives, and indexed relationship keys survive;
+the compound field data is silently gone. Both `add` and `update` corrupt;
+the same content via `/_atomic` without `waitForIndex`, or via a plain
+`boxel file write`, is preserved byte-for-byte.
+
+- **Detect:** card renders rows/sections with all text blank;
+  `boxel file read` shows `"entries": [{}, {}]`. Every static gate stays
+  green — only the serialized instance (or a render) shows it.
+- **Heal:** re-write the instance raw (`boxel file write`) — full recovery.
+  Note the ping-pong: an out-of-band raw write makes the next sync see a
+  remote/local conflict and re-upload (re-strip) — so healing must happen
+  after EVERY sync, not once.
+- Platform bug, reported upstream: atomic `waitForIndex` strips `containsMany` FieldDef attributes.
+
+## Cross-module instances silently dropped — `touch` is NOT enough (CS-12171 extension)
+
+A new `.gts` type that imports a sibling realm module, plus instances of
+it, can index to NOTHING — no card entry, no file row, empty
+`indexing-errors` — while `get-card-type-schema` says ready and
+`instantiate-card` passes. Unlike the basic CS-12171 race, `boxel file
+touch` does NOT recover this case; file DELETES can re-trigger it for
+previously-indexed dependents. Recovery:
+`npx boxel run-command @cardstack/boxel-host/tools/full-reindex-realm/default --realm <url> --input '{"realmIdentifier":"<url>"}'`.
+Diagnose with a probe pair first (plain type indexes / sibling-importing
+type doesn't). Never `cancel-indexing`.
+
+## Failed module evaluation poisons the module URL (CS-12167)
+
+A module whose evaluation THREW keeps serving the stale error through
+`file write`, `file touch`, and even `full-reindex-realm` — long after the
+source is fixed. First try
+`run-command @cardstack/boxel-host/tools/invalidate-realm-identifiers/default
+--input '{"realmIdentifier":"<url>"}'` (singular key; the effect can lag
+one probe). If the poison survives delete + rewrite (observed), the only
+reliable cure is **renaming the module URL** (new basename, repoint
+`adoptsFrom`, delete the old file). Prove cache-vs-real by pushing the
+identical source under a fresh probe name.
+
+**Bisecting a broken import chain:** a probe module that imports the
+suspect modules with `import * as ns` and
+`throw new Error(Object.keys(ns).join(','))` at module level makes
+`get-card-type-schema` print the real export names — e.g. this exposed
+that staging's `ts-file-def`/`json-file-def` export ONLY named symbols
+(no default) while `image-file-def` has both.
+
+## Successful module schemas can ALSO stay stale (no error required)
+
+The poisoned-URL behavior above has a sibling: after a **structural field
+change** (e.g. a field rename), `get-card-type-schema` can keep returning the
+older *successful* schema even though remote source and lint show the new
+shape, and `invalidate-realm-identifiers` doesn't dislodge it. Same cure:
+move the corrected module to a **fresh URL**, update importers, and remove
+the superseded module only after the fresh URL probes ready. (Observed on
+prod: original URL omitted a renamed field after writes + invalidation; a
+fresh URL exposed it immediately; all 98 definitions then probed ready.)
+
+## Shared-module edits: rewrite consumers in dependency order
+
+Writing an imported shared `.gts` component can leave an already-indexed
+CardDef on its **previous compiled template** even though the new dependency
+source is present in the realm. Rewrite in dependency order:
+**shared component → importing CardDef → affected instance**, then
+close/reopen the card (or hard-refresh the current Boxel stack). Use
+unchanged `file write`, never `file touch`. The tell: production source
+contains your new markers while the user still sees the old surface.
+Platform bug, tracked as CS-12172 (indexed computeds stale after module change).
+
+## CLI quirks worth knowing (verified in production use)
+
+- **`boxel realm push` ignores `.boxel-sync.json`** — a push right after a
+  fresh pull still proposes uploading every file (169/169 in dry-run). For
+  scoped changes use per-file
+  `npx boxel file write <path> --realm <url> --file <path>`; this also
+  sidesteps the `/_atomic` containsMany-strip trap.
+- **`get-card-type-schema` via `npx boxel run-command` takes input key
+  `codeRef`**, not `cardTypeRef`:
+  `--input '{"codeRef":{"module":"<realm>path","name":"ClassName"}}'`.
+- **New staging realms are auth-gated to anonymous HTTP reads** (401
+  "Missing Authorization header") — don't use plain `curl` size checks;
+  `boxel file read` is byte-perfect for media extensions.
+- **`WriteBinaryFileCommand` works from the CLI** for zip-family files that
+  `file write` would mangle:
+  `npx boxel run-command @cardstack/boxel-host/tools/write-binary-file/default
+  --realm <realm> --input '{"path":"…","realm":"<realm>","base64Content":"…",
+  "contentType":"…","useNonConflictingFilename":false}'`
+  (input-key mistakes surface as "Failed to construct 'URL'").
+- **`_touched` residue sweep** — anything ever hit by the deprecated
+  `boxel file touch` carries a permanent `_touched` attribute that makes the
+  card report as diverged from git forever. Heal a git-tracked card by
+  re-writing the repo copy; sweep a realm with:
+  `npx boxel file list --realm "$R" | grep '\.json$' | while read -r f; do
+  [ "$(npx boxel file read "$f" --realm "$R" 2>/dev/null | grep -c _touched)" != 0 ] && echo "RESIDUE: $f"; done`.

--- a/skills/boxel-environment/references/publishing-host-mode.md
+++ b/skills/boxel-environment/references/publishing-host-mode.md
@@ -1,0 +1,161 @@
+# Publishing & host mode — realm publication, portability, and published-site behavior
+
+Everything about `boxel realm publish`, what a published realm actually is,
+and the reference-portability rules that make a card graph survive
+publication. Companion to `indexing-operations.md` (indexing mechanics) and
+the `link-host-mode-paths` pattern (routing rules).
+
+---
+
+## Publish targets and workflow
+
+- `boxel realm publish <source> <published>` rejects any published-realm URL
+  not ending in **`boxel.space` or `boxel.site`** (HTTP 400 "publishedRealmURL
+  must use a valid domain"). `app.boxel.ai/...` URLs are never valid publish
+  targets. Publish under the profile that owns the source realm.
+- **Never use `--no-wait`.** Observed: `--no-wait` returned `status: pending`
+  and left the published realm with a stale modules cache — the entire site
+  served HTTP 500 (`FilterRefersToNonexistentTypeError ... may be caused by a
+  stale modules cache`). Re-running publish *without* `--no-wait` and letting
+  it block to completion recovered the site fully.
+- **A readiness timeout is not a failed publish.** `boxel realm wait-for-ready`
+  timed out (240s against `_readiness-check`) on a publish that had succeeded
+  and was already serving new content. Verify by fetching the published page,
+  not by trusting that poll.
+- **Realm tokens lapse between `npx boxel` invocations in long sessions** —
+  "No realm token available" is fixed by `npx boxel profile switch <profile>`
+  immediately before the command in the same shell operation; it is not a
+  sign of missing access.
+
+## A published realm is a snapshot
+
+Pushing new files to the source realm does **not** update the published copy.
+Re-run the same `boxel realm publish` command (same published URL) after
+every batch of source changes. Symptom of forgetting: the published host
+serves the old modules/templates while `app.boxel.ai` has the new ones, and
+no amount of browser cache-busting helps.
+
+Also: the published **prerendered HTML** can lag a just-pushed change by a
+beat even when the published module and instance JSON are already correct —
+the page hydrates and renders correctly anyway. Check the hydrated DOM, not
+`curl` output, before concluding a change didn't publish.
+
+## Portability: the pre-publish reference audit
+
+Before publishing, scan **every card reachable from each entry point** — not
+just the workspace card — for absolute source-realm URLs in:
+
+- `relationships.*.links.self` (including `cardInfo.theme`, media links,
+  child cards, entry points)
+- `meta.adoptsFrom.module`
+
+Convert same-realm references to explicit relative URLs (`./` or `../`) so
+the publish operation can rewrite the whole graph onto its public mount.
+**Relative is the house rule** — for `adoptsFrom` too. (A staging-Host bug
+can rebase a relative `adoptsFrom` against the parent card instead of the
+child resource in deep `Workspace.entryPoints` graphs — see bug report
+`2026-07-22-nested-adoptsfrom-rebased-against-parent.md`; we assume the
+upstream fix rather than switching to absolute URLs.)
+
+Runtime URLs returned by searches or FileDefs can still retain the source
+realm identity even when the JSON is portable — published-host navigation
+and raw media access must rebase those onto the active published mount
+before use.
+
+**The end-to-end gate:** after republishing, click every pinned entry point
+in an **anonymous** public Host session and verify both the
+`?hostModeStack=` target and the browser logs (no private-realm auth
+failures, no fetch failures). A successful publish command alone is not a
+navigation test; `_publishability` reporting "private external dependencies"
+means the audit above was incomplete.
+
+## In-realm images and files on published pages
+
+An absolute source-realm file URL baked into a string field returns **HTTP
+401 for anonymous visitors** on the published site — the host does not
+rewrite absolute strings. Reference in-realm files through a **relative
+FileDef link** (`linksTo(ImageDef/FileDef)`): the URL is derived from a
+relationship and follows whichever realm serves the card. Details and the
+two gotchas below live in `boxel-file-def/references/using-filedef-in-cards.md`
+("Raw images in published host mode"); the publication-specific facts:
+
+- **A FileDef link cannot live inside a `containsMany` FieldDef** —
+  `linksTo`/`linksToMany` are only valid on a CardDef. Hoist the file links
+  to the owning CardDef as an index-aligned parallel array
+  (`@field shots = linksToMany(ImageDef)` next to
+  `@field demos = containsMany(DemoField)`; render with
+  `(get @model.shots index)`).
+- **The base ImageDef fitted template paints a background-image** (zero
+  intrinsic size) and embedded renders `height:auto`. If a layout depends on
+  an image's intrinsic width, keep a real `<img src={{shot.url}}>` and give
+  the grid column an explicit width — never rely on intrinsic image size.
+
+## Realm root as an app (index card)
+
+For a card that IS the page on a published realm:
+
+1. **Set the card as `index.json`** (same attributes/adoptsFrom as a normal
+   instance, `./module` relative paths). Otherwise the realm root renders the
+   default CardsGrid — visitors land on a card browser, not the app.
+2. **The CardDef must set `static prefersWideFormat = true`** — without it
+   the isolated format renders as a centered narrow "paper" column and the
+   realm's wallpaper shows around it. Put any max-width column *inside* the
+   card's own full-bleed root. See `boxel/references/prefers-wide-format.md`.
+
+Republish after the index swap or the old grid keeps serving.
+
+## Deep links carry state in query params, never hash fragments
+
+The host SPA preserves `?c=CODE` on a published card URL
+(`window.location.search` sees it) but **eats `#CODE` during routing**.
+Encode deep-link state as query params, and strip them with
+`history.replaceState` after reading once (replay hygiene).
+
+## Raw file serving is Accept-header-gated
+
+A **published** realm serves raw file bytes to any request whose `Accept` is
+not `text/html`. `curl` (Accept `*/*`) gets the file with a correct MIME
+type; a browser *navigation* is routed to the card-rendering host app — that
+is the real cause of "Loading card…" pages for `.html` files. The
+`convert-accept-header-qp` middleware accepts `?acceptHeader=*/*` as an
+override for a top-level document, but the ruling is to not serve static
+pages raw at all: rewrite them as cards.
+
+The useful flip side: a `<script src>` request sends `Accept: */*`, so
+**cards can script-load vendored UMD bundles from their own published
+realm** (verified 200 `text/javascript`). Rules that make it robust:
+
+- Push the upstream dist as an ordinary realm file.
+- Keep the URL **explicit** (a card field), not `import.meta.url` — the same
+  card renders from several origins and only the published one serves those
+  bytes without auth. In Interact mode the load fails; degrade to the
+  non-library path rather than breaking the screen.
+- Cache the load promise at module scope, but reset it to `undefined` in the
+  `onerror` handler — a transient failure otherwise poisons every later
+  attempt.
+- A published realm also serves its own `.ts`/`.gts` modules as ES modules
+  to a plain browser-console `import()` — handy for testing a card's
+  internal module without a harness.
+
+## Porting instances between realms
+
+Copied `.json` instances carry a **mix** of relative and absolute
+`adoptsFrom.module` values (one real port: 21 of 32 absolute; no pattern —
+assume a mix). In the target realm the absolute ones keep pointing at the
+*source* realm; if the target credential can't read it, every affected card
+fails with a 401 — but only under `Accept: application/vnd.card+json`
+(full index resolution). `vnd.card+source` reads and `boxel file ls` look
+completely successful.
+
+**Fix:** after copying, rewrite source-realm absolute module URLs to
+relative before pushing (`raw.replace("https://<server>/<owner>/<realm>/", "../")`
+for instances one folder deep), then verify with a `vnd.card+json` fetch.
+Also strip links that will dangle in the target (`cardInfo.theme` to an
+uncopied card poisons the indexing write — Cardinal Rule 13).
+`boxel realm ingest-card` bundles same-realm deps but only works when source
+and target are on the *same realm server*.
+
+## Retiring files
+
+`npx boxel file delete <path> --realm <url>` exists and is the clean way to
+remove files from a realm (no `--yes` flag; it does not prompt).

--- a/skills/boxel-environment/references/searching-and-querying.md
+++ b/skills/boxel-environment/references/searching-and-querying.md
@@ -83,3 +83,25 @@ boxel:
   }
 }
 ```
+
+## CLI search gotchas (distilled 2026-07-17)
+
+Three traps when scripting `npx boxel search`:
+
+1. **`--json` output is a wrapper object, not a bare array.** The shape is
+   `{ "ok": ..., "status": ..., "data": [...] }` — the result count is
+   `len(data)` (`jq '.data | length'`). A bare `len(json.load(...))` returns
+   the wrapper's key count (3) for ANY result set, which reads as a
+   catastrophic index regression and has triggered unnecessary
+   `full-reindex-realm` calls.
+2. **Run from the workspace root.** With cwd outside the workspace tree
+   (e.g. a scratchpad dir), the CLI silently returns `0 total` for queries
+   that return real results from the root — same query, same realm, no
+   error. Check cwd before debugging the query; write output files to
+   absolute paths instead of `cd`-ing.
+3. **The raw wire grammar is deployment-dependent.** Some deployments accept
+   `filter: { type: ref }`, others demand the SearchEntry grammar
+   (`filter: { "item.on": ref }` + `item.`-prefixed field paths) — and it
+   has flipped within a day. Try `filter.type` first and READ the 400 error:
+   it names the accepted anchor. This applies only to raw CLI/endpoint
+   queries — never rewrite CardDef/GTS query code from a CLI 400.

--- a/skills/boxel-file-def/SKILL.md
+++ b/skills/boxel-file-def/SKILL.md
@@ -67,3 +67,4 @@ Need to reference an image / document / file asset?
 - `references/markdowndef-vs-markdownfield.md` — MarkdownDef vs MarkdownField
 - `references/filedef-vs-base64imagefield.md` — FileDef vs Base64ImageField
 - `references/no-inline-binary.md` — Mandatory no-inline-media rule, generated image workflow, and A Million Dreams MP3 FileDef example
+- `references/parser-output-ground-truth.md` — Measured parser output: contentTypes, hashes, epoch timestamps, extension-dependent binary safety, typed-entry coverage

--- a/skills/boxel-file-def/references/parser-output-ground-truth.md
+++ b/skills/boxel-file-def/references/parser-output-ground-truth.md
@@ -1,0 +1,47 @@
+# FileDef parser output — measured ground truth
+
+Measured on realms-staging 2026-07-15 by uploading real files and reading
+back their typed search entries. The authorable schema and the indexed
+reality differ — trust indexed files, not the schema probe.
+
+- **Index-time attrs are invisible to `get-card-type-schema`.** The
+  authorable schema for FileDef subtypes omits `contentSize`, `width`,
+  `height` — indexed search entries DO carry them. Never conclude a parser
+  field doesn't exist from the schema probe alone.
+- **contentType strings:** `.gts` → `text/typescript+glimmer`, `.ts` →
+  `text/typescript`, `.md` → `text/markdown`, `.csv` → `text/csv`,
+  `.json` → `application/json`, `.txt` → `text/plain`, `.svg` →
+  `image/svg+xml`, plus standard `image/jpeg` / `image/gif`.
+- **contentHash** = MD5 of the raw file bytes.
+- **File-entry timestamps** (`createdAt`/`lastModified`) are **epoch
+  seconds (numbers)**, not ISO strings — never copy into `DateTimeField`s
+  (Cardinal Rule 12).
+- **MarkdownDef extras:** `frontmatter.rawContent` (parsed YAML),
+  `excerpt` (first body paragraph), `content` with frontmatter STRIPPED,
+  `cardReferenceUrls`, `fileReferenceUrls`; `title` prefers frontmatter.
+- **Only parser-backed extensions get typed search entries.**
+  `.zip`/`.bin`/`.pdf`/`.wav` upload and serve fine but a `filter.type`
+  search for base `FileDef` returns 0 — no adoption-chain expansion for
+  the base file type. `.gts` appears under both `TsFileDef` and
+  `GtsFileDef`. `linksTo(FileDef)` to non-indexed binaries still resolves.
+- **Binary upload safety is extension-dependent.** `file write` /
+  `realm push` are byte-perfect for recognized media extensions
+  (`.jpg`, `.gif`, `.wav`, `.pdf`, `.mp3`) but **UTF-8-mangle**
+  unrecognized ones (`.zip`, `.bin`, `.mp4`) — U+FFFD inflation ~1.4–1.8×.
+  Universal safe path: `WriteBinaryFileCommand` (base64 via
+  `run-command @cardstack/boxel-host/tools/write-binary-file/default`);
+  darwin ARG_MAX caps that at ~600 KB — chunk or shrink bigger files.
+  `boxel file read` also mangles non-media binaries on the way OUT — a
+  CLI round-trip md5 is NOT a valid storage check; the truth source is
+  the indexed FileDef's `contentSize`/`contentHash`.
+- After a binary REWRITE, dependents' indexed `contentSize`/`contentHash`
+  can lag even through a racing `full-reindex-realm` — `file touch` the
+  linked card JSONs to force recompute.
+- **A byte-perfect PCM WAV is not a safe browser demo** — the default
+  FileDef player errored (`duration: Infinity`) on a valid 44.1 kHz WAV in
+  Safari AND Chrome; AAC-LC/M4A loaded fine. Prefer M4A for browser-facing
+  audio; keep WAV as source with a preview rendition.
+  (Platform bug, reported upstream: valid WAV errors in the default player.)
+
+**Apply when:** building file-metadata cards, mirroring parser fields, or
+debugging why a FileDef search returns nothing.

--- a/skills/boxel-file-def/references/type-hierarchy.md
+++ b/skills/boxel-file-def/references/type-hierarchy.md
@@ -21,3 +21,14 @@ FileDef                          → any file
 **This set is not extensible by Boxel users (currently).** The Boxel project provides these types and only new releases of boxel can add new ones. This may change in the future.
 
 ---
+
+## The linksTo trap — file links need FileDef-typed fields
+
+FileDef is a **separate hierarchy from CardDef**. A generic
+`@field x = linksTo(() => CardDef)` pointed at a file's card presence
+**passes lint, `get-card-type-schema`, and indexing** — then fails at
+render/instantiate with
+`field validation error: tried set PngDef as field 'x' but it is not an instance of CardDef`.
+Type the field `linksTo(() => FileDef)` (import default from
+`https://cardstack.com/base/file-api`) or a specific subtype. A render
+smoke test is the ONLY gate that catches this class of error.

--- a/skills/boxel-file-def/references/using-filedef-in-cards.md
+++ b/skills/boxel-file-def/references/using-filedef-in-cards.md
@@ -101,3 +101,48 @@ Keep the `linksTo(ImageDef)` relationship so publishing carries the file, but do
 For raw tags, use a verified public URL or a root-relative path under the published realm's mount point. Prefer `/published-mount/assets/image.svg` over `./assets/image.svg`: the relative form changes meaning when the page is served both with and without a trailing slash. The built-in FileDef field renderer remains preferable when it owns fetching and rendering.
 
 If card JSON and realm files are current but published HTML still contains an old asset URL, force a full source-realm reindex before publishing again.
+
+The publication-side rules (the `containsMany` hoist, ImageDef's
+background-image intrinsic-size gotcha, publish/republish mechanics) live in
+`boxel-environment/references/publishing-host-mode.md`.
+
+---
+
+## Extensions without a dedicated subtype use generic FileDef
+
+An `.html` realm resource is not indexed as `TextFileDef`. A card that owns
+an HTML source must declare `@field file = linksTo(FileDef)` using the
+default export from `https://cardstack.com/base/file-api`, keeping the
+relationship target as the real extension-backed filename
+(`./example.html`). The renderer can then fetch that FileDef URL as
+authenticated bytes (e.g. into a sandboxed iframe). Do not duplicate the
+markup into a string field or card JSON. Same recipe for any file format
+without a dedicated base FileDef subtype.
+
+---
+
+## Thumbnails: capture chromeless domain surfaces, not card templates
+
+FileDef thumbnail extraction must rasterize a purpose-built, chromeless
+domain surface at its natural aspect ratio — never screenshot an `embedded`
+or `isolated` card template. A card-template screenshot captures headers,
+player controls, inspector rows, and CardContainer chrome that become
+illegible when the image is reused inside fitted tiles. Prefer direct
+canvas/SVG/WebGL capture from source-derived data, normalize to the
+1280×800 thumbnail contract, and center the subject for safe cropping.
+Applies to audio, video, fonts, PDF, MIDI, 3D, large images — any renderer
+whose full template contains UI chrome unrelated to the preview subject.
+
+---
+
+## Sending private realm images to external AI providers
+
+Private realm `ImageDef` URLs require Boxel authentication, so external AI
+providers (OpenRouter/Gemini/etc.) get 401 fetching them. When the user has
+explicitly approved sending the image to a named external provider: read it
+inside Boxel with `ReadBinaryFileCommand`, construct a **transient**
+`data:<mime>;base64,...` request part, and send that — never persist the
+data URL or base64 bytes in card JSON. Treat it as a data-transmission
+boundary: disclose the provider and get explicit approval before enabling
+it. Validate `image/*`, omit SVG and oversized inputs, and isolate
+per-image failures so one bad image doesn't fail the whole request.

--- a/skills/boxel-patterns/patterns/app-card-home-with-search/README.md
+++ b/skills/boxel-patterns/patterns/app-card-home-with-search/README.md
@@ -314,3 +314,21 @@ In Host mode, open dev tools, inspect a rendered tile. Look for an `<a href="htt
 - `searchEntryWireQueryFromQuery` / `SearchEntryWireQuery` — see `runtime-common/index.ts` in the boxel monorepo. Full treatment in `boxel/references/query-systems.md`.
 
 **See also:** [`show-card-list-with-views`](../show-card-list-with-views/) (the lower-level CardsGrid component), [`automate-linked-to-me-lookup`](../automate-linked-to-me-lookup/) (when you need models not just rendered HTML), [`boxel-ui-guidelines/references/delegated-render-control.md`](../../../boxel-ui-guidelines/references/delegated-render-control.md), [`boxel/references/query-systems.md`](../../../boxel/references/query-systems.md).
+
+## Advanced live-surface notes (from the factory-dashboard work, 2026-07-16)
+
+- **Counts without hydration:** KPI/funnel numbers via `page: { size: 1 }`
+  on the wire query + `results.meta.page.total` — one row of HTML, full
+  count.
+- **`@cached` the wire-query getters** so SearchResults keeps ONE live
+  subscription per section instead of resubscribing on every re-render.
+- **`@mode='none'`** keeps results on prerendered HTML (no hover
+  hydration) — right for dashboards; `@mode='hover'` for browsable grids.
+- **Tile clicks in monitor-style cards:** use
+  `this.args.viewCard(url, 'isolated', { openCardInRightMostStack: true })`
+  — never `<a href>` (full-page navigation drops the surface).
+- **Churn warning:** live sections re-run on EVERY realm index change. A
+  realm that is being written every few seconds (sync loops, log writers)
+  makes every section flash its loading state continuously — keep
+  high-frequency writers out of the realm the dashboard watches, and
+  prefer showing stale results over a loading state during revalidation.

--- a/skills/boxel-patterns/patterns/integrate-screenshot-card-format/README.md
+++ b/skills/boxel-patterns/patterns/integrate-screenshot-card-format/README.md
@@ -126,3 +126,17 @@ This gives every instance of `MyCard` two menu items that capture a settled PNG 
 - [`integrate-filedef-generated-image`](../integrate-filedef-generated-image/README.md) — the storage half of any generated-media workflow; explains how `WriteBinaryFileCommand` + `ImageDef` / `PngDef` compose with binary outputs.
 - [`integrate-openrouter-image-generation`](../integrate-openrouter-image-generation/README.md) — lower-level OpenRouter image primitive that `GenerateThumbnailCommand` is built on top of.
 - [`boxel/references/command-invocation-modes.md`](../../../boxel/references/command-invocation-modes.md) — the wider taxonomy of how to expose a Command.
+
+## Async domain renderers: `_screenshot-card` settlement is insufficient (2026-07-17)
+
+The endpoint can return `ready` while the PNG still shows
+`Loading 3D scene…` / `Rendering page…` — any renderer with its own async
+fetch/parse/paint (WebGL, PDF.js, MIDI/SVG, charts, maps, large images)
+outruns settlement. Do not treat `_screenshot-card` as the authoritative
+thumbnail source for those. Instead: register a capture provider only
+after the domain renderer paints, capture the mounted canvas/DOM on
+Extract, normalize to a bounded 1280×800 matte, persist as ImageDef with
+the source hash — and when no detailed renderer mounted, generate an
+honest file poster rather than caching a loading screen. (Platform bug,
+reported upstream: screenshot-card signals ready before the domain
+renderer paints.)

--- a/skills/boxel-patterns/patterns/integrate-three-js-3mf-fabrication/README.md
+++ b/skills/boxel-patterns/patterns/integrate-three-js-3mf-fabrication/README.md
@@ -73,3 +73,20 @@ The accompanying `example.gts` implements the finish distinction, cavity overtra
 **Source:** Anonymized extraction from a live Boxel fabrication tool; identifying source details intentionally omitted.
 
 **See also:** `integrate-three-js-via-cdn` for WebGL lifecycle and cleanup, and `boxel/references/external-libraries.md` for pinned ESM imports.
+
+## Production-extension packages (Bambu) need a fallback loader (2026-07-16)
+
+Three.js `ThreeMFLoader` (0.160) handles core 3MF and same-document
+components but **ignores the production extension's `p:path` on
+`<component>`**. Bambu-style packages keep the build object in
+`3D/3dmodel.model` and the real meshes in `3D/Objects/object_1.model` —
+the stock loader looks up component IDs in the wrong document and throws
+while reading `mesh`. Keep the stock loader as the fast path and fall back
+to a bounded package loader: inflate every `.model` part, scope
+object/material IDs by part path, resolve `p:path`, apply 3MF 3×4
+transforms, reconstruct indexed geometry, preserve base-material colors —
+and frame the camera only after the assembled graph exists. Metadata
+extraction must aggregate every `.model` part and read
+`Metadata/model_settings.config` (named parts, face counts, plates,
+extruders). A successful ZIP parse is NOT proof the stock loader can
+render the package.

--- a/skills/boxel-patterns/patterns/link-command-menu-item/README.md
+++ b/skills/boxel-patterns/patterns/link-command-menu-item/README.md
@@ -89,3 +89,14 @@ Hide entirely when the action doesn't apply. Use `disabled: true` + a tooltip on
 
 - `boxel/references/command-invocation-modes.md` — the menu mode in the wider invocation taxonomy.
 - `command-typed-with-progress` — pair this when the action takes more than a moment.
+
+## Deployment caveat (2026-07-15, realms-staging)
+
+The `[getCardMenuItems]` hook does NOT work on current realms-staging:
+`https://cardstack.com/base/card-menu-items` doesn't exist there, and
+`card-api`'s apparent `getCardMenuItems` export lazily re-exports from a
+`runtime-common` that lacks it — the missing-import Proxy throws only when
+the binding is ACCESSED, so a probe module that merely imports the name
+loads `ready` and lies. UI-invocable commands on that deployment go
+through a **skill card with `boxel.tools` codeRef declarations** instead.
+Verify the hook exists on your target deployment before using this pattern.

--- a/skills/boxel-patterns/patterns/link-host-mode-paths/README.md
+++ b/skills/boxel-patterns/patterns/link-host-mode-paths/README.md
@@ -184,6 +184,29 @@ Host mode normally only applies on `*.boxel.host` (or whatever the deployment's 
 
 For end-to-end test coverage, see `packages/matrix/tests/host-mode.spec.ts` — the spec exercises the published-realm path with realm-json routes.
 
+## Production gotchas (verified 2026-07-20)
+
+- **Write `realm.json` with a raw `boxel file write`, never an atomic/batch
+  push.** `hostRoutingRules` is a `containsMany` FieldDef — exactly the shape
+  `POST /_atomic?waitForIndex=true` strips to `{}` on write. Push it as a
+  single raw file write and *read it back* before publishing.
+- **🔴 The bare path can 404 while the trailing-slash form serves** —
+  `/pricing` → 404, `/pricing/` → 200, same rule, correctly-built routing
+  map (bug report
+  `2026-07-20-host-routing-rule-404s-without-trailing-slash.md`).
+  Authoring consequence: **keep each routed instance at a realm-root id
+  matching its public path** (`pricing.json`, not `SomeDir/pricing.json`) —
+  the card-id fallback answers the bare path, the rule answers the slash
+  form. Declare the rules anyway (they document the path map), but don't
+  rely on them alone until the bug is fixed. Corollary: a routed site can
+  look like it works while its rules do nothing — to prove rules are
+  load-bearing, move an instance and confirm the path still resolves.
+- **Relative nav hrefs depend on the no-slash form.** Pages served at
+  `/pricing` (no trailing slash) make `./` resolve to the realm root — which
+  is what keeps `homeHref: "./"` portable between staging mounts and
+  production. If the canonical URL ever gains a trailing slash, every such
+  href silently retargets to the page itself and must become `../`.
+
 ## See also
 
 - [`app-card-home-with-search`](../app-card-home-with-search/README.md) — the Home card pattern that pairs naturally with a `/` route. Build your Home CardDef first, then add the routing rule.

--- a/skills/boxel-patterns/patterns/live-activity-feed-card/README.md
+++ b/skills/boxel-patterns/patterns/live-activity-feed-card/README.md
@@ -1,0 +1,59 @@
+---
+validated: source-proven
+---
+
+# live-activity-feed-card — A "more alive" activity/log card
+
+**What this gives you:** the working recipe for a live activity feed in the
+Workspace (card-grid v2) design language — status-gated motion, ticking
+clocks, append-only entries with per-entry linked cards/images, newest-first
+display. Proven live: `https://app.boxel.ai/chris/wardrobe/run-log.gts`
+(+ instance `Runs/boxel-wardrobe`) and `chris/jaraoke/run-log.gts` — the
+software factory's run-log live blog.
+
+## The five load-bearing moves
+
+1. **Append-only `containsMany(EntryFieldDef)` with per-entry `linksTo`,
+   newest-first via CSS.** Entries append (stable `entries.N.card` /
+   `entries.N.image` indexed relationship keys); the template renders
+   `{{#each @fields.entries as |Entry|}}<Entry />{{/each}}` inside a
+   `display:flex; flex-direction:column-reverse` container. **NEVER
+   prepend** — index shifts rewrite every existing relationship key.
+   Never use the plural-field wrapper (`<@fields.entries />`) — it defeats
+   the reversal. `justify-content: flex-end` pins content to the visual
+   top when the container is taller than the feed. DOM-first children
+   render at the visual BOTTOM — put a static intro/explainer block before
+   the `{{#each}}` and it becomes the story's start.
+2. **All motion gated on a status attribute.**
+   `data-status={{@model.status}}` on the root; scan line / pulse /
+   arrival-wash CSS only under `[data-status='running']` (plus
+   `{{#if this.running}}` for extra DOM like a throbber). The card visibly
+   "goes quiet" when the run ends. Vocabulary: `softpulse` 2s opacity,
+   `scan` 2.4s gradient sweep (background-size 200% + background-position
+   keyframes), one-shot `animation: arrive 3s ease-out 1` on
+   `.feed > :last-child` (DOM-last = newest).
+3. **Ticking clocks**: `@tracked nowMs = Date.now()` + `setInterval` in the
+   component constructor + `registerDestructor(this, () =>
+   clearInterval(...))`. Elapsed label derives from `startedAt` vs `nowMs`
+   while running, frozen at the last entry's timestamp when done. Per-entry
+   relative labels ("3m ago") use a 30s interval per entry component.
+4. **One `linksTo`, three renders.** The same `card` field renders
+   `@format='embedded'` for payoff moments (ship it!), a sized
+   `@format='fitted'` frame (~460×92, parent owns the box) for reference
+   moments, and `@format='atom'` chips for compact detail links — pick per
+   entry kind. Parent owns all chrome via `:deep(.boxel-card-container)`.
+   Entry images: `image = linksTo(() => FileDef)` — NEVER CardDef-typed
+   (see boxel-file-def/references/type-hierarchy.md).
+5. **CSS-only equalizer throbber**: three `<i>` bars, staggered
+   `animation-delay`, `scaleY` keyframes — reads as "working" next to the
+   NOW item without JS.
+
+Entry FieldDef shape that worked: `kind` (drives glyph + chip color via
+`data-kind`), `at` (DatetimeField), `who` (voice: orchestrator / executor /
+operator), `headline`, `body` (MarkdownField), `imageUrl` fallback +
+`image`/`card` links.
+
+**Writer-side caveat** (if an external process appends): the
+`/_atomic?waitForIndex=true` sync path strips containsMany FieldDef data —
+raw-write the instance after every sync. See
+`boxel-environment/references/indexing-operations.md`.

--- a/skills/boxel-patterns/references/integration-surfaces.md
+++ b/skills/boxel-patterns/references/integration-surfaces.md
@@ -238,6 +238,51 @@ The command returns `fileIdentifier`; assign a new `ImageDef` / `PngDef` with `i
 
 Underlying primitive for any API. Pattern: `integrate-send-request-via-proxy`. Use when OneShot or a specific API recipe does not cover your shape.
 
+**Import path matters:** for AI calls made from a CardDef or a typed realm
+Command, import from `@cardstack/boxel-host/commands/send-request-via-proxy`
+— NOT the similarly named `tools/send-request-via-proxy` path, which is the
+wrong integration boundary for user-facing flows (verified: the Command path
+passes module + runtime gates where the tool path did not).
+
+### Parsing LLM JSON output — staged, never fail-first
+
+Do not turn the first `JSON.parse` failure into an "AI unavailable"
+fallback — malformed JSON is *degraded output* (usually a completion budget
+running out), not proof interpretation was unavailable. Parse in stages:
+strict JSON → structural repair (unterminated strings/arrays/objects,
+trailing commas) → recovery of complete or final-partial records → only then
+a deterministic fallback. Record the recovery mode in the durable Job
+receipt: a completed Job that used fallback is degraded, not fully
+successful, and must stay eligible for rerun from its preserved typed
+inputs.
+
+### Sending private realm images to a provider
+
+External providers can't authenticate to a private realm (401 on ImageDef
+URLs). With explicit user consent, read the bytes via
+`ReadBinaryFileCommand` and send a transient `data:` part — never persisted.
+Details: `boxel-file-def/references/using-filedef-in-cards.md`.
+
+### Web crawl/retrieval is provider-backed userland, not a platform primitive
+
+The inspected Boxel checkout has no Firecrawl (or other crawler) adapter by
+name. Classify web retrieval like image generation: Boxel supplies generic
+authenticated HTTP transport (`SendRequestViaProxy`), an external provider
+performs retrieval, and a reusable userland command supplies typed
+input/output CardDefs plus a durable Job that freezes parameters and
+results. Until a live catalog module is verified (CodeRef, typed IO,
+fixture run, failure behavior, cost receipt), "crawl" is an explicit reuse
+*assumption* — a generic HTTP tool alone does not satisfy a reuse claim.
+
+### Host-mode guest writes — URL-less typed command drafts
+
+Published host-mode cards must not depend on `@saveCard`, a persisted card
+ID, or guest CRUD authority. A guest deserializes the use-case's Command
+input CardDef into the current CardStore with a `lid` and no `id`, edits
+that local card reactively, and passes the typed instance to the domain
+Command — the Command is the only outbound mutation. Applies to anonymous
+forms, purchases, games, chat, RSVP on published sites.
+
 ---
 
 ## 8. ESM CDN libraries

--- a/skills/boxel-patterns/references/libraries.md
+++ b/skills/boxel-patterns/references/libraries.md
@@ -87,6 +87,13 @@ Kanban helpers in `@cardstack/boxel-ui/components`: `KanbanPlane`, `KanbanDragMa
 
 ### `@cardstack/boxel-host` — host-side commands (only available inside the running app)
 
+> **Path rule:** host tool imports are `@cardstack/boxel-host/tools/<kebab-name>`.
+> The pre-rename `@cardstack/boxel-host/commands/…` path NO LONGER EXISTS —
+> imports of it pass every static gate (lint, schema probe, evaluate,
+> indexing) and fail only when a user triggers the code path in the
+> browser. LLMs trained before the rename write `commands/` — correct it
+> on sight.
+
 ```ts
 import UseAiAssistantCommand    from '@cardstack/boxel-host/tools/ai-assistant';
 import SetActiveLLMCommand      from '@cardstack/boxel-host/tools/set-active-llm';

--- a/skills/boxel-ui-guidelines/SKILL.md
+++ b/skills/boxel-ui-guidelines/SKILL.md
@@ -36,6 +36,7 @@ You are a Boxel UI specialist. Whenever you write or review GTS templates and ca
 - `references/prefer-component-apis-write-new-components-when-needed.md` — Prefer Component APIs; Write New Components When Needed
 - `references/use-boxel-ui-components.md` — Use Boxel-UI Components
 - `references/style-budget.md` — Style budget — keep `<style>` blocks ≤40% of file, deduplicate across formats
+- `references/css-escape-hatches.md` — `!important`/`:deep()`/`:global()` are smells: the 4-step legitimacy check, worked verdicts, and the tells
 - **`references/delegated-render-control.md`** — How the host wraps `<@fields.X @format='...' />` chrome (CardContainer + field-component classes) and how the parent overrides it via theme cascade, `:deep()`, or `@displayContainer={{false}}`. **Critical reading when embedding child cards in a parent that has its own design language.** Covers:
   - **Divider strategy is binary** — parent draws lines (AND kills `--boundaries` shadow), OR child halo IS the boundary (no parent borders). Both at once = "drop shadow fighting a thin border."
   - **Picking the format** — fitted vs embedded by who owns the cell size (the most common rendering bug is fitted-with-short-content leaving empty box space).

--- a/skills/boxel-ui-guidelines/references/css-escape-hatches.md
+++ b/skills/boxel-ui-guidelines/references/css-escape-hatches.md
@@ -1,0 +1,73 @@
+# `!important`, `:deep()`, `:global()` — smells, not tools
+
+**Never write (or advise) one of these without first establishing that the
+use case is legitimate.** Reaching for one almost always means a component
+boundary is in the wrong place, a value that should be a token is
+hard-coded, or a platform behavior needs fixing upstream.
+
+These escape hatches all do the same thing: they let one component reach
+across a boundary and overrule another. That works — right up until the
+component on the other side changes, at which point the override silently
+stops matching or silently starts fighting something new. The cost is
+deferred, not avoided.
+
+## The check, before writing one
+
+1. **Whose decision is this, really?** If component A keeps overriding
+   component B's padding/color/width, B probably shouldn't be hard-coding
+   it. Give B a token with a sensible default
+   (`padding-inline: var(--site-gutter, 2.5rem)`) and let A set the token.
+   A token is a *declared* extension point; `:deep()` is an undeclared one.
+2. **Can the value be inherited instead of overridden?** CSS custom
+   properties inherit. Passing a value down beats reaching down to
+   overwrite one.
+3. **Is the thing I'm fighting actually a platform bug?** If a host wrapper
+   resets values it shouldn't, the honest move is a bug report plus a
+   commented workaround — not a silent override that hides the defect.
+4. **Only then**, if the boundary genuinely cannot be changed (third-party
+   markup, host-injected DOM, yielded content carrying the caller's scope
+   id), use the escape hatch — and **comment why**, so the next reader
+   knows it was a decision, not a reflex.
+
+`!important` specifically: if it's needed to win a cascade fight against
+code you own, fix the specificity or the ordering. Legitimate uses are
+close to none.
+
+## Three worked verdicts (from a real refactor)
+
+**Legitimate — yielded content.** A page shell yields page content into its
+`<main>`. Yielded blocks carry the *caller's* scope id, so the shell's
+`<style scoped>` genuinely cannot reach them any other way, and no token
+substitutes because the shell styles structure the caller owns. `:deep()`
+is correct here.
+
+**Not legitimate — neutralizing child-card padding.**
+
+```css
+.resource-body :deep(.boxel-pricing-container),
+.resource-body :deep(.section-layout),
+.resource-body :deep(.legal) { padding-inline: 0; max-width: none; }
+```
+
+One component reaching into three others to undo framing they each
+hard-coded. It enumerates children by class name — a fourth content card
+silently breaks alignment. **The real fix:** each child reads
+`padding-inline: var(--site-gutter, <its current value>)`; the wrapper sets
+`--site-gutter` once; future cards align for free. (Tell-tale artifact:
+`max-width: none` in one rule immediately overridden by `max-width: 52rem`
+in the next — fighting your own override means you're on the wrong layer.)
+
+**Legitimate-with-caveat — working around a host behavior.** The host wraps
+each linked card in `.boxel-card-container` and re-declares theme tokens
+there from that card's own theme, resetting dark-mode values partway down
+the tree. Re-publishing the tokens under private `--site-*` names and
+mapping them back inside the container is defensible — the resetting DOM is
+host-injected — but it's a workaround for a platform gap and must be
+**filed upstream**, not just absorbed.
+
+## The tell
+
+If the override enumerates specific child class names, or you're overriding
+your own override, or the comment would read "because X sets Y and we don't
+want that" — stop. That's the shape of a missing token or a misplaced
+boundary, and the fix is usually smaller than the workaround.

--- a/skills/boxel-ui-guidelines/references/delegated-render-control.md
+++ b/skills/boxel-ui-guidelines/references/delegated-render-control.md
@@ -438,6 +438,37 @@ If the `Event` card's `static embedded` is designed as a one-line list row (icon
 
 When in doubt, read the child's `static embedded` and `static fitted` source — they advertise their intended sizes.
 
+### The default when you pass no `@format` is asymmetric
+
+A bare `<@fields.x />` inside isolated/embedded/fitted renders a **CardDef
+child as `fitted`** and a FieldDef child as `embedded`; `edit` on a linked
+CardDef/FileDef is rewritten to `fitted` (the "pill" in edit forms). If the
+child should own its own height, say `@format='embedded'` explicitly. Full
+table and the click-tracking consequence: `boxel-card-interaction/SKILL.md`.
+
+### Content budgets follow the format contract
+
+`fitted` is a bounded collection format — commonly prerendered for many
+instances into a small parent-owned cell. Apply a type-appropriate
+byte/line/item budget to the source projection **before** turning it into
+HTML; CSS clipping alone is not truncation — the hidden source still
+inflates prerender payloads, DOM size, and render work. `embedded` and
+`isolated` are document-flow formats and must receive the **complete**
+content by default (grow with the document, or scroll inside an explicitly
+bounded viewer) — never reuse the fitted budget there. A fitted preview
+should signal truncation and let the user open embedded/isolated for the
+rest.
+
+### Relationship-rendered components must guard an undefined model
+
+Any `Component<typeof this>` rendered through a `linksTo`/`linksToMany`
+field can run while `@model` is still `undefined` (the lazy-hydration
+window). Guard the whole template with `{{#if @model}}`, optional-chain
+every getter (`this.args.model?.…`), and filter unresolved plural entries
+before traversing. Source lint and realm indexing both pass on the broken
+version — treat a browser render smoke test as required for these
+components.
+
 ## Format-specific recipes
 
 ### Embedded — for grids of related cards (Row & Rail listings, performers, venues)

--- a/skills/boxel-ui-guidelines/references/template-patterns.md
+++ b/skills/boxel-ui-guidelines/references/template-patterns.md
@@ -286,3 +286,12 @@ import { array } from '@ember/helper';
 ```
 
 Use the block parameter in a `data-*` attribute so the key remains explicit. Keep persistent controls, progress, and navigation outside the keyed block: remounting intentionally resets focus and local DOM state inside it. Pair this with the visible resting-state rule above so reduced-motion and canceled animations remain usable.
+
+## BooleanField widens shared-component arg types
+
+A `contains(BooleanField)` model value types as `string | boolean |
+undefined`, so a shared component arg declared `showToggle?: boolean` fails
+glint ("Type 'string | boolean | undefined' is not assignable"). Declare
+shared-component boolean args as `boolean | string | null` (only truthiness
+is read). Same for args that receive a linked card purely for truthiness —
+type them `unknown`, not `boolean`.

--- a/skills/boxel/references/base-field-catalog.md
+++ b/skills/boxel/references/base-field-catalog.md
@@ -160,6 +160,18 @@ The mismatch will surface in the result's `error` / `stackTrace` if it's present
 | `MarkdownField` | `'https://cardstack.com/base/markdown'` | Plain CommonMark string. Renders to HTML in non-edit; textarea editor. |
 | `RichMarkdownField` | `'https://cardstack.com/base/rich-markdown'` | BFM-aware authoring surface with toolbar + slash menu. Use for cards where the body is the primary content (blog posts, docs). |
 
+**RichMarkdownField is consume-not-build.** It already ships computed
+`cardReferenceUrls`/`fileReferenceUrls` (via `extractCardReferenceUrls` /
+`extractFileReferenceUrls` from `@cardstack/runtime-common`), query-based
+`linkedCards = linksToMany(CardDef, { query: { filter: { in: { id:
+'$this.cardReferenceUrls' }}}})` (+ `linkedFiles` matched on `url`),
+transclusion-capable embedded/atom rendering, a verbatim `markdown` format,
+and a compose/source edit mode. Never hand-build a BFM content FieldDef,
+serialize-projection hook, ref extractor, or insert-card chooser. The one
+gap: heading/TOC extraction — document-layer cards still need their own
+`extractHeadings`. Host companions: `markdown-embed-chooser`,
+`apply-markdown-edit`, `copy-card-as-markdown`, `html-to-markdown`.
+
 ## File-backed (linksTo only)
 
 These extend `FileDef` and must be used with `linksTo`, never `contains`. See `boxel-file-def/SKILL.md`.

--- a/skills/boxel/references/container-query-fitted-layout.md
+++ b/skills/boxel/references/container-query-fitted-layout.md
@@ -18,6 +18,12 @@ Matching the wrapper with `100%` sizing is the one sanctioned sizing declaration
 
 Plus: stable grid/flex tracks (no `auto` rows for body content — use `minmax(0, 1fr)`), explicit `overflow: hidden` on every region, and text clamps (`-webkit-line-clamp: N`, `display: -webkit-box`, `-webkit-box-orient: vertical`).
 
+**Columns too, not just rows:** a `.fit` grid that declares only
+`grid-template-rows` lets the *implicit column* size to its content
+min-width and overflow the tile. Always pair it with
+`grid-template-columns: minmax(0, 1fr)` (and `min-width: 0` on
+`white-space: nowrap` flex children).
+
 **Container-query units (`cqw`, `cqh`, `cqmin`, `cqmax`) only resolve relative to an actual container.** If you reach for them on a surface that *isn't* a container (e.g. an `isolated` template not yet wrapped), they silently fall back to the viewport — which is fine on a full-page card but catastrophic in split panes or narrow canvases. Establish a container on the owning surface with `container-type: inline-size` (or `size`) before using cq units inside.
 
 **Parent already drawing the framing?** Direct child embeds often need `@displayContainer={{false}}` on the `<@fields.X />` invocation, OR explicit parent-side chrome styling that kills the host's default `CardContainer` background / padding / boundaries. Otherwise you'll see double framing or cramped rows. See `boxel-ui-guidelines/references/delegated-render-control.md`.

--- a/skills/boxel/references/core-patterns.md
+++ b/skills/boxel/references/core-patterns.md
@@ -163,6 +163,18 @@ Beyond the cardinal rules in `SKILL.md` (contains vs linksTo, exports, three for
 });
 ```
 
+Three more `computeVia` traps, all silent (indexing stays green):
+
+- **Never spread a hydrated FieldDef** (`{ ...row }`) inside `computeVia` —
+  field values live as prototype getters, so the spread yields empty objects
+  and downstream logic sees `undefined` fields with no error. Copy fields
+  explicitly.
+- **Computed fields don't appear in `boxel file read` card JSON** — verify
+  them through `boxel search` docs, not the raw file.
+- **Date/time formatting runs on the indexer's clock** — `toLocaleTimeString`
+  etc. in `computeVia` render in server UTC unless you pass an explicit
+  `timeZone`.
+
 ### 4. Templates with Proper Computation Patterns
 
 ```gts

--- a/skills/boxel/references/lint-workflow.md
+++ b/skills/boxel/references/lint-workflow.md
@@ -107,3 +107,24 @@ For `.gts` work, the minimum validation set is:
 5. Render validation for affected cards/formats when user-facing behavior changed.
 
 If the lint command is genuinely unavailable, say that explicitly, log the CLI gap, and run server-side render validation as a fallback. That fallback is not a clean lint.
+
+## `npx boxel parse` — the type gate lint doesn't run
+
+`boxel file lint` reported "No lint issues found" on a file that
+`npx boxel parse` (glint type-check + JSON document validation) flagged with
+a real type error. Lint is not the type gate — run
+`npx boxel parse --workspace .` before pushing. Usage notes:
+
+- It takes `--workspace <dir>`, not a bare directory argument (a directory
+  path errors with *"must end with one of .gts, .gjs, .ts, or .json"*).
+- On an established realm it reports a **noisy pre-existing baseline**
+  (UrlField→string assignment, missing `ember-modifier` types,
+  `typeof BaseDef` constraint errors). Diff against the baseline rather
+  than expecting zero: grep for your own files and check whether flagged
+  line numbers are ones you actually touched. Don't treat baseline errors
+  as regressions — the authoritative gates remain realm lint, the
+  module-load probe, typed search counts, and `realm indexing-errors`.
+
+One recurring remote-lint fix: `ember/no-empty-glimmer-component-classes`
+fires on template-only classes — convert to
+`const X: TemplateOnlyComponent<Sig> = <template>…</template>;`.

--- a/skills/boxel/references/prefers-wide-format.md
+++ b/skills/boxel/references/prefers-wide-format.md
@@ -14,6 +14,8 @@ export class MyCard extends CardDef {
 
 This is **one of the most-forgotten static properties.** The symptom is always the same: the card looks cramped, the user posts "why is my card so narrow?", and the fix is a one-line addition. Front-load the decision when you create the CardDef.
 
+**🚨 It must be `static`.** Written as an instance field (`prefersWideFormat = true;` without `static`) it is **silently ignored** — the flag is read off the class, nothing errors, and lint does not catch it. Same for the sibling class-level display flags (`displayName`, `icon`, `headerColor`). If a card that should be wide renders narrow, check for a missing `static` before touching CSS.
+
 ---
 
 ## Decision rule

--- a/skills/boxel/references/query-systems.md
+++ b/skills/boxel/references/query-systems.md
@@ -71,6 +71,97 @@ const realms = this.args.model?.[realmURL]
 
 Also: `realmURL` is a Symbol exported from `runtime-common` — import it directly. Don't write `Symbol.for('realmURL')`; that gives you a *different* Symbol that doesn't match what the host injected.
 
+### ⚠️ Raw-HTTP search uses the NEW `item.on` grammar — the legacy shapes 400
+
+The search-entry endpoints (`_federated-search` and the server-side
+search-entries engine; staging confirmed 2026-07-20/22) reject the legacy
+wire shapes: `filter: { type: ref }`, `filter: { on: ref }`, and
+`filter: { item: { on: ref } }` all return
+`HTTP 400: unknown filter member ... the type anchor is item.on`. The parser
+(`packages/runtime-common/search-entry.ts`, `translateFilterNode`) translates
+the new grammar into the legacy one internally:
+
+```jsonc
+// Pure card-type filter — the anchor is a TOP-LEVEL filter key:
+{ "filter": { "item.on": { "module": "<realm>/path/to/module", "name": "MyCard" } } }
+
+// Type + field predicate — field paths take the `item.` prefix INSIDE eq/contains/in/range:
+{ "filter": { "item.on": ref, "eq": { "item.status": "active" } } }
+
+// Sort — same anchor spelling, `by` uses the item. prefix:
+{ "sort": [{ "by": "item.title", "item.on": ref, "direction": "desc" }] }
+```
+
+**The silent trap:** `filter: { eq: { "item.on": ref } }` parses (HTTP 200)
+but treats `on` as a *field path* and matches nothing — the classic
+zero-rows failure, relocated. The anchor must sit at the top level of the
+filter node, never inside an operator.
+
+Notes:
+
+- **`npx boxel search --query '{"filter":{"type":...}}'` still works** — the
+  CLI rewrites the filter into the new shape. Do not infer from CLI success
+  that the same JSON works over raw HTTP, and do not read a raw-HTTP empty
+  result as "the card failed to index" without checking the shape first.
+- `<realm>/_search` does **not** exist (404). `<server>/_federated-search`
+  (QUERY method) requires `{"realms":[...]}` in the body.
+- The CLI has no `--type` flag — pass `--query` with a full filter.
+- The card-owned `Query` type used inside `.gts` (via `getCards` etc.) keeps
+  the legacy `filter: { type: ref }` shape documented above — this section is
+  about the raw HTTP wire format.
+- Fallback verification when a query returns a suspicious empty set:
+  directory listing + per-card fetch
+  (`GET <realm>/<Type>/` with `Accept: application/vnd.api+json`, then
+  `GET <realm>/<Type>/<slug>` with `Accept: application/vnd.card+json`) —
+  N+1 but fails loudly instead of silently returning zero rows.
+
+### Realm scope and server-side bounds are mandatory
+
+Every card-owned search declares both:
+
+1. A non-empty realm or realms list — normally the current card's realm.
+2. `page: { size: N }`, with `N <= 100` for general-purpose hydration.
+
+| Surface | Realm scope |
+|---|---|
+| `store.search(query, realms)` | Required second argument |
+| `getCards(parent, queryThunk, realmsThunk)` | Required third thunk |
+| `@context.searchResultsComponent` | `realms` inside `SearchEntryWireQuery` |
+| Query-backed relationship | `realm: '$REALM'` or explicit `realms` |
+
+Missing and empty realm arrays are not safe idle values. The current host normalizes either one to every available realm, turning a card render or live invalidation into a federated query. If the current realm is not known, return an undefined query or skip the call; do not pass `[]`.
+
+```ts
+import { realmURL, type Query } from '@cardstack/runtime-common';
+
+let realm = this.args.model?.[realmURL]?.href;
+if (!realm) return []; // do not call search with []
+
+return await this.args.context.store.search(
+  {
+    filter: { type: ref },
+    page: { size: 100 },
+  } satisfies Query,
+  [realm],
+);
+```
+
+For the unified result surface, keep the component idle until the realm exists:
+
+```ts
+get query(): SearchEntryWireQuery | undefined {
+  let realm = this.args.model?.[realmURL]?.href;
+  if (!realm) return undefined;
+  return {
+    ...searchEntryWireQueryFromQuery({
+      filter: { type: ref },
+      page: { size: 100 },
+    }),
+    realms: [realm],
+  };
+}
+```
+
 ### Path rule (.gts vs JSON)
 
 - **In .gts files (queries):** Use `./` — you're in the same directory as the module.

--- a/skills/glossary.md
+++ b/skills/glossary.md
@@ -51,7 +51,11 @@ Entry shape: `**Term** — one-sentence definition + (optional) where it's cover
 - **`<@fields.x />`** — Render a field through its FieldDef's view for the current format. The host injects chrome (CardContainer wrapper) around the child.
 - **`@format='isolated'|'embedded'|'fitted'|'edit'|'atom'`** — Override the default format when delegating to a child via `<@fields.x @format='…' />`.
 - **`@model`** — The card/field instance accessed inside a Component. `@model.firstName`, `@model.body`, etc.
-- **`@context`** — Host context object exposing `commandContext`, `prerenderedCardSearchComponent`, `viewCard`, etc.
+- **`@context`** — Host context object (`CardContext`) exposing `toolContext`/`commandContext`, `searchResultsComponent`, `getCard(s)`, `store`, `cardComponentModifier`, and the runtime hints `mode` / `submode`. Note `viewCard` is **not** on `@context` — it arrives as a component arg (`this.args.viewCard`). → `boxel-card-interaction`
+- **`this.args.viewCard(cardOrURL, format, opts?)`** — The default way to open a card from your own button/handler. Pushes onto the stack in Interact **and** published Host mode with no page reload. Guard with `?.` (absent in prerender/freestyle). → `boxel-card-interaction`
+- **`@context.submode`** — `'interact' | 'code' | 'host'` (with `@context.mode`: `'operator' | 'host'`). The supported way to branch on runtime mode. Never branch on `cardComponentModifier` existence — a `NoOpModifier` default makes it always truthy. → `boxel-card-interaction`
+- **`@context.cardComponentModifier`** — Registers a rendered element with the host's card tracker so the stock hover chrome / card menu appears. Narrow purpose; no-op outside operator mode. Not a general click mechanism. → `boxel-card-interaction`
+- **card-URL `<a href>` (anti-pattern)** — An anchor pointing at a card URL causes a full document navigation that reboots the Boxel SPA, discarding the stack and in-flight edits — in Interact *and* on published Host sites. Use `viewCard`. → `boxel-card-interaction`
 - **`<style scoped>`** — Boxel's scoped-CSS block. Must be a direct child of `<template>`; doesn't propagate scope hash into inner GlimmerComponent classes.
 - **`:deep()`** — Pierce the scoped-CSS boundary to style inner host-injected wrappers (`.boxel-card-container`, `.plural-field`, etc.). → `boxel-ui-guidelines/references/delegated-render-control.md`
 - **plural-field wrapper** — `<@fields.X @format='…' />` for a `containsMany`/`linksToMany` injects `.plural-field` + per-item wrappers (`.containsMany-item`, `.linksToMany-itemContainer`) between your grid and the cards. Apply `display: contents` cascade. → `boxel-ui-guidelines/references/delegated-render-control.md`
@@ -103,6 +107,7 @@ The five formats every CardDef can declare via `static <format> = class extends 
 - **silent zero-rows traps** (memorize) — (1) `filter: { on: ref }` with no predicate. (2) Custom sort field without `on:`. (3) `Symbol.for('realmURL')` instead of the canonical Symbol import. (4) Bare `links.self` like `"Foo/bar"` instead of `"./Foo/bar"` — relationship deserialization throws and the parent card silently fails to index. (5) FileDef-typed relationships dropping the file extension (e.g. `"../guide"` instead of `"../guide.md"`) — file exists but parent card fails to type-filter. → `boxel/references/query-systems.md`, `boxel/references/card-references.md`
 - **verified query composition patterns** — Templates that have been confirmed against a live realm + indexer (not just inferred from source): `every: [{ type: ref }, { on: ref, eq: { … } }]`, `… in: { field: [values] } …`, `… range: { field: { gte: … } } …`, `… contains: { cardTitle: … } …`. Build a **validation lab card** in the realm with one `@context.searchResultsComponent` section per pattern you depend on; assert non-empty results in browser QA. → `boxel/references/query-systems.md`
 - **transient federated-search failures** — `npx boxel search` can briefly return `Realms not found` right after a new card landing while the realm-server settles. Read files back, `npx boxel realm wait-for-ready`, validate via `@context.searchResultsComponent`, then retry. → `boxel-environment/references/workflows-and-orchestration.md`
+- **`item.on` grammar (raw HTTP)** — The search-entry endpoints reject the legacy wire shapes; the type anchor is a top-level filter key (`{"filter":{"item.on":ref}}`), field paths take the `item.` prefix inside operators, and `eq:{"item.on":ref}` parses but silently matches nothing. The CLI still accepts `filter:{type}` and rewrites it. → `boxel/references/query-systems.md`
 
 ## 6. Theme system
 
@@ -194,7 +199,8 @@ The dialect Boxel reads and writes. See [bfm.boxel.site](https://bfm.boxel.site)
 - **`RoutingRuleField`** — FieldDef inside `RealmConfig.hostRoutingRules`. Each rule = `{ path: StringField, instance: linksTo(CardDef) }`.
 - **`hostRoutingRules`** — `containsMany(RoutingRuleField)` on `RealmConfig`. Maps clean paths (`/`, `/about`, `/blog`) to cards in the same realm.
 - **same-realm guard** — Defensive read-time filter that drops routing rules pointing at cards in *other* realms. Prevents private-realm card surfacing via a public realm's URL.
-- **published realm** — Realm reachable by anonymous visitors over HTTPS at a public domain.
+- **published realm** — Realm reachable by anonymous visitors over HTTPS at a public domain. A publish is a **point-in-time snapshot** — re-run `boxel realm publish` after source changes. Valid targets end in `boxel.space`/`boxel.site` only; never `--no-wait`. → `boxel-environment/references/publishing-host-mode.md`
+- **publishing-host-mode reference** — Publish workflow, snapshot semantics, the pre-publish relative-reference audit, index-card requirements, deep-link query params, Accept-header-gated raw file serving (incl. script-loading vendored UMD libs), and realm-to-realm porting. → `boxel-environment/references/publishing-host-mode.md`
 - **print and published-output hardening** — Unclip host wrappers in print media, use semantic SVG fill attributes, validate Chromium and Firefox print output, and reindex before checking published HTML. → `boxel-ui-guidelines/references/print-and-published-output.md`
 - **`/_search-prerendered`** — Deployment-specific realm-server endpoint for prerendered HTML. Where exposed, call it with HTTP `QUERY`, not `GET`; otherwise use `npx boxel search --json` and inspect `relationships.html`.
 - **`.boxel-history/`** — Per-realm git repo for change history; managed by `boxel-cli`.
@@ -266,6 +272,11 @@ Direct browser ESM imports for libraries Boxel realms don't bundle.
 
 Available only inside the running Boxel app. Each is a default-export `Command` subclass.
 
+> ⚠️ The path is `tools/` — the pre-rename `@cardstack/boxel-host/commands/…`
+> no longer exists and fails ONLY at runtime (every static gate passes).
+> Correct `commands/` to `tools/` on sight. →
+> `boxel-patterns/references/libraries.md`.
+
 - **AI** — `ai-assistant`, `create-ai-assistant-room`, `open-ai-assistant-room`, `send-ai-assistant-message`, `one-shot-llm-request`, `set-active-llm`, `sync-openrouter-models`, `update-room-skills`.
 - **HTTP / generic** — `send-request-via-proxy`, `authed-fetch`, `search-google-images`.
 - **Card I/O** — `save-card`, `patch-fields`, `patch-card-instance`, `apply-markdown-edit`, `write-text-file`, `copy-card`, `copy-source`, `copy-file-to-realm`, `transform-cards`, `read-file-for-ai-assistant`, `read-card-for-ai-assistant`, `fetch-card-json`, `get-card`, `read-source`, `serialize-card`.
@@ -274,7 +285,7 @@ Available only inside the running Boxel app. Each is a default-export `Command` 
 - **UI / navigation** — `switch-submode`, `show-card`, `show-file`, `preview-format`, `update-code-path-with-selection`, `open-workspace`.
 - **Store** — `store-add`.
 - **Catalog** — `listing-create`, `listing-install`, `listing-remix`, `listing-use`, `listing-generate-example`, `listing-update-specs`, `create-and-open-submission-workflow-card`, `retry-submission-workflow`, `execute-atomic-operations`.
-- **Code-introspection** — `get-card-type-schema`.
+- **Code-introspection** — `get-card-type-schema`. CLI input shape is `{"codeRef":{"module":…,"name":…}}` (not `cardTypeModule`/`cardTypeName`); success returns a schema document — treat "schema returned" as ready.
 
 → `boxel-patterns/references/integration-surfaces.md` §3 for the full annotated table.
 
@@ -318,10 +329,10 @@ Use the namespaced CLI published from the Boxel monorepo through `npx boxel`. Th
 - **`npx boxel realm history`** — List/restore/tag checkpoints.
 - **`npx boxel realm milestone`** — Tag checkpoints.
 - **`npx boxel realm watch <start|stop>`** — Pull server-side realm changes into the local workspace; not a local auto-push loop.
-- **`npx boxel file <read|write|list|touch|delete>`** — Per-file realm operations.
+- **`npx boxel file <read|write|list|delete>`** — Per-file realm operations. To force a reindex, re-write the unchanged file with `file write`; **`file touch` is deprecated here** — it persists a `_touched` key into the card's attributes (residue sweep recipe: `boxel-environment/references/indexing-operations.md`).
 - **`npx boxel file lint <path> --realm <url> --file <local-file>`** — Local lint.
 - **`npx boxel lint [path] --realm <url>`** — Remote lint (single file or whole realm).
-- **`npx boxel parse [path]`** — Local Glint type-check plus JSON document validation.
+- **`npx boxel parse [path]`** — Local Glint type-check plus JSON document validation; catches type errors `file lint` passes. `--workspace <dir>`; diff against the noisy baseline. → `boxel/references/lint-workflow.md`
 - **`npx boxel test`** — Run co-located `.test.gts` QUnit card tests against the local workspace (or `--realm <url>` for cards already on a remote realm). Test-file contract (`runTests()`, `setupCardTest`, `renderCard`, shimmed modules): → `boxel/references/qunit-testing.md`
 - **`npx boxel search '<query-json>' --realms <urls>`** — Federated search.
 - **`npx boxel run-command <command-specifier> [--realm <url>] [--input <json>] [--json]`** — Execute a host command via the prerenderer. CLI invocation mode for Commands. → `automate-run-command-cli`
@@ -361,6 +372,8 @@ Use the namespaced CLI published from the Boxel monorepo through `npx boxel`. Th
 - **`boxel-markdown-format`** — Static `markdown` template output format.
 - **`boxel-create-edit-cards`** — Thin pointer skill; content lives at `boxel-environment/references/card-tool-selection.md` (create/edit tool tables, file naming, path rules).
 - **`boxel-skill-authoring`** — SKILL.md format contract for user-authored skills: `boxel.kind: skill` frontmatter, tool declarations, verify loop.
+- **`boxel-card-interaction`** — One decision tree for "what happens when a user clicks a rendered card": `viewCard` vs `cardComponentModifier` vs anchor, the Interact/Host click inversion, child-owned pointer events, and `@mode` hydration. Empirically verified in a live interaction-lab harness.
+- **`memory-leak`** — Near-completion lifecycle and hot-loop allocation audit for Boxel builds using timers, media, canvas/WebGL, observers, object URLs, fetches, workers, or subscriptions; load on suspected leaks, not every turn. → `memory-leak/SKILL.md`
 - **`boxel-workspace-cardinal-rules`** — Silent-failure trap checklist (DateField vs DateTimeField formats, external URLs in relationship links, `linksToMany` indexed keys, …); partially overlaps the `boxel` skill's cardinal rules under its own numbering.
 - **`boxel-ui-component-discovery`** — Mandatory catalog Spec search before hand-rolling UI primitives; enumerate → one broad `boxel search` query → read `attributes.readMe` → self-audit.
 - **`ember-best-practices`** — Ember.js performance + accessibility rules, 59 `rules/*.md` files across 10 prefix-keyed categories, indexed in its SKILL.md.
@@ -473,6 +486,7 @@ Ready patterns live at `boxel-patterns/patterns/<slug>/{README.md, example.gts}`
 - **`organize-recursive-fielddef`** — Self-referencing FieldDef shape (story → branches → branches).
 - **`organize-sensitive-stub-pair`** — Full sensitive record + safe operational stub kept in sync via a `Sync<X>StubCommand`. `syncIssues` getter surfaces drift; one-way `full → stub` link direction preserves the privacy boundary.
 - **`organize-typed-activity-feed`** — Base `FeedEntry` CardDef + N specialized subclasses. Mixed-type queries hit the base; filtered queries hit a subclass. Replaces single-Entry-with-enum + conditional rendering.
+- **`live-activity-feed-card`** — "More alive" live log/feed card: append-only containsMany + column-reverse (stable `entries.N.*` relationship keys), status-gated motion, ticking clocks with registerDestructor, one linksTo rendered as embed/fitted/atom per moment. Proven by the factory run-log live blog.
 
 ### Planned (no `example.gts` yet — do not chase; fall back to source realms or core skills)
 
@@ -488,6 +502,7 @@ Ready patterns live at `boxel-patterns/patterns/<slug>/{README.md, example.gts}`
 - **`commands/`** — Slash commands (action layer).
 - **`skills/`** — Portable skill tree (this file's home).
 - **`.claude/learnings/`** — Session scratchpad; `/distill-learnings` folds into skill tree.
+- **`.claude/bug-reports/`** — Platform defect/enhancement tickets with repros (minimal repro, expected/actual, workaround, suggested fix). Never distilled; filed upstream instead. `INDEX.md` lists all reports.
 
 ## 27. Acronyms
 

--- a/skills/memory-leak/SKILL.md
+++ b/skills/memory-leak/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: memory-leak
+description: Run a lifecycle and allocation audit near completion of Boxel builds that use animation frames, timers, media, canvas/WebGL, observers, object URLs, fetches, or subscriptions, and whenever a leak is suspected. Do not load this skill on every turn.
+---
+
+# Memory-leak completion gate
+
+Use this once when an interactive or media-heavy build is close to complete, before browser soak testing or publication. Use it immediately when memory growth is reported. Do not make it a per-turn ritual.
+
+This workspace adaptation is based on the `component-memory-leaks` rule in the monorepo's `ember-best-practices` skill. It extends that Ember lifecycle guidance for Boxel cards and GPU-backed Manim/canvas fields.
+
+## Static audit first
+
+Do not open a page known to exhaust memory before completing this audit.
+
+1. Search authored code for `requestAnimationFrame`, timers, event listeners, observers, subscriptions, fetches, workers, object URLs, audio/video contexts, renderers, scenes, geometries, materials, and textures.
+2. Pair every acquired resource with cleanup owned by the same component or modifier:
+   - `requestAnimationFrame` / `cancelAnimationFrame`
+   - `setInterval` / `clearInterval`
+   - `setTimeout` / `clearTimeout`
+   - `addEventListener` / `removeEventListener` using the same function and compatible options
+   - `observe` / `disconnect`, `subscribe` / `unsubscribe`
+   - `fetch(signal)` / `AbortController.abort()`
+   - `URL.createObjectURL` / `URL.revokeObjectURL`
+   - renderer, scene, mobject, geometry, material, texture, worker, and audio-context creation / `dispose`, `terminate`, or `close`
+3. Prefer modifier cleanup functions for DOM-owned resources. Use `registerDestructor` for resources owned by a long-lived Glimmer object without a DOM modifier.
+4. Confirm cleanup is idempotent and runs both when dependencies change and when the card unmounts.
+
+## Hot-loop allocation gate
+
+Treat audio clocks, animation frames, pointer moves, scrolling, and reactive render passes as hot loops.
+
+- Never construct replacement scenes, Mobjects, WebGL geometries/materials, media blobs, or large arrays on every tick.
+- Create persistent render objects once and mutate their bounded numeric state in place.
+- Rebuild only when topology or preset identity changes; dispose the old scene objects before replacement.
+- Cap tracked UI invalidation to the cadence the lesson actually needs (normally 20–30 fps for timeline-driven diagrams), and skip insignificant scalar changes.
+- Ensure a repeated `playing`, mount, or dependency-change event cannot start a second animation loop.
+- Keep runtime objects out of tracked card data and serialized JSON.
+
+## Verification after the static fix
+
+Only after the leak path is removed:
+
+1. Run Boxel file lint locally.
+2. Exercise mount → play → pause → seek → manual mode → resume → unmount with a deliberately short run.
+3. Watch browser-process memory and WebGL resource counts. Stop immediately on monotonic explosive growth.
+4. Repeat the short cycle several times. Memory may fluctuate, but must return to a bounded plateau after garbage collection.
+5. Run the normal render smoke test, then publish.
+
+Document the leak's acquisition path, cleanup owner, hot-loop bound, and verification result in the handoff.


### PR DESCRIPTION
## Summary

Two distillation passes (consolidating ~50 session learnings) were applied to a downstream workspace's *copy* of this skill tree. That copy was later dropped in favor of consuming the boxel-cli plugin — the right call — but it stranded the distilled edits in the workspace's git history. This PR ports them onto current `main` via 3-way merge (base = pre-distill copy, so upstream's own evolution is preserved).

## New skills

- **`boxel-card-interaction/`** — empirically-measured click contract for cards that render other cards: `viewCard` vs `cardComponentModifier` vs anchor, the Interact/Host click-behavior inversion, child-owned pointer events, `@mode` hydration. Verified in a live interaction-lab harness; supersedes the scattered click advice. Also corrects the stale glossary claim that `viewCard` lives on `@context` (it arrives as a component arg).
- **`memory-leak/`** — near-completion lifecycle/allocation audit gate for media/animation-heavy builds.

## New references & patterns

- `boxel-environment/references/publishing-host-mode.md`
- `boxel-ui-guidelines/references/css-escape-hatches.md` (`!important`/`:deep()`/`:global()` are smells — decision ladder)
- `boxel-file-def/references/parser-output-ground-truth.md` (measured parser output per file type)
- `boxel-patterns/patterns/live-activity-feed-card/README.md`

## Notable refinements

- **query-systems** — raw-HTTP search uses the new `item.on` wire grammar (legacy shapes 400, with the silent `eq:{"item.on":…}` zero-rows trap); realm scope + `page` bounds are mandatory (`[]` fans out to a federated query).
- **indexing-operations** — the `/_atomic` batch trap, post-push verification gate, `file touch` `_touched`-residue deprecation, CS-12172 stale-computed recovery.
- **prefers-wide-format** — the flag must be `static` or it is silently ignored.
- Assorted refinements across file-def, ui-guidelines, patterns, lint-workflow, glossary.

## Notes for reviewers

- Workspace-only content (a `boxel-platform-bug-reports` skill, bug-report file cross-references) was kept out or reworded; realm-URL examples follow existing precedent in this repo.
- Per the maintainer note, `Skill/` (in-app assistant cards) has **not** been updated — the two trees will drift on these topics until that port happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)