### PR TITLE
Link the skill catalog entries so they resolve for the assistant

### DIFF
--- a/index.md
+++ b/index.md
@@ -26,6 +26,10 @@ The skill catalog below covers the workflows that produce these deliverables.
 
 Match the user's intent to a skill in the catalog below and read it before starting. If several could apply, list the candidates with one-line summaries and ask the user to pick — don't barrel forward on a guess.
 
+**Acting on the app takes one more read.** This index carries no host commands, and neither does any skill page: the commands live in [`skills/boxel-environment/references/host-commands-reference.md`](skills/boxel-environment/references/host-commands-reference.md), and reading that file is what makes `switch-submode`, `show-card`, `search-cards`, and the rest callable. Anything beyond answering in prose — creating a card, editing a file, switching mode, searching a realm — needs it, so read it alongside the skill you picked.
+
+Read it before you plan out loud. Describing a plan you have no tools to carry out, or asking the user to switch modes by hand, means this step was skipped.
+
 ## Skill-tree glossary
 
 [`skills/glossary.md`](skills/glossary.md) is the back-of-the-book reference — every term, concept, library, helper, host command, pattern, convention, and acronym used across the skills, with a one-line definition and a pointer to the deeper file. Scan it when you're not sure what a term means or where it's documented. **Update this file whenever a skill, reference, pattern, extension, or convention is added, renamed, or removed.**

--- a/index.md
+++ b/index.md
@@ -36,32 +36,32 @@ Every skill lives in `skills/` and auto-activates on its description triggers �
 
 ### Foundation
 
-- **`boxel/`** — Cardinal rules + 18 references for CardDef, FieldDef, templates, queries, formats, commands.
-- **`boxel-workspace-cardinal-rules/`** — Silent-failure trap checklist: rules that pass lint (and often indexing), then corrupt the realm index, crash at render, or drop data with no error. Check every card/field against it before finishing.
-- **`source-code-editing/`** — SEARCH/REPLACE block format. Required before any `.gts` edit.
-- **`ember-best-practices/`** — Ember.js performance + accessibility rules (59 rules across 10 categories) for writing, reviewing, or refactoring Ember code.
+- **[`boxel/`](skills/boxel/SKILL.md)** — Cardinal rules + 18 references for CardDef, FieldDef, templates, queries, formats, commands.
+- **[`boxel-workspace-cardinal-rules/`](skills/boxel-workspace-cardinal-rules/SKILL.md)** — Silent-failure trap checklist: rules that pass lint (and often indexing), then corrupt the realm index, crash at render, or drop data with no error. Check every card/field against it before finishing.
+- **[`source-code-editing/`](skills/source-code-editing/SKILL.md)** — SEARCH/REPLACE block format. Required before any `.gts` edit.
+- **[`ember-best-practices/`](skills/ember-best-practices/SKILL.md)** — Ember.js performance + accessibility rules (59 rules across 10 categories) for writing, reviewing, or refactoring Ember code.
 
 ### UI & content
 
-- **`boxel-ui-guidelines/`** — Template UI rules: theme tokens, `@fields` vs `@model`, container queries, layout safety.
-- **`boxel-ui-component-discovery/`** — Mandatory catalog search for a boxel-ui component Spec before hand-rolling any UI primitive in a `.gts` template.
-- **`boxel-design/`** — Visual design language, mood, typography, asset direction.
-- **`boxel-file-def/`** — File-typed fields (FileDef, ImageDef, MarkdownDef, PngDef, CsvFileDef).
-- **`boxel-flavored-markdown/`** — Authoring BFM content with `:card`/`::card` directives, mermaid, math, alerts.
-- **`boxel-markdown-format/`** — Static `markdown` template format with `markdownEscape` and helpers.
-- **`boxel-skill-authoring/`** — Writing user-authored skills: the SKILL.md format contract (`boxel.kind: skill` frontmatter), tool declarations, placement, and the verify loop.
+- **[`boxel-ui-guidelines/`](skills/boxel-ui-guidelines/SKILL.md)** — Template UI rules: theme tokens, `@fields` vs `@model`, container queries, layout safety.
+- **[`boxel-ui-component-discovery/`](skills/boxel-ui-component-discovery/SKILL.md)** — Mandatory catalog search for a boxel-ui component Spec before hand-rolling any UI primitive in a `.gts` template.
+- **[`boxel-design/`](skills/boxel-design/SKILL.md)** — Visual design language, mood, typography, asset direction.
+- **[`boxel-file-def/`](skills/boxel-file-def/SKILL.md)** — File-typed fields (FileDef, ImageDef, MarkdownDef, PngDef, CsvFileDef).
+- **[`boxel-flavored-markdown/`](skills/boxel-flavored-markdown/SKILL.md)** — Authoring BFM content with `:card`/`::card` directives, mermaid, math, alerts.
+- **[`boxel-markdown-format/`](skills/boxel-markdown-format/SKILL.md)** — Static `markdown` template format with `markdownEscape` and helpers.
+- **[`boxel-skill-authoring/`](skills/boxel-skill-authoring/SKILL.md)** — Writing user-authored skills: the SKILL.md format contract (`boxel.kind: skill` frontmatter), tool declarations, placement, and the verify loop.
 
 ### Runtime
 
-- **`boxel-environment/`** — Driving the live Boxel app: switch-submode, host commands, search-cards, indexing.
-- **`catalog-listing/`** — Catalog use / install / remix / update operations, plus submission through `SubmissionWorkflowCard`.
-- **`boxel-create-edit-cards/`** — Thin pointer to `boxel-environment/references/card-tool-selection.md` (host-command combos for card create/edit).
+- **[`boxel-environment/`](skills/boxel-environment/SKILL.md)** — Driving the live Boxel app: switch-submode, host commands, search-cards, indexing.
+- **[`catalog-listing/`](skills/catalog-listing/SKILL.md)** — Catalog use / install / remix / update operations, plus submission through `SubmissionWorkflowCard`.
+- **[`boxel-create-edit-cards/`](skills/boxel-create-edit-cards/SKILL.md)** — Thin pointer to `boxel-environment/references/card-tool-selection.md` (host-command combos for card create/edit).
 
 ### Patterns
 
-- **`boxel-patterns/`** — Outcome-indexed catalogue of working examples. Ready patterns and planned backlog are kept separate. Two reference docs at this level:
-  - `references/integration-surfaces.md` — capability cheatsheet (what cards can reach for: base APIs, host commands, AI services, BFM, boxel-cli, etc.).
-  - `references/libraries.md` — import-path catalogue (where each symbol comes from).
+- **[`boxel-patterns/`](skills/boxel-patterns/SKILL.md)** — Outcome-indexed catalogue of working examples. Ready patterns and planned backlog are kept separate. Two reference docs at this level:
+  - [`references/integration-surfaces.md`](skills/boxel-patterns/references/integration-surfaces.md) — capability cheatsheet (what cards can reach for: base APIs, host commands, AI services, BFM, boxel-cli, etc.).
+  - [`references/libraries.md`](skills/boxel-patterns/references/libraries.md) — import-path catalogue (where each symbol comes from).
 
 ## Conventions
 

--- a/skills/boxel-environment/SKILL.md
+++ b/skills/boxel-environment/SKILL.md
@@ -9,6 +9,12 @@ boxel:
 
 You are the orchestrator of the Boxel AI Assistant. You decide which host command to call, when to switch submode, when to swap LLM, and when to activate companion skills. You work alongside `boxel` (the coding skill) and `source-code-editing` (the SEARCH/REPLACE format).
 
+## 🚨 Read this before planning anything
+
+**[`references/host-commands-reference.md`](references/host-commands-reference.md) is where the host commands come from — not this file.** Reading it is what makes `switch-submode`, `show-card`, `search-cards`, and the rest callable. Until you have read it you cannot drive the app at all, no matter what this page says a command does: the names below are descriptions, and the tools themselves arrive with that file.
+
+So read it as your first action, before you plan the work or tell the user what you are about to do. If you find yourself about to say you lack a tool, or asking the user to switch to code mode by hand, you have not read it yet.
+
 ---
 
 ## ⚠️ Master Decision Tree
@@ -105,27 +111,27 @@ Full create/edit tool tables, file naming, and path rules: `references/card-tool
 
 Batch your reads: fetch the always-relevant set in one multi-file read when this skill activates, and pull by-task references the same way — everything you know you need in one go, not one or two per turn.
 
-Always-relevant:
-- `references/assistant-persona.md` — Communication style. Concise, intent-based responses.
-- `references/calling-commands.md` — JSON structure for all tool calls. Required before any command execution.
-- `references/user-environment-awareness.md` — Parse workspace, mode, open cards from each message.
-- `references/host-commands-reference.md` — Full catalog of every host command, what it does, approval rules.
+Always-relevant — read these together, first:
+- **[`references/host-commands-reference.md`](references/host-commands-reference.md)** — **the host commands themselves.** Reading this is what makes them callable; every other file here only tells you how to use what it gives you.
+- [`references/calling-commands.md`](references/calling-commands.md) — JSON structure for all tool calls. Required before any command execution.
+- [`references/assistant-persona.md`](references/assistant-persona.md) — Communication style. Concise, intent-based responses.
+- [`references/user-environment-awareness.md`](references/user-environment-awareness.md) — Parse workspace, mode, open cards from each message.
 
 By task:
-- `references/choosing-llm-models.md` — Model selection. Check when code tasks detected or debugging stuck.
-- `references/searching-and-querying.md` — Query syntax for finding cards.
-- `references/workflows-and-orchestration.md` — Multi-step patterns (migrations, bulk operations).
-- `references/markdown-edit.md` — Editing long markdown fields surgically.
-- `../boxel/references/lint-workflow.md` — Required installed npm `boxel` lint gate for `.gts` code tasks.
+- [`references/choosing-llm-models.md`](references/choosing-llm-models.md) — Model selection. Check when code tasks detected or debugging stuck.
+- [`references/searching-and-querying.md`](references/searching-and-querying.md) — Query syntax for finding cards.
+- [`references/workflows-and-orchestration.md`](references/workflows-and-orchestration.md) — Multi-step patterns (migrations, bulk operations).
+- [`references/markdown-edit.md`](references/markdown-edit.md) — Editing long markdown fields surgically.
+- [`../boxel/references/lint-workflow.md`](../boxel/references/lint-workflow.md) — Required installed npm `boxel` lint gate for `.gts` code tasks.
 
 Troubleshooting:
-- `references/common-errors.md` — Tool-call JSON errors and their fixes (XML in JSON, wrong key names, escaping, etc.).
+- [`references/common-errors.md`](references/common-errors.md) — Tool-call JSON errors and their fixes (XML in JSON, wrong key names, escaping, etc.).
 
 Specialty:
-- `references/indexing-operations.md` — Realm reindexing commands.
-- `references/fresh-realm-push-integrity.md` — First-deployment ordering: definitions ready before instances, nested-field readback, and forced rewrites when mixed pushes silently store `null` leaves.
-- `references/diagnosing-broken-links.md` — The broken-link DOM placeholder as the canonical signal; the `data-test-broken-link-*` attribute contract; `error` vs `not-found`; the follow-the-URL-to-the-linked-instance remediation workflow. (Card-author side: `boxel/references/defensive-link-traversal.md`.)
-- `references/source-code-editing.md` — Cross-link to the SEARCH/REPLACE skill.
+- [`references/indexing-operations.md`](references/indexing-operations.md) — Realm reindexing commands.
+- [`references/fresh-realm-push-integrity.md`](references/fresh-realm-push-integrity.md) — First-deployment ordering: definitions ready before instances, nested-field readback, and forced rewrites when mixed pushes silently store `null` leaves.
+- [`references/diagnosing-broken-links.md`](references/diagnosing-broken-links.md) — The broken-link DOM placeholder as the canonical signal; the `data-test-broken-link-*` attribute contract; `error` vs `not-found`; the follow-the-URL-to-the-linked-instance remediation workflow. (Card-author side: `boxel/references/defensive-link-traversal.md`.)
+- [`references/source-code-editing.md`](references/source-code-editing.md) — Cross-link to the SEARCH/REPLACE skill.
 
 ## Sibling skills
 


### PR DESCRIPTION
Here is the problem - the skill urls are wrong and the model needs to figure it out in the next attempt:
<img width="350" height="514" alt="image" src="https://github.com/user-attachments/assets/fbdc3b72-b7da-4627-acd4-32114eacaf31" />


The skill catalog named each skill as a code span — **`boxel/`** — instead of a link, so the AI assistant had no URL to follow and guessed one. Every guess was a 404:

```
guessed:  https://…/skills/source-code-editing/SKILL.md         404
actual:   https://…/skills/skills/source-code-editing/SKILL.md   200
```

The path has `skills` twice because the realm is served at `/skills/` and the skill files sit in a `skills/` directory inside it. The assistant resolves markdown links in a skill body against that skill's own URL, so a link lands on the right path automatically — but a code span isn't a link, and nothing resolves it.

Each catalog entry is now a link to `skills/<name>/SKILL.md`, matching the actions section above it, which already used links and always worked. The two reference docs under `boxel-patterns` get the same treatment. It reads the same in a plain markdown viewer.

Checked that every link target exists on disk and that the resolved URLs return 200 from a running realm.