### PR TITLE
Fix card menu docs for getMenuItems API

### DIFF
--- a/Skill/dev-command-development.md
+++ b/Skill/dev-command-development.md
@@ -134,20 +134,19 @@ export class MyCommand extends Command<typeof Input, undefined> {
 ### Menu Integration
 
 ```gts
-import { getCardMenuItems } from '@cardstack/runtime-common';
+import { getMenuItems } from '@cardstack/runtime-common';
 
-[getCardMenuItems](params: GetCardMenuItemParams): MenuItemOptions[] {
+[getMenuItems](params: GetMenuItemParams): MenuItemOptions[] {
   return [{
     label: 'My Action',
     icon: MyIcon,
     action: async () => {
-      await new MyCommand(params.commandContext).execute({
-        cardId: this.id,
-        realm: params.realmURL
+      await new MyCommand(params.toolContext).execute({
+        cardId: this.id
       });
-      await params.saveCard(this);
+      params.cardCrudFunctions.saveCard?.(this.id!);
     }
-  }, ...super[getCardMenuItems](params)];
+  }, ...super[getMenuItems](params)];
 }
 ```
 

--- a/skills/boxel-patterns/SKILL.md
+++ b/skills/boxel-patterns/SKILL.md
@@ -103,7 +103,7 @@ Ready patterns below can be read and adapted. Each has `patterns/<slug>/README.m
 - `command-typed-with-progress` — `Command<Input, Output>` with a typed `progressStep` state machine the invoking component reflects in UI.
 - `command-optimistic-pipeline` — One durable run card per invocation, mutated in place while `SaveCardCommand` writes are queued fire-and-forget. Use for LLM/image/import pipelines that need fast UI and queryable progress logs.
 - `command-atomic-install` — Transactional realm install with `PlanBuilder` + `planModuleInstall` + `planInstanceInstall` + `ExecuteAtomicOperationsCommand`. The canonical catalog-install pattern.
-- `link-command-menu-item` — Expose a Command as a card menu item via `[getCardMenuItems]`. The card-native way to surface card-scoped actions.
+- `link-command-menu-item` — Expose a Command as a card menu item via `[getMenuItems]`. The card-native way to surface card-scoped actions.
 - `automate-run-command-cli` — Invoke a Command from the shell via `npx boxel run-command <spec> --input '{}'`, pairing with a typed run card for queryable history. Batch jobs, cron, CI gates.
 
 For the wider taxonomy (direct call, reactive resource, menu, typed progress, optimistic pipeline, AI processor, multi-turn assistant, CLI script, atomic install) and a single Command class exposed via every mode, see [`boxel/references/command-invocation-modes.md`](../boxel/references/command-invocation-modes.md).

--- a/skills/boxel-patterns/patterns/integrate-screenshot-card-format/README.md
+++ b/skills/boxel-patterns/patterns/integrate-screenshot-card-format/README.md
@@ -68,18 +68,20 @@ You don't see any of this from the consumer side — `await new ScreenshotCardCo
 To make "Screenshot this card" a right-click affordance on every CardDef, compose with the [`link-command-menu-item`](../link-command-menu-item/README.md) pattern. The action body calls `ScreenshotCardCommand` with `this` as the card and a fixed format (or branches on a sub-menu):
 
 ```ts
-import { getCardMenuItems, type GetCardMenuItemParams, type MenuItemOptions } from '@cardstack/runtime-common';
+import { getMenuItems } from '@cardstack/runtime-common';
+import { type GetMenuItemParams } from 'https://cardstack.com/base/menu-items';
+import { type MenuItemOptions } from '@cardstack/boxel-ui/helpers';
 import ScreenshotCardCommand from '@cardstack/boxel-host/tools/screenshot-card';
 import CameraIcon from '@cardstack/boxel-icons/camera';
 
 class MyCard extends CardDef {
-  [getCardMenuItems](params: GetCardMenuItemParams): MenuItemOptions[] {
+  [getMenuItems](params: GetMenuItemParams): MenuItemOptions[] {
     return [
       {
         label: 'Screenshot isolated',
         icon: CameraIcon,
         action: async () => {
-          let result = await new ScreenshotCardCommand(params.commandContext)
+          let result = await new ScreenshotCardCommand(params.toolContext)
             .execute({ card: this as any, format: 'isolated' });
           // Optionally show toast with result.imageDefUrl
         },
@@ -88,11 +90,11 @@ class MyCard extends CardDef {
         label: 'Screenshot embedded',
         icon: CameraIcon,
         action: async () => {
-          await new ScreenshotCardCommand(params.commandContext)
+          await new ScreenshotCardCommand(params.toolContext)
             .execute({ card: this as any, format: 'embedded' });
         },
       },
-      ...super[getCardMenuItems](params),
+      ...super[getMenuItems](params),
     ];
   }
 }
@@ -107,7 +109,7 @@ This gives every instance of `MyCard` two menu items that capture a settled PNG 
 - **Permission check is strict.** The command saves to the target card's realm. If the current user can't write there, it fails fast — no silent fallback to the user's home realm.
 - **Output lands in `Screenshots/` of the target's realm, not the caller's.** If you screenshot a third-party realm's card and you have write access, the PNG lives over there.
 - **Filenames are slug + uuid.** `<lowercased-last-url-segment>-<8-char-uuid>.png`. Stable for known cards, unique on collisions.
-- **Long renders block the request.** The realm-server polls the job until completion (Puppeteer needs to settle the page). On a slow card or under load, expect a few seconds. Wrap in `@tracked isRunning` / show a spinner; don't `await` inside `getCardMenuItems` without surfacing progress.
+- **Long renders block the request.** The realm-server polls the job until completion (Puppeteer needs to settle the page). On a slow card or under load, expect a few seconds. Wrap in `@tracked isRunning` / show a spinner; don't `await` inside `getMenuItems` without surfacing progress.
 - **commandContext must exist.** Only available in host interact mode — the prerenderer / SSR context doesn't have a live host. Feature-detect with `this.args.context?.commandContext` before calling.
 - **`listing-create` does not use this command.** The catalog's listing-creation flow uses `GenerateThumbnailCommand` (AI-generated stylized icon, not a real screenshot). Use `ScreenshotCardCommand` when you want the actual rendered card, not an interpretation.
 

--- a/skills/boxel-patterns/patterns/integrate-thumbnail-card-ai/README.md
+++ b/skills/boxel-patterns/patterns/integrate-thumbnail-card-ai/README.md
@@ -133,20 +133,22 @@ Vary by:
 Pair with [`link-command-menu-item`](../link-command-menu-item/README.md) to make "Regenerate thumbnail" a right-click on any card:
 
 ```ts
-import { getCardMenuItems, type GetCardMenuItemParams, type MenuItemOptions } from '@cardstack/runtime-common';
+import { getMenuItems } from '@cardstack/runtime-common';
+import { type GetMenuItemParams } from 'https://cardstack.com/base/menu-items';
+import { type MenuItemOptions } from '@cardstack/boxel-ui/helpers';
 import GenerateThumbnailCommand from '@cardstack/boxel-host/tools/generate-thumbnail';
 import { realmURL } from 'https://cardstack.com/base/card-api';
 import WandIcon from '@cardstack/boxel-icons/wand';
 
 class MyCard extends CardDef {
-  [getCardMenuItems](params: GetCardMenuItemParams): MenuItemOptions[] {
+  [getMenuItems](params: GetMenuItemParams): MenuItemOptions[] {
     return [
       {
         label: 'Generate AI thumbnail',
         icon: WandIcon,
         action: async () => {
           let prompt = /* derive from this.title, theme, or a fixed template */;
-          await new GenerateThumbnailCommand(params.commandContext).execute({
+          await new GenerateThumbnailCommand(params.toolContext).execute({
             prompt,
             targetRealmIdentifier: this[realmURL]!.href,
             targetPath: 'Thumbnails',
@@ -157,7 +159,7 @@ class MyCard extends CardDef {
           // chrome updates next render — no manual saveCard needed here.
         },
       },
-      ...super[getCardMenuItems](params),
+      ...super[getMenuItems](params),
     ];
   }
 }

--- a/skills/boxel-patterns/patterns/link-command-menu-item/README.md
+++ b/skills/boxel-patterns/patterns/link-command-menu-item/README.md
@@ -2,38 +2,38 @@
 validated: source-proven
 ---
 
-# link-command-menu-item — Expose a Command as a card menu item via `[getCardMenuItems]`
+# link-command-menu-item — Expose a Command as a card menu item via `[getMenuItems]`
 
 **What this gives you:** A right-click / overflow-menu entry on a card that runs a host Command with the card's data as input. The native Boxel menu chrome handles icon, label, keyboard navigation, and disabled states.
 
 **When to use:** The Command is an *action the user takes on this specific card* — "Generate Avatar", "Send to Printer", "Reindex Linked Children", "Export as PDF", "Refresh from Source". Anywhere you'd otherwise sprinkle bespoke buttons onto the isolated template, route through the menu instead — it keeps the card's visual surface clean and gives the user a consistent place to find actions.
 
-**The insight:** `getCardMenuItems` is a symbol the host calls on each card to compose its menu. Override the symbol on your CardDef (call `super[getCardMenuItems](params)` to keep the host's defaults), return an array of `{ label, icon, action }` entries. `params.commandContext` is what your action passes to `new MyCommand(params.commandContext)`; `params.realmURL` and `params.saveCard` give you the rest.
+**The insight:** `getMenuItems` is a symbol the host calls on each card to compose its menu. Override the symbol on your CardDef (call `super[getMenuItems](params)` to keep the host's defaults), return an array of `{ label, icon, action }` entries. `params.toolContext` is what your action passes to a host Command; `params.cardCrudFunctions` supplies host-aware create/view/edit/save/delete operations.
 
 ## Recipe shape
 
 ```ts
-import { getCardMenuItems } from '@cardstack/runtime-common';
-import { type GetCardMenuItemParams } from 'https://cardstack.com/base/card-menu-items';
+import { getMenuItems } from '@cardstack/runtime-common';
+import { type GetMenuItemParams } from 'https://cardstack.com/base/menu-items';
 import { type MenuItemOptions } from '@cardstack/boxel-ui/helpers';
 import MyIcon from '@cardstack/boxel-icons/sparkles';
 import MyCommand from './my-command';
 
 export class MyCardDef extends CardDef {
-  [getCardMenuItems](params: GetCardMenuItemParams): MenuItemOptions[] {
+  [getMenuItems](params: GetMenuItemParams): MenuItemOptions[] {
     return [
       {
         label: 'My Action',
         icon: MyIcon,
         action: async () => {
-          await new MyCommand(params.commandContext).execute({
+          await new MyCommand(params.toolContext).execute({
             cardId: this.id,
           });
-          await params.saveCard(this);
+          params.cardCrudFunctions.saveCard?.(this.id!);
         },
       },
       // Host defaults LAST so user-actions show on top.
-      ...super[getCardMenuItems](params),
+      ...super[getMenuItems](params),
     ];
   }
 }
@@ -41,18 +41,18 @@ export class MyCardDef extends CardDef {
 
 ## Conventions
 
-- **Always `...super[getCardMenuItems](params)`** — preserves the host's default entries (Open, Copy, Delete, etc.). Forgetting this strips the menu.
+- **Always `...super[getMenuItems](params)`** — preserves the host's default entries (Open, Copy, Delete, etc.). Forgetting this strips the menu.
 - **Order: custom items first, defaults last.** Users read top-down; card-specific actions belong above the generic ones.
 - **Icon comes from `@cardstack/boxel-icons/<name>` or `@cardstack/boxel-ui/icons/<name>`.** Match the existing menu style — small, single-color, Lucide/Tabler-flavored.
 - **Label is verb-first.** "Generate avatar" not "Avatar generation". Title-cased like other menu items.
-- **`action` is async.** Always `await` the Command, then `await params.saveCard(this)` if the action mutates fields on the card itself.
+- **`action` may be async.** Await Commands that perform work. If the action mutates the card itself, call `params.cardCrudFunctions.saveCard?.(this.id!)` afterward.
 
 ## Conditional items
 
 Return entries conditionally to hide or disable based on card state:
 
 ```ts
-[getCardMenuItems](params: GetCardMenuItemParams): MenuItemOptions[] {
+[getMenuItems](params: GetMenuItemParams): MenuItemOptions[] {
   const items: MenuItemOptions[] = [];
   if (this.id) {
     // Only saved cards can be exported.
@@ -61,7 +61,7 @@ Return entries conditionally to hide or disable based on card state:
   if (!this.publishedAt) {
     items.push({ label: 'Publish', icon: PublishIcon, action: async () => { /*…*/ } });
   }
-  return [...items, ...super[getCardMenuItems](params)];
+  return [...items, ...super[getMenuItems](params)];
 }
 ```
 
@@ -75,10 +75,14 @@ Hide entirely when the action doesn't apply. Use `disabled: true` + a tooltip on
 
 ## Gotchas
 
-- **Forgetting `...super[getCardMenuItems](params)`** strips the host defaults silently — the user loses Open/Copy/Delete and won't know why.
+- **Forgetting `...super[getMenuItems](params)`** strips the host defaults silently — the user loses Open/Copy/Delete and won't know why.
 - **Heavy work inside `action`** blocks the menu close animation. Kick off the work, close the menu, surface progress via a tracked field or toast.
 - **`this` inside `action`** refers to the CardDef instance because the arrow function is captured in the closure. If you write a regular method, you lose the binding.
-- **Saving without `params.saveCard`** skips the host's permission and indexing handling. Prefer `params.saveCard(this)` over constructing `new SaveCardCommand(...)` yourself.
+- **Saving outside `params.cardCrudFunctions`** skips the menu host's store and permission handling. Prefer `params.cardCrudFunctions.saveCard?.(this.id!)` for a card already loaded in the host.
+
+## API version note
+
+The platform renamed `[getCardMenuItems]` to `[getMenuItems]` in January 2026 (`cardstack/boxel` commit `2b018231e6`). The associated type and base module are now `GetMenuItemParams` and `https://cardstack.com/base/menu-items`. The old named import can pass static lint but fails when the realm module is evaluated, so use the names in this recipe exactly.
 
 ## Source
 

--- a/skills/boxel-patterns/patterns/link-command-menu-item/example.gts
+++ b/skills/boxel-patterns/patterns/link-command-menu-item/example.gts
@@ -5,17 +5,17 @@ import {
   contains,
 } from 'https://cardstack.com/base/card-api';
 import StringField from 'https://cardstack.com/base/string';
-import { getCardMenuItems } from '@cardstack/runtime-common';
-import { type GetCardMenuItemParams } from 'https://cardstack.com/base/card-menu-items';
+import { getMenuItems } from '@cardstack/runtime-common';
+import { type GetMenuItemParams } from 'https://cardstack.com/base/menu-items';
 import { type MenuItemOptions } from '@cardstack/boxel-ui/helpers';
 import MapPinIcon from '@cardstack/boxel-icons/map-pin';
 import BuildingIcon from '@cardstack/boxel-icons/building';
 
 // 🧩 PATTERN: expose card-scoped actions as menu items.
 //
-// The host calls `[getCardMenuItems]` on every CardDef when it composes
+// The host calls `[getMenuItems]` on every CardDef when it composes
 // the card's right-click / overflow menu. Override the symbol on your
-// class, spread `super[getCardMenuItems](params)` to keep the host's
+// class, spread `super[getMenuItems](params)` to keep the host's
 // defaults (Open, Copy, Delete, ...), and return your own entries.
 
 export class Destination extends CardDef {
@@ -23,8 +23,8 @@ export class Destination extends CardDef {
 
   @field name = contains(StringField);
 
-  [getCardMenuItems](params: GetCardMenuItemParams): MenuItemOptions[] {
-    let hostItems = super[getCardMenuItems](params);
+  [getMenuItems](params: GetMenuItemParams): MenuItemOptions[] {
+    let hostItems = super[getMenuItems](params);
 
     return [
       {
@@ -37,7 +37,7 @@ export class Destination extends CardDef {
             cardThumbnailURL:
               'https://images.unsplash.com/photo-1502602898657-3e91760cbb34?w=400',
           });
-          await params.saveCard(this);
+          params.cardCrudFunctions.saveCard?.(this.id!);
         },
       },
       {
@@ -50,7 +50,7 @@ export class Destination extends CardDef {
             cardThumbnailURL:
               'https://images.unsplash.com/photo-1496442226666-8d4d0e62e6e9?w=400',
           });
-          await params.saveCard(this);
+          params.cardCrudFunctions.saveCard?.(this.id!);
         },
       },
       // Host defaults LAST so user-actions show on top.
@@ -62,9 +62,8 @@ export class Destination extends CardDef {
 // --- Notes ---
 //
 // `params` carries everything you need to write back:
-//   - params.commandContext  → pass to `new MyCommand(params.commandContext)`
-//   - params.saveCard(card)  → host-aware save (permissions, indexing)
-//   - params.realmURL        → realm scope for queries/writes
+//   - params.toolContext         → pass to `new MyCommand(params.toolContext)`
+//   - params.cardCrudFunctions   → host-aware create/view/edit/save/delete
 //
 // For a heavier action, swap the body of `action` for a Command
 // invocation:
@@ -72,10 +71,10 @@ export class Destination extends CardDef {
 //   import MyExpensiveCommand from './my-expensive-command';
 //   ...
 //   action: async () => {
-//     await new MyExpensiveCommand(params.commandContext).execute({
+//     await new MyExpensiveCommand(params.toolContext).execute({
 //       cardId: this.id,
 //     });
-//     await params.saveCard(this);
+//     params.cardCrudFunctions.saveCard?.(this.id!);
 //   },
 //
 // Pair with command-typed-with-progress when the action takes more

--- a/skills/boxel/references/command-development.md
+++ b/skills/boxel/references/command-development.md
@@ -175,20 +175,19 @@ Pattern: `boxel-patterns/patterns/command-optimistic-pipeline`.
 ### Menu Integration
 
 ```gts
-import { getCardMenuItems } from '@cardstack/runtime-common';
+import { getMenuItems } from '@cardstack/runtime-common';
 
-[getCardMenuItems](params: GetCardMenuItemParams): MenuItemOptions[] {
+[getMenuItems](params: GetMenuItemParams): MenuItemOptions[] {
   return [{
     label: 'My Action',
     icon: MyIcon,
     action: async () => {
-      await new MyCommand(params.commandContext).execute({
-        cardId: this.id,
-        realm: params.realmURL
+      await new MyCommand(params.toolContext).execute({
+        cardId: this.id
       });
-      await params.saveCard(this);
+      params.cardCrudFunctions.saveCard?.(this.id!);
     }
-  }, ...super[getCardMenuItems](params)];
+  }, ...super[getMenuItems](params)];
 }
 ```
 

--- a/skills/boxel/references/command-invocation-modes.md
+++ b/skills/boxel/references/command-invocation-modes.md
@@ -12,7 +12,7 @@ _TODO: fill in the recommended use cases + worked snippets for each mode. The sk
 |---|---|---|
 | **Direct call** — `new MyCommand(ctx).execute(input)` | _TODO_ Inside another Command, inside a tracked task, inside an action method. The lowest-level form. | `boxel/references/command-development.md` (opening sections) |
 | **Reactive resource** — `commandData<T>(this, MyCommand)` | _TODO_ A Glimmer component needs the command's *result*, rendered reactively when it resolves. Replaces hand-rolled `restartableTask` + `@tracked`. | `command-data-resource` |
-| **Card menu item** — `[getCardMenuItems]` | _TODO_ The Command is an action the user takes *on a specific card* — generate avatar, send to printer, refresh from source. | `link-command-menu-item` |
+| **Card menu item** — `[getMenuItems]` | _TODO_ The Command is an action the user takes *on a specific card* — generate avatar, send to printer, refresh from source. | `link-command-menu-item` |
 | **Typed run card with progress** — `@tracked progressStep` on the Command class | _TODO_ The user wants to watch a long-running operation (upload, AI call, migration) progress through named phases. | `command-typed-with-progress` |
 | **Optimistic run-card pipeline** — durable run card with steps + logs | _TODO_ Multi-step workflow (LLM call → file write → save → index) that needs an auditable history record. The card *is* the history. | `command-optimistic-pipeline` |
 | **One-shot AI processor** — wraps `OneShotLlmRequestCommand` | _TODO_ Single LLM call, no conversation. Classification, summarization, JSON extraction from a card. | `integrate-one-shot-llm` |
@@ -43,7 +43,7 @@ _TODO: a single canonical `MyCommand` class shown wired up to each mode. This is
 
 **Card menu item:**
 ```ts
-// _TODO: [getCardMenuItems](params) returning { label, icon, action } that calls execute_
+// _TODO: [getMenuItems](params) returning { label, icon, action } that calls execute_
 ```
 
 **CLI script:**

--- a/skills/glossary.md
+++ b/skills/glossary.md
@@ -278,7 +278,7 @@ Available only inside the running Boxel app. Each is a default-export `Command` 
 
 → `boxel-patterns/references/integration-surfaces.md` §3 for the full annotated table.
 
-**Command invocation modes** — A Command can be exposed via direct call, reactive resource (`commandData<T>`), card menu item (`[getCardMenuItems]`), typed progress, optimistic pipeline (run-card history), one-shot AI processor, multi-turn AI assistant, CLI script (`npx boxel run-command`), or atomic transactional install. → `boxel/references/command-invocation-modes.md`
+**Command invocation modes** — A Command can be exposed via direct call, reactive resource (`commandData<T>`), card menu item (`[getMenuItems]`), typed progress, optimistic pipeline (run-card history), one-shot AI processor, multi-turn AI assistant, CLI script (`npx boxel run-command`), or atomic transactional install. → `boxel/references/command-invocation-modes.md`
 
 ## 19. Boxel UI (`@cardstack/boxel-ui`)
 
@@ -441,7 +441,7 @@ Ready patterns live at `boxel-patterns/patterns/<slug>/{README.md, example.gts}`
 - **`link-view-transition`** — `document.startViewTransition` + `view-transition-name`.
 - **`link-flip-card`** — CSS-only front/back flip primitive.
 - **`link-host-mode-paths`** — `realm.json` `hostRoutingRules` to route `/`, `/about`, `/blog` to cards.
-- **`link-command-menu-item`** — Expose a Command as a card menu item via `[getCardMenuItems]`.
+- **`link-command-menu-item`** — Expose a Command as a card menu item via `[getMenuItems]`.
 
 ### Make a Command
 - **`command-data-resource`** — `commandData<T>(this, MyCommand)` reactive resource.


### PR DESCRIPTION
## Summary
- update card menu examples from getCardMenuItems to getMenuItems
- update GetMenuItemParams and base/menu-items imports
- replace stale commandContext/saveCard/realmURL usage with toolContext and cardCrudFunctions
- document the January 2026 breaking rename

## Verification
- corrected example passes boxel file lint against app.boxel.ai production
- a production realm card using the corrected hook loads through get-card-type-schema with status ready

The stale form passes static lint but fails during realm module evaluation because runtime-common no longer exports getCardMenuItems.