### PR TITLE
Distill realm-coordination POC learnings into the skill tree

### DIFF
--- a/skills/boxel-patterns/SKILL.md
+++ b/skills/boxel-patterns/SKILL.md
@@ -81,6 +81,10 @@ Ready patterns below can be read and adapted. Each has `patterns/<slug>/README.m
 - `link-flip-card` — CSS-only front/back flip primitive: `perspective` + `transform: rotateY(180deg)` + `backface-visibility: hidden`, driven by a single `@tracked isFlipped`. Flashcards, product reveals, two-sided info cards.
 - `link-host-mode-paths` — Route clean external URLs (`/`, `/about`, `/pricing`) to specific cards via `hostRoutingRules` on the `RealmConfig` card at `/realm.json`. Public realms only; static paths only; same-realm references.
 
+### Collaborate
+
+- `collab-yjs-shared-document` *(README-only)* — Real-time co-editing of a card-backed document (Y.Text code/text pad, or Y.Map structured state like a shared 3D scene) via a Yjs websocket relay. Everyone syncs; a single committer peer holding a realm JWT materializes settled content back into the official card. Includes the seeding rules, read-only role enforcement, and the boundary with ordered commands (scarcity/fairness never goes in a CRDT).
+
 ### Integrate external
 
 - `integrate-openrouter-image-generation` — Preferred image generator. OpenRouter chat completions with `modalities: ['image', 'text']`; default to Gemini image, use ChatGPT/OpenAI image models when requested; persist bytes with `WriteBinaryFileCommand` + `ImageDef`.

--- a/skills/boxel-patterns/patterns/collab-yjs-shared-document/README.md
+++ b/skills/boxel-patterns/patterns/collab-yjs-shared-document/README.md
@@ -1,0 +1,48 @@
+---
+validated: source-proven
+---
+
+# collab-yjs-shared-document — Real-time co-editing where everyone syncs, one identity commits
+
+**What this gives you:** Live multi-user editing of a card-backed document (code/text field, or structured state like a shared 3D scene) using Yjs CRDTs — with the realm staying authoritative. Every participant syncs through a WebSocket relay; a single *committer* peer holding a realm JWT materializes the settled content back into the official card. Everyone can write; one identity records.
+
+**When to use:**
+- Collaborative code/text fields, a shared whiteboard-ish doc, or any "everyone edits, one identity commits" surface over realm cards.
+- Structured shared state (camera position, object properties, table cells) that several browsers mutate concurrently.
+
+When NOT to use:
+- Contested business state — scarcity, arrival-order fairness, sealed bids, auction clocks, inventory decrements. CRDTs merge concurrent writes; they cannot arbitrate them. That state belongs to an ordered command kernel that admits one winner, with the CRDT plane (if any) carrying only the visible content.
+- Ordinary card editing where last-save-wins is acceptable — the built-in edit format already handles that.
+
+**The insight:** Authority is the pen, not the CRDT. The relay is just another Yjs peer and never needs a realm credential; the committing role is a separate outbound peer that runs wherever a CLI profile is authenticated. It seeds an empty room once from the official card, debounces document updates (a few seconds, with a hard cap), and writes the materialized text/JSON back to the realm under its own JWT. Realm permissions, audit, and indexing all keep working because every durable write is an ordinary realm write.
+
+## Recipe shape
+
+Three moving parts:
+
+1. **Relay** — a y-websocket-compatible server (Node daemon, or a Cloudflare Worker + Durable Object with hibernatable WebSockets, one room per DO). Payload-agnostic: the same relay serves Y.Text and Y.Map rooms unchanged.
+2. **Committer** — an outbound-websocket Yjs peer colocated with an authenticated `boxel` CLI profile. Seeds the room from the official card once, then commits settled content back (`boxel file read` / `boxel file write` or the equivalent client calls).
+3. **Card-side client** — the collaborative card bundles yjs + y-websocket + y-indexeddb (+ editor binding) into a single ESM file served from the realm and imported by the card.
+
+Load-bearing details:
+
+- **Role enforcement lives in the relay's message loop.** Decode the Yjs message type yourself: for read-only connections, handle SyncStep1 but DROP SyncStep2/update messages — and reply with a fresh SyncStep1 so a locally-typed viewer converges back to the shared state. Relay awareness for everyone (read-only users still get colored cursors). Client-side, also set `EditorState.readOnly` + `EditorView.editable.of(false)`.
+- **Auth preflight beats in-protocol auth.** A CORS-open `GET /auth?key=` before opening the provider gives clean UX (immediate editor/viewer role assignment); the websocket upgrade re-checks the key anyway. A wrong key should mean "join as viewer with a notice", not a reconnect loop.
+- **Never re-seed a CRDT room by inserting text.** A daemon that re-seeds on restart under a new Yjs clientID makes returning replicas merge their old op history alongside — doubling the document. Persist the encoded doc state (Durable Object storage / a state file) so op history is the durable thing; seed-by-insert must be a once-ever event guarded by "doc is empty after initial sync". Y.Map keys are last-writer-wins, which relaxes this: a racing double-seed converges instead of doubling — still guard on `map.size === 0` after sync.
+- **Skip the settle when the update origin is the seed transact**, or boot commits a no-op revision.
+- **Don't reuse the host's CodeMirror** (`globalThis.__loadCodeMirror`) for yCollab — its context is markdown-wired, and extensions from a second `@codemirror/state` copy are rejected. Bundle codemirror + yjs together so module identities stay consistent.
+- **Pick the Yjs type by shape, not habit.** Most card and surface editing does not need a bespoke CRDT: nested `Y.Map` for stable keyed objects and ordinary cells, `Y.Array` for meaningful order or repeated values, `Y.Text` for plain text, `Y.XmlFragment` (or an editor-native binding) for rich text. Keep cursors, selections, focus, and presence in **awareness**, not the doc. Keep file bytes, computed fields, schema/permissions, and command-owned invariants out of the map entirely.
+- **Map values are peer-supplied input.** Validate every key on read (hex-regex colors, clamped numbers, allowlisted enums) in BOTH the card and the committer before they reach a renderer, inline styles, or the official card.
+- **Split hot state from tracked state.** For pointer-rate updates (camera drag), the render loop reads a plain untracked object, flushed to the Y.Map via a throttled transact (~25 Hz); a tracked snapshot updates only from the map observer. Apply your own echo (`txn.local`) to slow UI state but NOT to the hot path, or the stale echo rubber-bands an in-flight drag.
+- The `no-raf-for-state` lint rule fires on WebGL/canvas paint loops; the rule text itself sanctions an inline `eslint-disable-next-line @cardstack/boxel/no-raf-for-state` for genuine animation loops.
+- `ws://localhost:<port>` is reachable from a published HTTPS boxel.site page (Chrome-family mixed-content exemption for the `localhost` hostname — `127.0.0.1` does not qualify). Fine for local development; deploy the relay behind `wss://` for real multi-device use.
+
+**Boundary with the command plane:** Yjs is the collaborative *content* plane only. Ordered commands keep authority over contested outcomes; audit storage records attribution and outcomes; periodic whole-realm checkpoints provide restore. A snapshot-style writer (AI, sync) submits against an expected realm revision and rebases on conflict rather than forking a server-side head.
+
+**Source:** Extracted from a live realm-collaboration POC workspace — a CodeMirror Y.Text pad settling into an official doc card, and a Three.js Y.Map scene settling into an official scene card, via y-websocket relay + committer daemons. Ask the user for the current realm URL if you want to read the originals.
+
+## See also
+
+- `resource-for-state` — wrapping stateful third-party library objects in a Resource.
+- `integrate-three-js-via-cdn` — the renderer side of the Y.Map scene demo.
+- `boxel/references/lint-workflow.md` — the lint gate, including the `no-raf-for-state` escape hatch.

--- a/skills/boxel-patterns/patterns/collab-yjs-shared-document/README.md
+++ b/skills/boxel-patterns/patterns/collab-yjs-shared-document/README.md
@@ -45,4 +45,4 @@ Load-bearing details:
 
 - `resource-for-state` — wrapping stateful third-party library objects in a Resource.
 - `integrate-three-js-via-cdn` — the renderer side of the Y.Map scene demo.
-- `boxel/references/lint-workflow.md` — the lint gate, including the `no-raf-for-state` escape hatch.
+- `boxel/references/lint-workflow.md` — the lint gate to run before declaring the card done.

--- a/skills/boxel-theme-development/SKILL.md
+++ b/skills/boxel-theme-development/SKILL.md
@@ -44,7 +44,7 @@ Use this for the theme artifact itself. Use `boxel-design` when the task is prim
    - Put logo and mark material in `markUsage`; never invent miscellaneous string fields for brand assets.
    - Put brand colors in `brandColorPalette` and role colors in `functionalPalette`.
    - Put semantic UI values in `rootVariables` and `darkModeVariables`.
-   - Treat shadcn-style tokens as paired surface/foreground contracts: `--primary` is an action fill or indicator, not ordinary text.
+   - Treat shadcn-style tokens as paired surface/foreground contracts: `--primary` is an action fill or indicator, not ordinary text. Same for the muted pair: `--muted` is a pale *surface* (table stripes, wells) and `--muted-foreground` is quiet-but-readable *text*; defining both as dark grays yields dark-on-dark tables in long-form Markdown.
    - Normalize `rootVariables.spacing` for Boxel's runtime `--spacing * 4` mapping. Use `0.25rem` for a 16px `--boxel-sp` base unless there is a deliberate reason to diverge.
    - Put design rationale in `visualDNA` and the DetailedStyleReference markdown fields.
 
@@ -53,6 +53,7 @@ Use this for the theme artifact itself. Use `boxel-design` when the task is prim
    - Include `attributes.cardInfo` for name, summary, thumbnail, and notes.
    - Omit `relationships["cardInfo.theme"]` on Theme cards themselves.
    - Keep `cssImports` as font/link URLs; do not inline `@import` in templates.
+   - Never nest `@media` blocks inside `cssVariables` — the theme parser silently skips those declarations. Dark-mode values belong in `darkModeVariables`.
    - Use absolute URLs for cross-realm theme links unless a relative path has been verified.
 
 6. **Validate.**

--- a/skills/boxel-workspace-cardinal-rules/SKILL.md
+++ b/skills/boxel-workspace-cardinal-rules/SKILL.md
@@ -94,6 +94,17 @@ through the realm server), or read an existing instance of that card already in 
 target realm. Same rule for any published `*.boxel.site` / `*.boxel.build` URL: those
 are Webflow-published sites, not realms — never point realm operations at them.
 
+## 9. Never call `serializeCard(model)` from a render getter
+
+Serializing the card's own model inside a template-facing getter (isolated/embedded
+component code) can appear to work, then fails in two environment-dependent ways:
+in prerender it throws during render (instance-error 500, the card drops out of
+prerendered listings), and in interactive sessions it raises the deterministic
+IDResolver error `conflicting instance id in store` — the serialize path re-registers
+the instance under a conflicting local id. When a template needs a JSON:API-shaped
+view of the card, reconstruct the shape from `@model` fields instead of calling
+`serializeCard`.
+
 Also: many base cards are **default exports**, so the schema ref is `name: "default"`,
 NOT the class name. The base **Theme** card is the default export of
 `https://cardstack.com/base/theme` (the module is `export default Theme`) — query it as

--- a/skills/boxel-workspace-cardinal-rules/SKILL.md
+++ b/skills/boxel-workspace-cardinal-rules/SKILL.md
@@ -94,6 +94,14 @@ through the realm server), or read an existing instance of that card already in 
 target realm. Same rule for any published `*.boxel.site` / `*.boxel.build` URL: those
 are Webflow-published sites, not realms — never point realm operations at them.
 
+Also: many base cards are **default exports**, so the schema ref is `name: "default"`,
+NOT the class name. The base **Theme** card is the default export of
+`https://cardstack.com/base/theme` (the module is `export default Theme`) — query it as
+module `https://cardstack.com/base/theme`, name `default` (querying `#Theme` fails).
+`StructuredTheme` is likewise the default export of `base/structured-theme`. When a
+`get_card_schema` call fails with "named export is a CardDef", retry with `name:
+"default"` before assuming the card is unreachable — do NOT fall back to curling the URL.
+
 ## 9. Never call `serializeCard(model)` from a render getter
 
 Serializing the card's own model inside a template-facing getter (isolated/embedded
@@ -104,11 +112,3 @@ IDResolver error `conflicting instance id in store` — the serialize path re-re
 the instance under a conflicting local id. When a template needs a JSON:API-shaped
 view of the card, reconstruct the shape from `@model` fields instead of calling
 `serializeCard`.
-
-Also: many base cards are **default exports**, so the schema ref is `name: "default"`,
-NOT the class name. The base **Theme** card is the default export of
-`https://cardstack.com/base/theme` (the module is `export default Theme`) — query it as
-module `https://cardstack.com/base/theme`, name `default` (querying `#Theme` fails).
-`StructuredTheme` is likewise the default export of `base/structured-theme`. When a
-`get_card_schema` call fails with "named export is a CardDef", retry with `name:
-"default"` before assuming the card is unreachable — do NOT fall back to curling the URL.

--- a/skills/glossary.md
+++ b/skills/glossary.md
@@ -443,6 +443,9 @@ Ready patterns live at `boxel-patterns/patterns/<slug>/{README.md, example.gts}`
 - **`link-host-mode-paths`** — `realm.json` `hostRoutingRules` to route `/`, `/about`, `/blog` to cards.
 - **`link-command-menu-item`** — Expose a Command as a card menu item via `[getCardMenuItems]`.
 
+### Collaborate
+- **`collab-yjs-shared-document`** — Real-time co-editing over a Yjs websocket relay: everyone syncs, one committer peer with a realm JWT materializes settled content into the official card. Y.Text and Y.Map variants; contested state stays with ordered commands.
+
 ### Make a Command
 - **`command-data-resource`** — `commandData<T>(this, MyCommand)` reactive resource.
 - **`command-with-skill-card-ref`** — Card kicks off an AI conversation with a Skill card pre-loaded.


### PR DESCRIPTION
Chris asked for his new realm-coordination POC learnings in boxel-workspaces to be ported into boxel-skills. The source is boxel-workspaces `main` as of cardstack/boxel-workspaces@214bfd4 — the learnings batch added in cardstack/boxel-workspaces@f4c3b04 and cardstack/boxel-workspaces@c8559c0. This distills the generally-useful parts of that batch into the skill tree:

- New pattern `collab-yjs-shared-document` (README-only): real-time co-editing over a Yjs websocket relay where everyone syncs and a single committer peer holding a realm JWT materializes settled content back into the official card. Covers relay-side role enforcement, seeding rules (Y.Text seed-once vs Y.Map last-writer-wins), the CodeMirror/yjs bundling pitfall, peer-input validation, hot-vs-tracked state splitting, and the boundary with ordered commands (contested state never goes in a CRDT). Registered in the boxel-patterns catalogue and the glossary. From `2026-07-27-yjs-collab-gateway-pattern.md` + the boundary section of `2026-07-27-realm-collaboration-git-yjs-decision.md`.
- Cardinal rule 9: never call `serializeCard(model)` from a render getter — it 500s in prerender and raises the deterministic IDResolver "conflicting instance id in store" error interactively; reconstruct the JSON:API shape from `@model` fields instead. From finding 9 of the yjs learning + the IDResolver bug report.
- Theme development: nested `@media` blocks inside `cssVariables` are silently skipped by the theme parser (dark-mode values belong in `darkModeVariables`), and the `--muted` / `--muted-foreground` surface-vs-text contract. From `2026-07-27-realm-collaboration-theme-muted-contract.md`.

Workspace-specific learnings (deployment records, realm packaging, private realm URLs) stay in boxel-workspaces. Only the realm-coordination batch is ported here; the earlier workspace distillations are already covered by the open stranded-distillations port PR. Per the maintainer note in `index.md`, the `Skill/` tree has not been double-authored here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)